### PR TITLE
jammain_2.h: In `seqp_`, reckon with `jcs_` findings.

### DIFF
--- a/include/jaudio/audiostruct.h
+++ b/include/jaudio/audiostruct.h
@@ -62,17 +62,21 @@ struct panData {
 };
 
 /**
- * @brief TODO.
+ * @brief TODO
+ *
+ * @note Size: 0x74.
  */
 struct jcs_ {
-	u32 _00;
-	int _04;
-	jc_* _08;
-	jc_* _0C;
-	jc_* _10;
-	jc_* _14;
-	u8 _18[0x70 - 0x18];
-	int _70;
+	u32 _00;             // _00
+	int _04;             // _04
+	jc_* _08;            // _08
+	jc_* _0C;            // _0C
+	jc_* _10;            // _10
+	jc_* _14;            // _14
+	u8 _18[0x4e - 0x18]; // _18
+	u16 _4E[1];          // _4E | Exact length unknown, but it is an array.
+	u8 _50[0x70 - 0x50]; // _50
+	int _70;             // _70
 };
 
 struct JCMgr {

--- a/include/jaudio/jammain_2.h
+++ b/include/jaudio/jammain_2.h
@@ -56,9 +56,6 @@ struct seqp_ {
 	u8 _D5;                                       // _0D5
 	u8 _D6[0x0d8 - 0x0d6];                        // _0D6
 	jcs_ _D8;                                     // _0D8
-	u8 _PADDING1[0x126 - (0x0d8 + sizeof(jcs_))]; //
-	u16 _126[2];                                  // _126 | Exact length unknown, but it is an array.
-	u8 _12A[0x14c - 0x12a];                       // _12A
 	seqp__Invented2* _14C[4];                     // _14C
 	u8 _15C[0x1f2 - 0x15c];                       // _15C
 	u16 _1F2[2];                                  // _1F2 | Exact length unknown, but it is an array.

--- a/src/jaudio/jammain_2.c
+++ b/src/jaudio/jammain_2.c
@@ -3539,7 +3539,7 @@ static u32 Cmd_UpdateSync()
 static u32 Cmd_BusConnect()
 {
 	if (SEQ_ARG._00[0] < 6) {
-		SEQ_P->_126[SEQ_ARG._00[0]] = SEQ_ARG._00[1];
+		SEQ_P->_D8._4E[SEQ_ARG._00[0]] = SEQ_ARG._00[1];
 	}
 	return 0;
 }


### PR DESCRIPTION
Somehow this codebase was compiling with a u8[-37] member in `seqp_`.  Don't ask me how.