### PR TITLE
fat.c: yeah

### DIFF
--- a/include/jaudio/fat.h
+++ b/include/jaudio/fat.h
@@ -9,9 +9,9 @@ int FAT_AllocateMemory(u32);
 int FAT_FreeMemory(u16);
 u8* FAT_GetPointer(u16, u32);
 u8 FAT_ReadByte(u16, u32);
-u32 FAT_ReadWord(u16, u32);   // UNUSED, but these were probably global
+u16 FAT_ReadWord(u16, u32);   // UNUSED, but these were probably global
 void FAT_ReadWordD(u16, u32); // UNUSED, but these were probably global
-void FAT_ReadLong(u16, u32);  // UNUSED, but these were probably global
+u32 FAT_ReadLong(u16, u32);   // UNUSED, but these were probably global
 void FAT_ReadLongD(u16, u32); // UNUSED, but these were probably global
 int FAT_StoreBlock(u8*, u16, u32, u32);
 

--- a/src/jaudio/fat.c
+++ b/src/jaudio/fat.c
@@ -451,11 +451,11 @@ u8 FAT_ReadByte(u16 a, u32 b)
  * Address:	........
  * Size:	000034
  */
-u32 FAT_ReadWord(u16 a, u32 b)
+u16 FAT_ReadWord(u16 a, u32 b)
 {
 	// Guessing based on name/size
 
-	u32* ptr = (u32*)FAT_GetPointer(a, b);
+	u16* ptr = (u16*)FAT_GetPointer(a, b);
 	if (ptr == nullptr) {
 		return 0;
 	}
@@ -478,9 +478,12 @@ void FAT_ReadWordD(u16 a, u32 b)
  * Address:	........
  * Size:	000024
  */
-void FAT_ReadLong(u16, u32)
+u32 FAT_ReadLong(u16 a, u32 b)
 {
 	// UNUSED FUNCTION
+
+	// Guessing based on name/size
+	return *(u32*)FAT_GetPointer(a, b);
 }
 
 /*


### PR DESCRIPTION
Noticed this in PikHacker's recent changes. I know in jammain_2.c "word" is used in a more traditional sense to represent a 2-byte value (as opposed to how PowerPC uses "word" for 4-byte values and halfword for 2-byte values), so I think this would be a better guess.  Also took a stab at guessing `FAT_ReadLong` based on its size.