### PR TITLE
frank.py: Add peephole lwz/{li,lfs} reordering

### DIFF
--- a/tools/frank.py
+++ b/tools/frank.py
@@ -88,6 +88,7 @@ while idx < len(profile_bytes) - 16:
     LFS = 0xC0 >> 2
     ADDI = 0x38 >> 2
     LI = ADDI # an LI instruction is just an ADDI with RA=0
+    LMW = 0xB8 >> 2
 
     if opcode_a == LWZ and \
        opcode_b in [LI, LFS] and \
@@ -102,6 +103,17 @@ while idx < len(profile_bytes) - 16:
                 + PROFILE_EXTRA_BYTES \
                 + vanilla_inst_b \
                 + profile_bytes[epi_pos+12:]
+
+    # Similar reordering for lwz/lmw, except both insns follow the bl/nop
+    elif opcode_b == LWZ and \
+         opcode_c == LMW and \
+         vanilla_inst_b == profile_inst_c and \
+         vanilla_inst_c == profile_inst_b:
+
+        profile_bytes = profile_bytes[:epi_pos+8] \
+                + vanilla_inst_b \
+                + vanilla_inst_c \
+                + profile_bytes[epi_pos+16:]
 
     idx = epi_pos + 8
 

--- a/tools/frank.py
+++ b/tools/frank.py
@@ -85,11 +85,12 @@ while idx < len(profile_bytes) - 16:
     opcode_c = vanilla_inst_c[0] >> 2
 
     LWZ = 0x80 >> 2
+    LFS = 0xC0 >> 2
     ADDI = 0x38 >> 2
     LI = ADDI # an LI instruction is just an ADDI with RA=0
 
     if opcode_a == LWZ and \
-       opcode_b == LI and \
+       opcode_b in [LI, LFS] and \
        vanilla_inst_a == profile_inst_b and \
        vanilla_inst_b == profile_inst_a and \
        vanilla_inst_c == profile_inst_c and \


### PR DESCRIPTION
We disable epilogue scheduling in 1.2.5e, but the patched
1.2.5 behavior still has some epilogue scheduling enabled.

When vanilla 1.2.5 and 1.2.5e differ by an lwz/li instruction
swap prior to epilogue register restoration, the vanilla order
seems to actually be the correct one.

Fixes melee's wobj.c and dobj.c matches, so frank can be reenabled for them.