### PR TITLE
JAudio: One last volatile

### DIFF
--- a/include/jaudio/PikiDemo.h
+++ b/include/jaudio/PikiDemo.h
@@ -25,7 +25,7 @@ void Jac_DemoSound(int);                      // args
 BOOL Jac_DemoFrame(int);                      // args
 void Jac_FinishDemo(void);                    // args
 void Jac_PrepareDemo(int);                    // args
-void Jac_StartPartsFindDemo(vu32 p1, int p2); // unsure on first arg
+void Jac_StartPartsFindDemo(u32 p1, int p2);  // unsure on first arg
 void Jac_FinishPartsFindDemo(void);           // args
 void Jac_StartTextDemo(int);                  // args
 void Jac_FinishTextDemo(void);                // args

--- a/src/jaudio/pikidemo.c
+++ b/src/jaudio/pikidemo.c
@@ -1662,9 +1662,10 @@ void Jac_PrepareDemo(int id)
  * Address:	8001B120
  * Size:	0000D0
  */
-void Jac_StartPartsFindDemo(vu32 p1, int p2)
+void Jac_StartPartsFindDemo(u32 p1, int p2)
 {
-	int badcompiler[4];
+	int badcompiler[2];
+	u32* REF_p1;
 
 	if (parts_find_demo_state == 1) {
 		if (p2) {
@@ -1681,6 +1682,7 @@ void Jac_StartPartsFindDemo(vu32 p1, int p2)
 	if (p2) {
 		Jac_DemoFade(0.1, 1, 0xf);
 
+		REF_p1 = &p1;
 		if (p1 == 0) {
 			Jac_PlaySystemSe(0x24);
 		} else {


### PR DESCRIPTION
Meeo opinion time: Using the vu8/16/32 typedefs instead of volatile u8/16/32 hurts searchability and readability.