### PR TITLE
clang-format: InsertNewlineAtEOF

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,3 +28,5 @@ Cpp11BracedListStyle: false
 AlwaysBreakTemplateDeclarations: true
 BreakStringLiterals: true
 ReflowComments: true
+
+InsertNewlineAtEOF: true

--- a/format-files.py
+++ b/format-files.py
@@ -25,13 +25,6 @@ def format_folders(folder_to_iter):
                    print("")
                    continue
 
-                with open(relative_path, "r+") as f:
-                   f.seek(0, 2)
-                   f.seek(f.tell() - 1, 0)
-                   if f.read() != '\n':
-                      f.write("\n");
-                      print("added newline", end="")
-
                 print("")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Requires clang-format 16, which hopefully isn't a dealbreaker for anyone.  Should make the format-files python script faster since it doesn't have to open the file a second time.