### PR TITLE
Identify user `PRINT`s for Kando, Nakata, and Yamashita

### DIFF
--- a/include/DebugLog.h
+++ b/include/DebugLog.h
@@ -54,6 +54,20 @@
 #define PRINT_GLOBAL(...) (__VA_ARGS__)
 #endif
 
+// This macro exists to abstract the user PRINTs seen below.  mapMgr.cpp seems to have used this macro as well.
+#define PRINT_IF(cond, ...) \
+	if (cond) {             \
+		PRINT(__VA_ARGS__); \
+	}
+
+// In the DLL, there are five global BOOLs (only three are actually used) consistently used to control `PRINT_IF` statements belonging
+// to a specific plugPiki library (e.g. plugPikiKando).  However, these BOOLs seemingly only exist in the DLL.  I'm not even sure what
+// translation unit they belong to.  For now, this stubbed configuration doesn't break matching.
+
+#define PRINT_KANDO(...)  PRINT_IF(true, __VA_ARGS__)
+#define PRINT_NAKATA(...) PRINT_IF(true, __VA_ARGS__)
+#define PRINT_YAMASH(...) PRINT_IF(true, __VA_ARGS__)
+
 // TODO: Confirm if newlines are necessary or even just desirable for `ERROR`s.   Given the samples we have, it seems the
 // devs were mixed on whether one should be used or not.  We'll have to wait until JPN Demo's error handler is understood.
 #if defined(BUGFIX)

--- a/src/plugPikiColin/game.cpp
+++ b/src/plugPikiColin/game.cpp
@@ -303,6 +303,7 @@ void OnePlayerSection::init()
 			} else {
 				gameflow.mLevelBannerTexture = tex;
 			}
+			// It is somewhere before this PRINT that all of the BOOLs controlling user PRINTs are set to FALSE.
 			PRINT("making new MAINGAME\n");
 			currentSection = new NewPikiGameSection();
 			break;

--- a/src/plugPikiColin/mapMgr.cpp
+++ b/src/plugPikiColin/mapMgr.cpp
@@ -1730,11 +1730,9 @@ void MapMgr::recTraceMove(CollGroup* colls, MoveTrace& trace, f32 timeStep)
 			if (trace.mObject) {
 				trace.mObject->mCollisionOccurred = 1;
 			}
-			if (false) {
-				PRINT(">> before bounce : n(%.1f,%.1f,%.1f) vel(%.1f,%.1f,%.1f) p(%.1f,%.1f,%.1f) % s :%.1f %.1f\n", normal.x, normal.y,
-				      normal.z, vel.x, vel.y, vel.z, nextPos.x, nextPos.y, nextPos.z, currColls->mSourceCollider ? "PLATFORM" : "MAP", pen,
-				      rad);
-			}
+			PRINT_IF(false, ">> before bounce : n(%.1f,%.1f,%.1f) vel(%.1f,%.1f,%.1f) p(%.1f,%.1f,%.1f) % s :%.1f %.1f\n", normal.x,
+			         normal.y, normal.z, vel.x, vel.y, vel.z, nextPos.x, nextPos.y, nextPos.z,
+			         currColls->mSourceCollider ? "PLATFORM" : "MAP", pen, rad);
 			bool check2 = false;
 			if (!currColls->mSourceCollider) {
 				check1 = true;
@@ -1743,9 +1741,7 @@ void MapMgr::recTraceMove(CollGroup* colls, MoveTrace& trace, f32 timeStep)
 				vel.bounce(normal, bounceFactor);
 			} else if (check1 && vec.DP(normal) < -0.5f) {
 				check2 = true;
-				if (false) {
-					PRINT("ignore platform\n");
-				}
+				PRINT_IF(false, "ignore platform\n");
 			} else {
 				if (trace.mObject && currColls->mSourceCollider && currColls->mSourceCollider->mCreature) {
 					bounceFactor = 1.0f;
@@ -1753,10 +1749,8 @@ void MapMgr::recTraceMove(CollGroup* colls, MoveTrace& trace, f32 timeStep)
 				trace.mVelocity.bounce(normal, bounceFactor);
 				vel.bounce(normal, bounceFactor);
 			}
-			if (false) {
-				PRINT(">> after bounce : n(%.1f,%.1f,%.1f) vel(%.1f,%.1f,%.1f) p(%.1f,%.1f,%.1f) %s\n", normal.x, normal.y, normal.z, vel.x,
-				      vel.y, vel.z, nextPos.x, nextPos.y, nextPos.z, currColls->mSourceCollider ? "PLATFORM" : "MAP");
-			}
+			PRINT_IF(false, ">> after bounce : n(%.1f,%.1f,%.1f) vel(%.1f,%.1f,%.1f) p(%.1f,%.1f,%.1f) %s\n", normal.x, normal.y, normal.z,
+			         vel.x, vel.y, vel.z, nextPos.x, nextPos.y, nextPos.z, currColls->mSourceCollider ? "PLATFORM" : "MAP");
 			if (!check2) {
 				nextPos.x += normal.x * (rad - pen);
 				nextPos.y += normal.y * (rad - pen);

--- a/src/plugPikiColin/newPikiGame.cpp
+++ b/src/plugPikiColin/newPikiGame.cpp
@@ -1721,6 +1721,7 @@ NewPikiGameSection::NewPikiGameSection()
 	flowCont._23CPAL = 0;
 #endif
 	gsys->setFrameClamp(2);
+	// In the DLL, Nakata and Kando have their PRINTs disabled here for a second time.
 	mapMgr = nullptr;
 	npgss  = nullptr;
 

--- a/src/plugPikiKando/aiAttack.cpp
+++ b/src/plugPikiKando/aiAttack.cpp
@@ -237,7 +237,7 @@ int ActAttack::exec()
 		if (target) {
 			seMgr->leaveBattle();
 			init(target);
-			PRINT("... found new target!\n");
+			PRINT_KANDO("... found new target!\n");
 			return ACTOUT_Continue;
 		}
 
@@ -260,15 +260,15 @@ int ActAttack::exec()
 	}
 
 	if (!mPiki->isStickTo() && (mOther.getPtr()->isFlying() || !mOther.getPtr()->isVisible())) {
-		PRINT("target start flying\n");
+		PRINT_KANDO("target start flying\n");
 
 		Creature* target = findTarget();
 		if (target) {
 			init(target);
-			PRINT("... found new target!\n");
+			PRINT_KANDO("... found new target!\n");
 			return ACTOUT_Continue;
 		}
-		PRINT("TARGET LOST !!\n");
+		PRINT_KANDO("TARGET LOST !!\n");
 		startLost();
 		return ACTOUT_Continue;
 	}
@@ -277,14 +277,14 @@ int ActAttack::exec()
 	if (andRet != ACTOUT_Continue) {
 		if (mTargetIsPlayer) {
 			Creature* target = findTarget();
-			PRINT("piki attack : res is %s\n", (andRet == 2) ? "success" : (andRet == 1) ? "failed" : "not");
+			PRINT_KANDO("piki attack : res is %s\n", (andRet == 2) ? "success" : (andRet == 1) ? "failed" : "not");
 			if (target && andRet == ACTOUT_Success) {
 				seMgr->leaveBattle();
 				init(mPlayerObject);
 				return ACTOUT_Success;
 			}
 
-			PRINT("all targets are removed !\n");
+			PRINT_KANDO("all targets are removed !\n");
 			return ACTOUT_Success;
 		}
 
@@ -296,17 +296,17 @@ int ActAttack::exec()
 				return ACTOUT_Continue;
 			}
 
-			PRINT("genocide start ?\n"); // lol?
+			PRINT_KANDO("genocide start ?\n"); // lol?
 			target = findTarget();
 			if (target) {
 				seMgr->leaveBattle();
 				init(target);
-				PRINT("... found new target!\n");
+				PRINT_KANDO("... found new target!\n");
 				return ACTOUT_Continue;
 			}
 		}
 
-		PRINT("once is done : %x\n", mPiki);
+		PRINT_KANDO("once is done : %x\n", mPiki);
 		return ACTOUT_Success;
 	}
 
@@ -353,7 +353,7 @@ void ActJumpAttack::init(Creature* creature)
 	mState = 0;
 	_2C    = false;
 	if (mPiki->isStickTo()) {
-		PRINT("jump attack : piki sticks to %s\n", mPiki->mStickPart ? mPiki->mStickPart->mCollInfo->mId.mStringID : "?");
+		PRINT_KANDO("jump attack : piki sticks to %s\n", mPiki->mStickPart ? mPiki->mStickPart->mCollInfo->mId.mStringID : "?");
 		if (mPiki->mStickPart && mPiki->mStickPart->isClimbable()) {
 			mPiki->startClimb();
 			mState = 6;
@@ -454,7 +454,7 @@ void ActJumpAttack::procCollideMsg(Piki* piki, MsgCollide* msg)
 		return;
 	}
 
-	PRINT("JUMP STICK ###\n");
+	PRINT_KANDO("JUMP STICK ###\n");
 
 	if (msg->mEvent.mColliderPart == 0) {
 		PRINT("ざまし! ta no coll part\n"); // 'alarm clock! ta no coll part'
@@ -463,29 +463,29 @@ void ActJumpAttack::procCollideMsg(Piki* piki, MsgCollide* msg)
 
 	if (msg->mEvent.mColliderPart->isPlatformType()) {
 		if (msg->mEvent.mColliderPart->isStickable()) {
-			PRINT("stick to platform\n");
+			PRINT_KANDO("stick to platform\n");
 			piki->startStick(msg->mEvent.mCollider, msg->mEvent.mColliderPart);
 		} else {
 			if (msg->mEvent.mColliderPart->isClimbable()) {
-				PRINT("start climb platform\n");
+				PRINT_KANDO("start climb platform\n");
 				piki->startStick(msg->mEvent.mCollider, msg->mEvent.mColliderPart);
 			} else {
-				PRINT("stickable nor climbable platform\n");
+				PRINT_KANDO("stickable nor climbable platform\n");
 				return;
 			}
 		}
 	} else {
 		if (msg->mEvent.mColliderPart->isCollisionType() || msg->mEvent.mColliderPart->isTubeType()) {
-			PRINT("try to stick %s : いみない \n", msg->mEvent.mColliderPart->mCollInfo->mId.mStringID); // 'no point'
 			if (msg->mEvent.mColliderPart->isStickable()) {
-				PRINT(" stick to 球 or チューブ\n"); // 'stick to ball or tube'
+				PRINT_KANDO(" stick to 球 or チューブ\n"); // 'stick to ball or tube'
 				piki->startStickObject(msg->mEvent.mCollider, msg->mEvent.mColliderPart, -1, 0.0f);
 			} else {
-				PRINT("try to stick to coll-sphere (%s:code %s): いまはくっっつかない\n", // 'it doesn't stick now'
-				      msg->mEvent.mColliderPart->mCollInfo->mId.mStringID, msg->mEvent.mColliderPart->mCollInfo->mCode.mStringID);
+				PRINT_KANDO("try to stick to coll-sphere (%s:code %s): いまはくっっつかない\n", // 'it doesn't stick now'
+				            msg->mEvent.mColliderPart->mCollInfo->mId.mStringID, msg->mEvent.mColliderPart->mCollInfo->mCode.mStringID);
 				return;
 			}
 		} else {
+			PRINT_KANDO("try to stick %s : いみない \n", msg->mEvent.mColliderPart->mCollInfo->mId.mStringID); // 'no point'
 			return;
 		}
 	}
@@ -562,7 +562,7 @@ int ActJumpAttack::exec()
 			mPiki->startMotion(PaniMotionInfo(PIKIANIM_StillJump, this), PaniMotionInfo(PIKIANIM_StillJump));
 			mState              = 1;
 			mPiki->mWantToStick = true;
-			PRINT("jump !\n");
+			PRINT_KANDO("jump !\n");
 			break;
 		}
 
@@ -589,7 +589,7 @@ int ActJumpAttack::exec()
 			mState = 2;
 		} else {
 			if (dist2D < getAttackSize() + mPiki->getCentreSize() && gsys->getRand(1.0f) > 0.7f) {
-				PRINT("jump adjust : dist2d = %.1f d = %.1f\n", dist2D, dist3D);
+				PRINT_KANDO("jump adjust : dist2d = %.1f d = %.1f\n", dist2D, dist3D);
 				mState = 2;
 			}
 
@@ -720,7 +720,7 @@ int ActJumpAttack::exec()
 		}
 
 		if (!mPiki->isStickTo()) {
-			PRINT("jump attack : finish stick\n");
+			PRINT_KANDO("jump attack : finish stick\n");
 			mPiki->startMotion(PaniMotionInfo(PIKIANIM_Walk, this), PaniMotionInfo(PIKIANIM_Walk));
 			mState = 0;
 			return ACTOUT_Continue;
@@ -800,7 +800,7 @@ void ActJumpAttack::doClimb()
 			Vector3f dir = part->mCentre - mPiki->mPosition;
 			f32 sep      = dir.length();
 			f32 dist     = sep - part->mRadius - mPiki->getCentreSize();
-			PRINT("  :: climb target distance = %.1f\n", dist);
+			PRINT_KANDO("  :: climb target distance = %.1f\n", dist);
 			if (dist < 5.0f) {
 				mState         = 5;
 				mIsCriticalHit = false;
@@ -814,7 +814,7 @@ void ActJumpAttack::doClimb()
 		}
 	}
 
-	PRINT("climbing ...\n");
+	PRINT_KANDO("climbing ...\n");
 	if (!mPiki->mClimbingTri) {
 		mState = 0;
 		mPiki->endClimb();
@@ -824,8 +824,8 @@ void ActJumpAttack::doClimb()
 	bool check = true;
 	for (int i = 0; i < 3; i++) {
 		if (mPiki->mClimbingTri->mEdgePlanes[i].dist(mPiki->mPosition) < -2.0f * mPiki->getCentreSize()) {
-			PRINT("out of tri : dist is %.1f | centre * -2.0f = %.1f\n", mPiki->mClimbingTri->mEdgePlanes[i].dist(mPiki->mPosition),
-			      -2.0f * mPiki->getCentreSize());
+			PRINT_KANDO("out of tri : dist is %.1f | centre * -2.0f = %.1f\n", mPiki->mClimbingTri->mEdgePlanes[i].dist(mPiki->mPosition),
+			            -2.0f * mPiki->getCentreSize());
 			check = false;
 		}
 	}
@@ -833,7 +833,7 @@ void ActJumpAttack::doClimb()
 	if (!check) {
 		mPiki->endStick();
 		mState = 0;
-		PRINT("finish stick :: out of tri\n");
+		PRINT_KANDO("finish stick :: out of tri\n");
 		return;
 	}
 

--- a/src/plugPikiKando/aiEnter.cpp
+++ b/src/plugPikiKando/aiEnter.cpp
@@ -154,7 +154,7 @@ void ActEnter::procCollideMsg(Piki*, MsgCollide* msg)
 int ActEnter::gotoLeg()
 {
 	if (mPiki->mRope) {
-		PRINT("goto leg ok! %x\n", mPiki);
+		PRINT_KANDO("goto leg ok! %x\n", mPiki);
 		mState = STATE_Climb;
 		mPiki->playEventSound(mOnyon, SE_CONTAINER_CLIMB);
 		mPiki->mVelocity.set(0.0f, 0.0f, 0.0f);
@@ -182,7 +182,7 @@ int ActEnter::gotoLeg()
 int ActEnter::climb()
 {
 	if (!mPiki->mRope || mPiki->mRopePosRatio > 0.9f) {
-		PRINT("enter goal ???\n");
+		PRINT_KANDO("enter goal ???\n");
 		mOnyon->enterGoal(mPiki);
 		return ACTOUT_Fail;
 	}
@@ -192,7 +192,7 @@ int ActEnter::climb()
 	}
 
 	if (mPiki->mRopePosRatio > 0.72f) {
-		PRINT("piki->ropePos = %f\n", mPiki->mRopePosRatio);
+		PRINT_KANDO("piki->ropePos = %f\n", mPiki->mRopePosRatio);
 		mPiki->mIsCallable = false;
 		f32 scale          = (1.0f - mPiki->mRopePosRatio) / (1.0f - 0.72f) * 1.0f;
 		if (scale < 0.0f) {

--- a/src/plugPikiKando/aiExit.cpp
+++ b/src/plugPikiKando/aiExit.cpp
@@ -77,7 +77,7 @@ int ActExit::exec()
 
 	mPrevPosition = mPiki->mPosition;
 	if (mPiki->mRopePosRatio > 0.72f) {
-		PRINT("piki->ropePos = %f\n", mPiki->mRopePosRatio);
+		PRINT_KANDO("piki->ropePos = %f\n", mPiki->mRopePosRatio);
 		mPiki->mIsCallable = false;
 		f32 scale          = (1.0f - mPiki->mRopePosRatio) / (1.0f - 0.72f) * 1.0f;
 		if (scale < 0.0f) {

--- a/src/plugPikiKando/aiPush.cpp
+++ b/src/plugPikiKando/aiPush.cpp
@@ -264,9 +264,9 @@ void ActPush::animationKeyUpdated(PaniAnimKeyEvent& event)
 
 		if (mPushAnimationState == 0) {
 			mPushCount--;
-			PRINT("loopCnt = %d\n", mPushCount);
+			PRINT_KANDO("loopCnt = %d\n", mPushCount);
 			if (mPushCount <= 0) {
-				PRINT("osu count = 0: finish motion\n");
+				PRINT_KANDO("osu count = 0: finish motion\n");
 				mPiki->mPikiAnimMgr.finishMotion(this);
 			}
 		}
@@ -280,7 +280,7 @@ void ActPush::animationKeyUpdated(PaniAnimKeyEvent& event)
 		}
 
 		if (mState == STATE_Go) {
-			PRINT("restart motion !\n");
+			PRINT_KANDO("restart motion !\n");
 			mPiki->startMotion(PaniMotionInfo(PIKIANIM_Osu, this), PaniMotionInfo(PIKIANIM_Osu));
 			mPushCount = int(5.0f * gsys->getRand(1.0f)) + 5;
 		}

--- a/src/plugPikiKando/aiTransport.cpp
+++ b/src/plugPikiKando/aiTransport.cpp
@@ -629,7 +629,7 @@ void ActTransport::doLift()
 			int idx       = nearestWP->mIndex;
 			int goalWPIdx = mGoal->getRouteIndex();
 			int maxNumWP  = routeMgr->getNumWayPoints('test') - 1;
-			PRINT("PATHFINDING : %d ==> %d\n", idx, goalWPIdx);
+			PRINT_KANDO("PATHFINDING : %d ==> %d\n", idx, goalWPIdx);
 			if (idx < 0 || idx > maxNumWP || goalWPIdx < 0 || goalWPIdx > maxNumWP) {
 				ERROR("sorry");
 			}
@@ -1036,7 +1036,7 @@ void ActTransport::decideGoal(Creature* cargo)
 	int onyonColor = Blue;
 	bool isVsMode  = flowCont.mNaviOnMap == 1;
 
-	PRINT("###### decide goal\n");
+	PRINT_KANDO("###### decide goal\n");
 	int i;
 	for (i = 0; i < PikiColorCount; i++) {
 		colorCounts[i] = 0;
@@ -1064,7 +1064,7 @@ void ActTransport::decideGoal(Creature* cargo)
 	for (i = 0; i < PikiColorCount; i++) {
 		if (colorCounts[i] > maxCount) {
 			maxCount = colorCounts[i];
-			PRINT("color %d : is max (%d)\n", i, maxCount);
+			PRINT_KANDO("color %d : is max (%d)\n", i, maxCount);
 		}
 	}
 
@@ -1076,12 +1076,12 @@ void ActTransport::decideGoal(Creature* cargo)
 
 	int randColor = (f32(numOptions) * gsys->getRand(1.0f));
 	if (randColor >= numOptions) {
-		PRINT("random select color=%d : maxcols=%d\n", randColor, numOptions);
+		PRINT_KANDO("random select color=%d : maxcols=%d\n", randColor, numOptions);
 		randColor = Blue;
 	}
 
 	onyonColor = optionColors[randColor];
-	PRINT(" ## color %d is selected\n", onyonColor);
+	PRINT_KANDO(" ## color %d is selected\n", onyonColor);
 	mGoal                     = itemMgr->getContainer(onyonColor);
 	mPellet.mPtr->mTargetGoal = mGoal; // hmm.
 

--- a/src/plugPikiKando/creature.cpp
+++ b/src/plugPikiKando/creature.cpp
@@ -562,7 +562,7 @@ void Creature::kill(bool p1)
 	finishWaterEffect();
 
 	if (mObjType == OBJTYPE_Teki) {
-		PRINT("TEKI DIED ************************************\n");
+		PRINT_KANDO("TEKI DIED ************************************\n");
 	}
 
 	detachGenerator();
@@ -628,8 +628,9 @@ void Creature::kill(bool p1)
 
 	doKill();
 	if (mSeContext) {
-		PRINT("***************************************\n");
-		PRINT("objType %d : dead : release secontext\n", mObjType);
+		// This specific spot is what convinced me these conditional PRINTs were originally implemented with a macro.
+		PRINT_KANDO("***************************************\n");
+		PRINT_KANDO("objType %d : dead : release secontext\n", mObjType);
 		mSeContext->releaseEvent();
 	}
 

--- a/src/plugPikiKando/creatureStick.cpp
+++ b/src/plugPikiKando/creatureStick.cpp
@@ -192,7 +192,7 @@ void Creature::startStickObjectSphere(Creature* obj, CollPart* stickPart, f32 st
 
 	// Convert final position to object's local space
 	mAttachPosition.multMatrix(invWorldMatrix);
-	PRINT("StartStick SPHERE * (%.1f %.1f %.1f) \n", mAttachPosition.x, mAttachPosition.y, mAttachPosition.z);
+	PRINT_KANDO("StartStick SPHERE * (%.1f %.1f %.1f) \n", mAttachPosition.x, mAttachPosition.y, mAttachPosition.z);
 }
 
 /*
@@ -329,7 +329,7 @@ bool Creature::startStick(Creature* stickTarget, CollPart* stickPart)
 		return false;
 	}
 
-	PRINT("piki%x :::: stick ! : standType = %s\n", _standType[getStandType()]);
+	PRINT_KANDO("piki%x :::: stick ! : standType = %s\n", _standType[getStandType()]);
 
 	mStickTarget = stickTarget;
 	if (!stickTarget->mStickListHead) {
@@ -464,7 +464,7 @@ void Creature::endRope()
 		return;
 	}
 
-	PRINT("endRope called ! : %x\n", this);
+	PRINT_KANDO("endRope called ! : %x\n", this);
 
 	if (!mPrevRopeHolder && !mNextRopeHolder) {
 		mRope->mRopeListHead = nullptr;
@@ -808,7 +808,7 @@ void Creature::updateStickRope()
 	if (mRopePosRatio > 1.0f) {
 		endRope();
 		if (rope->mParentRope->mObjType == OBJTYPE_Rope) {
-			PRINT("upper rope\n");
+			PRINT_KANDO("upper rope\n");
 			PRINT("%x upper rope!\n", this);
 			startRope(static_cast<RopeCreature*>(rope->mParentRope), 0.0f);
 			PRINT("==> ratio = %f\n", mRopePosRatio);
@@ -820,7 +820,7 @@ void Creature::updateStickRope()
 
 	} else if (mRopePosRatio < 0.0f && rope->mAttachedObj) {
 		endRope();
-		PRINT("lower rope\n");
+		PRINT_KANDO("lower rope\n");
 		PRINT("%x lower rope!\n", this);
 		startRope(rope->mAttachedObj, 1.0f);
 		PRINT("==> ratio = %f\n", mRopePosRatio);

--- a/src/plugPikiKando/itemMgr.cpp
+++ b/src/plugPikiKando/itemMgr.cpp
@@ -1057,7 +1057,7 @@ void BuildingItem::startAI(int)
 
 	mWayPoint            = routeMgr->findNearestWayPointAll('test', mPosition);
 	mWayPoint->mPosition = mPosition;
-	PRINT("*** \n");
+	PRINT_KANDO("*** \n");
 	C_SAI(this)->start(this, SluiceAI::Sluice_WaitInit);
 
 	_448   = mPosition;
@@ -1196,7 +1196,7 @@ void BuildingItem::doSave(RandomAccessStream& output)
 	output.writeInt(mCurrStage);
 	output.writeInt(mNumStages);
 	output.writeInt(mCurrAnimId);
-	PRINT("\t life=%.1f maxLife=%.1f curr/num=%d/%d\n", mHealth, mMaxHealth, mCurrStage, mNumStages);
+	PRINT_KANDO("\t life=%.1f maxLife=%.1f curr/num=%d/%d\n", mHealth, mMaxHealth, mCurrStage, mNumStages);
 }
 
 /*
@@ -1212,7 +1212,7 @@ void BuildingItem::doLoad(RandomAccessStream& input)
 	mNumStages  = input.readInt();
 	mCurrAnimId = input.readInt();
 
-	PRINT("currStage %d numStages %d\n", mCurrStage, mNumStages);
+	PRINT_KANDO("currStage %d numStages %d\n", mCurrStage, mNumStages);
 
 	if (mCurrStage < mNumStages) {
 		startMotion(mCurrStage);
@@ -1226,7 +1226,7 @@ void BuildingItem::doLoad(RandomAccessStream& input)
 
 	stopMotion();
 	C_SAI(this)->start(this, SluiceAI::Sluice_WaitInit);
-	PRINT("* DONE\n");
+	PRINT_KANDO("* DONE\n");
 }
 
 /*
@@ -1266,7 +1266,7 @@ void BuildingItem::doRestore(CreatureInf* info)
 	else {
 		int finalKeyframeIdx = mItemAnimator.mAnimInfo->countAKeys() - 1;
 		f32 frame            = mItemAnimator.mAnimInfo->getKeyValue(finalKeyframeIdx) - 1.0f;
-		PRINT("*** BUILDING ITEM START MOTION (%d) @ %.1f frame\n", mNumStages - 1, frame);
+		PRINT_KANDO("*** BUILDING ITEM START MOTION (%d) @ %.1f frame\n", mNumStages - 1, frame);
 		startMotion(mNumStages - 1, frame);
 		mWayPoint->setFlag(true);
 	}
@@ -1386,11 +1386,11 @@ void ItemMgr::kill(Creature* item)
 PikiHeadMgr::PikiHeadMgr(ItemMgr* mgr)
 {
 	mItemMgr = mgr;
-	PRINT("PIKIHEADMGR *** this = %x\n", this);
+	PRINT_KANDO("PIKIHEADMGR *** this = %x\n", this);
 	mPikiHeadProps = new PikiHeadItemProp();
 	mPikiHeadAI    = new PikiHeadAI();
 	create(MAX_PIKI_ON_FIELD);
-	PRINT("=====================================\n");
+	PRINT_KANDO("=====================================\n");
 }
 
 /*

--- a/src/plugPikiKando/objectMgr.cpp
+++ b/src/plugPikiKando/objectMgr.cpp
@@ -664,7 +664,7 @@ void PolyObjectMgr::update()
 		}
 
 		if (mObjectIndices[i] == -2 && get(i)->removable()) {
-			PRINT("killing ... %x\n", get(i));
+			PRINT_KANDO("killing ... %x\n", get(i));
 			kill(get(i));
 		} else if (mObjectIndices[i] == -2) {
 			get(i)->clearCnt();
@@ -876,7 +876,7 @@ void PolyObjectMgr::kill(Creature* obj)
 {
 	int id = getIndex(obj);
 	if (obj->removable()) {
-		PRINT("%x really dead (index %d) \n", obj, id);
+		PRINT_KANDO("%x really dead (index %d) \n", obj, id);
 		mObjectIndices[id] = -1;
 		mActiveObjects--;
 	} else {

--- a/src/plugPikiKando/pikiInf.cpp
+++ b/src/plugPikiKando/pikiInf.cpp
@@ -532,23 +532,19 @@ void CreatureInf::doStore(Creature* owner)
 	mObjType             = owner->mObjType;
 	mRebirthDay          = 0;
 	mCurrentDay          = -1;
-	mAdjustFaceDirection = owner->isCreatureFlag(CF_FaceDirAdjust) != false;
+	mAdjustFaceDirection = owner->isCreatureFlag(CF_FaceDirAdjust);
 	owner->doStore(this);
 
-	if (owner->mRebirthDay > 0) {
+	if (owner->getRebirthDay() > 0) {
 		if (owner->isAlive()) {
 			mAdjustFaceDirection = 1;
 			mRebirthDay          = owner->mRebirthDay;
-			if (true) { // DLL: Some flag in memory controlling certain prints
-				PRINT("KKKKKKKKKKKK ALIVE : CARRYOVER !!!\n");
-			}
+			PRINT_KANDO("KKKKKKKKKKKK ALIVE : CARRYOVER !!!\n");
 		} else {
 			mAdjustFaceDirection = 0;
 			mCurrentDay          = gameflow.mWorldClock.mCurrentDay;
 			mRebirthDay          = owner->mRebirthDay;
-			if (true) { // DLL: Some flag in memory controlling certain prints
-				PRINT("KKKKKKKKKKKK DEAD : CARRYOVER !!!\n");
-			}
+			PRINT_KANDO("KKKKKKKKKKKK DEAD : CARRYOVER !!!\n");
 		}
 	}
 }

--- a/src/plugPikiKando/pikiState.cpp
+++ b/src/plugPikiKando/pikiState.cpp
@@ -889,7 +889,7 @@ PikiSwallowedState::PikiSwallowedState()
  */
 void PikiSwallowedState::init(Piki* piki)
 {
-	PRINT("swallowed init **** \n");
+	PRINT_KANDO("swallowed init **** \n");
 	piki->stopAI();
 }
 
@@ -1039,7 +1039,7 @@ void PikiFlickState::exec(Piki* piki)
 {
 	PaniAnimator& upper = piki->mPikiAnimMgr.getUpperAnimator();
 	if (upper.getCurrentMotionIndex() == PIKIANIM_Kuttuku) {
-		PRINT("piki %x motion KENKA!\n", piki);
+		PRINT_KANDO("piki %x motion KENKA!\n", piki);
 	}
 
 	if (mState == 0) {
@@ -1144,7 +1144,7 @@ void PikiFlickState::cleanup(Piki* piki)
 		return;
 	}
 
-	PRINT("piki%x FLICK ** aiAction->curr = %d is not resumable!\n", piki, piki->mActiveAction->mCurrActionIdx);
+	PRINT_KANDO("piki%x FLICK ** aiAction->curr = %d is not resumable!\n", piki, piki->mActiveAction->mCurrActionIdx);
 	piki->mActiveAction->abandon(nullptr);
 }
 
@@ -1194,7 +1194,7 @@ void PikiFlownState::exec(Piki* piki)
 {
 	PaniAnimator& upper = piki->mPikiAnimMgr.getUpperAnimator();
 	if (upper.getCurrentMotionIndex() == PIKIANIM_Kuttuku) {
-		PRINT("piki %x motion KENKA!\n", piki);
+		PRINT_KANDO("piki %x motion KENKA!\n", piki);
 	}
 
 	if (mState == 0) {
@@ -1303,7 +1303,7 @@ PikiFallMeckState::PikiFallMeckState()
  */
 void PikiFallMeckState::init(Piki* piki)
 {
-	PRINT("--- fall start\n");
+	PRINT_KANDO("--- fall start\n");
 	piki->startMotion(PaniMotionInfo(PIKIANIM_Fall, piki), PaniMotionInfo(PIKIANIM_Fall));
 	piki->endStickMouth();
 	piki->mSwallowMouthPart = nullptr;
@@ -1396,7 +1396,7 @@ PikiFallState::PikiFallState()
  */
 void PikiFallState::init(Piki* piki)
 {
-	PRINT("--- fall start\n");
+	PRINT_KANDO("--- fall start\n");
 	piki->startMotion(PaniMotionInfo(PIKIANIM_Fall, piki), PaniMotionInfo(PIKIANIM_Fall));
 	mState = 0;
 }
@@ -1417,7 +1417,7 @@ void PikiFallState::exec(Piki* piki)
  */
 void PikiFallState::procBounceMsg(Piki* piki, MsgBounce*)
 {
-	PRINT("fall : got bounce\n");
+	PRINT_KANDO("fall : got bounce\n");
 	mState = 1;
 	piki->startMotion(PaniMotionInfo(PIKIANIM_JKoke, piki), PaniMotionInfo(PIKIANIM_JKoke));
 }
@@ -1482,7 +1482,7 @@ void PikiCliffState::init(Piki* piki)
 	piki->startMotion(PaniMotionInfo(PIKIANIM_LSuberu, piki), PaniMotionInfo(PIKIANIM_LSuberu));
 	piki->mTargetVelocity.set(0.0f, 0.0f, 0.0f);
 	mState = 0;
-	PRINT("%x cliff start :: %s\n", piki, mCliffHangType ? "BURAN" : "OTIKAKE"); // 'hang' and 'fall' (i think)
+	PRINT_KANDO("%x cliff start :: %s\n", piki, mCliffHangType ? "BURAN" : "OTIKAKE"); // 'hang' and 'fall' (i think)
 	mInitialFaceDir = piki->mFaceDirection;
 }
 
@@ -1494,7 +1494,7 @@ void PikiCliffState::init(Piki* piki)
 void PikiCliffState::exec(Piki* piki)
 {
 	if (!piki->mGroundTriangle) {
-		PRINT("piki %x: no floor !\n", piki);
+		PRINT_KANDO("piki %x: no floor !\n", piki);
 		transit(piki, PIKISTATE_Fall);
 	}
 }
@@ -1540,7 +1540,7 @@ bool PikiCliffState::nearEnough(Piki* piki)
 			return true;
 		}
 
-		PRINT("currY = %.1f botY = %.1f\n", currY, botY);
+		PRINT_KANDO("currY = %.1f botY = %.1f\n", currY, botY);
 	}
 
 	return false;
@@ -1563,22 +1563,22 @@ void PikiCliffState::procAnimMsg(Piki* piki, MsgAnim* msg)
 
 			mState       = 1;
 			mLoopCounter = int((2.0f * gsys->getRand(1.0f))) + 1;
-			PRINT("otikake motion start\n");
+			PRINT_KANDO("otikake motion start\n");
 			piki->startMotion(PaniMotionInfo(PIKIANIM_Otikake, piki), PaniMotionInfo(PIKIANIM_Otikake));
 			break;
 
 		case 3:
 			if (!piki->mGroundTriangle) {
-				PRINT("piki fall (otiru) %x\n", piki);
+				PRINT_KANDO("piki fall (otiru) %x\n", piki);
 				transit(piki, PIKISTATE_Fall);
 				return;
 			}
-			PRINT("otiru escaped\n");
+			PRINT_KANDO("otiru escaped\n");
 			transit(piki, PIKISTATE_Normal);
 			break;
 
 		case 1:
-			PRINT("goto normal !?\n");
+			PRINT_KANDO("goto normal !?\n");
 			transit(piki, PIKISTATE_Normal);
 			break;
 		}
@@ -1598,33 +1598,34 @@ void PikiCliffState::procAnimMsg(Piki* piki, MsgAnim* msg)
 					Plane* plane = piki->getNearestPlane(piki->mGroundTriangle);
 					if (plane) {
 						f32 dist = plane->dist(piki->mPosition);
-						PRINT("dist is %.1f ( radius=%f : centresize=%f\n", dist, piki->mCollisionRadius, piki->getCentreSize());
+						PRINT_KANDO("dist is %.1f ( radius=%f : centresize=%f\n", dist, piki->mCollisionRadius, piki->getCentreSize());
 						if (dist > -0.2f && dist < 3.0f) {
-							PRINT("piki%x : ####### start buran motion :: floor = %s\n", piki, piki->mGroundTriangle ? "on floor" : "air");
+							PRINT_KANDO("piki%x : ####### start buran motion :: floor = %s\n", piki,
+							            piki->mGroundTriangle ? "on floor" : "air");
 							mState       = 2;
 							mLoopCounter = int((2.0f * gsys->getRand(1.0f))) + 2;
 							break;
 						}
-						PRINT("buran is not executable : dist is too far\n");
+						PRINT_KANDO("buran is not executable : dist is too far\n");
 						transit(piki, PIKISTATE_Normal);
 						break;
 					}
-					PRINT("buran is not executable : no plane\n");
+					PRINT_KANDO("buran is not executable : no plane\n");
 					transit(piki, PIKISTATE_Normal);
 					break;
 				}
-				PRINT("buran is not executable : no floorCollTri\n");
+				PRINT_KANDO("buran is not executable : no floorCollTri\n");
 				startFall(piki);
 				break;
 			}
 
 			if (piki->mGroundTriangle) {
-				PRINT("piki escaped from falling!\n");
+				PRINT_KANDO("piki escaped from falling!\n");
 				transit(piki, PIKISTATE_Normal);
 				break;
 			}
 
-			PRINT("fall start : \n");
+			PRINT_KANDO("fall start : \n");
 			startFall(piki);
 			break;
 
@@ -1635,7 +1636,7 @@ void PikiCliffState::procAnimMsg(Piki* piki, MsgAnim* msg)
 			}
 
 			piki->mPosition = piki->getCentre();
-			PRINT("piki %x : do fall\n", piki);
+			PRINT_KANDO("piki %x : do fall\n", piki);
 			transit(piki, PIKISTATE_Fall);
 			break;
 		}
@@ -1650,7 +1651,7 @@ void PikiCliffState::procAnimMsg(Piki* piki, MsgAnim* msg)
  */
 void PikiCliffState::cleanup(Piki* piki)
 {
-	PRINT("cliff cleanup\n");
+	PRINT_KANDO("cliff cleanup\n");
 }
 
 /*
@@ -1940,8 +1941,8 @@ void PikiFlyingState::restartEffect()
  */
 void PikiFlyingState::init(Piki* piki)
 {
-	PRINT("flying state init\n");
-	PRINT("piki is %s\n", piki->isHolding() ? "holding" : "not holding");
+	PRINT_KANDO("flying state init\n");
+	PRINT_KANDO("piki is %s\n", piki->isHolding() ? "holding" : "not holding");
 	piki->mMotionSpeed = 30.0f;
 	piki->startMotion(PaniMotionInfo(PIKIANIM_RollJmp), PaniMotionInfo(PIKIANIM_RollJmp));
 	piki->stopAI();
@@ -2143,38 +2144,39 @@ void PikiFlyingState::procCollideMsg(Piki* piki, MsgCollide* msg)
 
 	if (colliderType == OBJTYPE_Teki && collider->isOrganic()) {
 		piki->mActiveAction->abandon(nullptr);
-		PRINT("FLYING .. collide\n");
+		PRINT_KANDO("FLYING .. collide\n");
 		if (msg->mEvent.mColliderPart->isPlatformType()) {
 			if (msg->mEvent.mColliderPart->isStickable()) {
-				PRINT("flying ... stick to platform::%s(code %s)\n", msg->mEvent.mColliderPart->mCollInfo->mId.mStringID,
-				      msg->mEvent.mColliderPart->mCollInfo->mCode.mStringID);
+				PRINT_KANDO("flying ... stick to platform::%s(code %s)\n", msg->mEvent.mColliderPart->mCollInfo->mId.mStringID,
+				            msg->mEvent.mColliderPart->mCollInfo->mCode.mStringID);
 				piki->startStick(collider, msg->mEvent.mColliderPart);
 				SeSystem::playPlayerSe(SE_PIKI_ATTACHENEMY);
 			} else if (msg->mEvent.mColliderPart->isClimbable()) {
-				PRINT("flying ... stick to platform::%s(code %s)\n", msg->mEvent.mColliderPart->mCollInfo->mId.mStringID,
-				      msg->mEvent.mColliderPart->mCollInfo->mCode.mStringID);
+				PRINT_KANDO("flying ... stick to platform::%s(code %s)\n", msg->mEvent.mColliderPart->mCollInfo->mId.mStringID,
+				            msg->mEvent.mColliderPart->mCollInfo->mCode.mStringID);
 				piki->startStick(collider, msg->mEvent.mColliderPart);
 				SeSystem::playPlayerSe(SE_PIKI_ATTACHENEMY);
 			}
 		} else if ((msg->mEvent.mColliderPart->isCollisionType() || msg->mEvent.mColliderPart->isTubeType())
 		           && msg->mEvent.mColliderPart->isStickable()) {
-			PRINT("flying ... stick to sphere\n");
+			PRINT_KANDO("flying ... stick to sphere\n");
 			piki->startStickObject(collider, msg->mEvent.mColliderPart, -1, 0.0f);
 			SeSystem::playPlayerSe(SE_PIKI_ATTACHENEMY);
 		}
 
 		transit(piki, PIKISTATE_Normal);
-		PRINT("++++++++++++++++++++++++++++++++\n");
-		PRINT(" _stickPart = %x : %s\n", piki->mStickPart, piki->mStickPart ? piki->mStickPart->mCollInfo->mId.mStringID : "nothing!");
-		PRINT(" _stickPart = %x\n", piki->mStickPart);
+		PRINT_KANDO("++++++++++++++++++++++++++++++++\n");
+		PRINT_KANDO(" _stickPart = %x : %s\n", piki->mStickPart,
+		            piki->mStickPart ? piki->mStickPart->mCollInfo->mId.mStringID : "nothing!");
+		PRINT_KANDO(" _stickPart = %x\n", piki->mStickPart);
 		piki->mActiveAction->mCurrActionIdx = PikiAction::Attack;
-		PRINT("----------------\n");
+		PRINT_KANDO("----------------\n");
 		piki->mActiveAction->mChildActions[PikiAction::Attack].initialise(collider);
-		PRINT("----------------\n");
+		PRINT_KANDO("----------------\n");
 		piki->mMode = PikiMode::AttackMode;
-		PRINT(" _stickPart = %x\n", piki->mStickPart);
-		PRINT("(%x) stick OBJECT attack start ? ########\n", piki);
-		PRINT(" _stickPart = %x\n", piki->mStickPart); // this is excessive.
+		PRINT_KANDO(" _stickPart = %x\n", piki->mStickPart);
+		PRINT_KANDO("(%x) stick OBJECT attack start ? ########\n", piki);
+		PRINT_KANDO(" _stickPart = %x\n", piki->mStickPart); // this is excessive.
 		return;
 	}
 
@@ -2194,7 +2196,7 @@ void PikiFlyingState::procCollideMsg(Piki* piki, MsgCollide* msg)
 	}
 
 	if (collider->isSluice()) {
-		PRINT("got here\n");
+		PRINT_KANDO("got here\n");
 		piki->mMode                         = PikiMode::BreakwallMode;
 		piki->mActiveAction->mCurrActionIdx = PikiAction::BreakWall;
 		piki->mActiveAction->mChildActions[PikiAction::BreakWall].initialise(collider);
@@ -2211,7 +2213,7 @@ void PikiFlyingState::procCollideMsg(Piki* piki, MsgCollide* msg)
 	}
 
 	if (colliderType != OBJTYPE_Navi) {
-		PRINT("collide restart!!\n");
+		PRINT_KANDO("collide restart!!\n");
 		piki->restartAI();
 		transit(piki, PIKISTATE_Normal);
 	}
@@ -3130,7 +3132,7 @@ void PikiPressedState::init(Piki* piki)
 	piki->mScale.set(scale, 0.01f, scale);
 	mStunTimer    = 1.5f;
 	mIsInvincible = true;
-	PRINT("pressed init !\n");
+	PRINT_KANDO("pressed init !\n");
 }
 
 /*

--- a/src/plugPikiKando/routeMgr.cpp
+++ b/src/plugPikiKando/routeMgr.cpp
@@ -1285,7 +1285,7 @@ void WayPoint::initLinkInfos()
 
 		// If no link exists in this slot, mark all info entries as dead ends (-2)
 		if (mLinkIndices[i] == -1) {
-			PRINT("nolink wp %d : link%d set deadend\n", mIndex, i);
+			PRINT_KANDO("nolink wp %d : link%d set deadend\n", mIndex, i);
 			for (int j = 0; j < 4; j++) {
 				info->setInfo(j, -2);
 			}
@@ -1319,14 +1319,14 @@ void WayPoint::initLinkInfos()
 				int linkWaypointIdx    = mLinkIndices[i];
 				PathFinder* pathfinder = routeMgr->getPathFinder('test');
 
-				PRINT("** (%d to %d)\n", linkWaypointIdx, wpIdx);
+				PRINT_KANDO("** (%d to %d)\n", linkWaypointIdx, wpIdx);
 
 				int pathLength = pathfinder->findSync(pathfinder->mBuffer, linkWaypointIdx, wpIdx, true);
 
 				// If no path is found, mark dead end
 				if (pathLength == 0) {
 					info->setInfo(goalIdx, -2);
-					PRINT("noway wp %d : link%d set deadend\n", mIndex, i);
+					PRINT_KANDO("noway wp %d : link%d set deadend\n", mIndex, i);
 					continue;
 				}
 
@@ -1357,7 +1357,7 @@ void WayPoint::initLinkInfos()
 			} else {
 				// If no valid target waypoint, mark as dead end for this goal
 				info->setInfo(goalIdx, -2);
-				PRINT("(goal%d) wp %d : link%d set deadend\n", goalIdx, mIndex, i);
+				PRINT_KANDO("(goal%d) wp %d : link%d set deadend\n", goalIdx, mIndex, i);
 			}
 		}
 	}

--- a/src/plugPikiKando/soundMgr.cpp
+++ b/src/plugPikiKando/soundMgr.cpp
@@ -542,11 +542,11 @@ void SeContext::update()
  */
 bool SeContext::releaseEvent()
 {
-	PRINT("releaseEvent : %x : handle = %d\n", this, mEventHandle);
+	PRINT_KANDO("releaseEvent : %x : handle = %d\n", this, mEventHandle);
 
 	if (mEventHandle != -1) {
 		bool ret = seSystem->destroyEvent(this, mEventHandle);
-		PRINT("** destroyEvent %s\n", ret ? "succeeded" : "failed");
+		PRINT_KANDO("** destroyEvent %s\n", ret ? "succeeded" : "failed");
 		mEventHandle = -1;
 		return ret;
 	}

--- a/src/plugPikiNakata/nakatacode.cpp
+++ b/src/plugPikiNakata/nakatacode.cpp
@@ -29,7 +29,7 @@ DEFINE_PRINT("nakatacode")
 void NakataCodeInitializer::init()
 {
 	nakataDebugMode = TRUE;
-	PRINT("NNNNNNNNNNNNNNNNNNNNNNNakataCodeInitializer::init\n"); // lol
+	PRINT_NAKATA("NNNNNNNNNNNNNNNNNNNNNNNakataCodeInitializer::init\n"); // lol
 	NSystem::initSystem(gsys);
 	PaniPikiAnimMgr::motionTable = nullptr;
 	TekiMgr::initTekiMgr();

--- a/src/plugPikiNakata/nlibfunction.cpp
+++ b/src/plugPikiNakata/nlibfunction.cpp
@@ -101,9 +101,9 @@ f32 NPolynomialFunction::getCoefficient(int)
  */
 void NPolynomialFunction::println()
 {
-	PRINT("NPolynomialFunction:%d\n", mData.getDimension());
+	PRINT_NAKATA("NPolynomialFunction:%d\n", mData.getDimension());
 	for (int i = 0; i < mData.getDimension(); i++) {
-		PRINT("NPolynomialFunction:%d:%f\n", i, mData.mValues[i]);
+		PRINT_NAKATA("NPolynomialFunction:%d:%f\n", i, mData.mValues[i]);
 	}
 }
 

--- a/src/plugPikiNakata/nlibgeometry.cpp
+++ b/src/plugPikiNakata/nlibgeometry.cpp
@@ -363,7 +363,7 @@ void NMatrix4f::makeIdentRow(int row)
 void NMatrix4f::println()
 {
 	for (int i = 0; i < 4; i++) {
-		PRINT("|%f,%f,%f,%f|\n", mMtx[i][0], mMtx[i][1], mMtx[i][2], mMtx[i][3]);
+		PRINT_NAKATA("|%f,%f,%f,%f|\n", mMtx[i][0], mMtx[i][1], mMtx[i][2], mMtx[i][3]);
 	}
 }
 
@@ -487,7 +487,7 @@ void NOrientation::makeUp()
 		orient.inputUp(NVector3f(0.0f, 0.0f, 1.0f));
 
 	} else {
-		PRINT("?makeUp\n");
+		PRINT_NAKATA("?makeUp\n");
 	}
 
 	orient.normalize();
@@ -553,9 +553,9 @@ void NOrientation::inputRotation(NTransform3D& transform)
  */
 void NOrientation::println()
 {
-	PRINT("fore:");
+	PRINT_NAKATA("fore:");
 	mDirection.println();
-	PRINT("up:");
+	PRINT_NAKATA("up:");
 	mUpVector.println();
 }
 
@@ -738,7 +738,7 @@ bool NPolar3f::clampMeridian(f32 angle)
  */
 void NPolar3f::println()
 {
-	PRINT("(%f,%f,%f)\n", mRadius, mInclination, mAzimuth);
+	PRINT_NAKATA("(%f,%f,%f)\n", mRadius, mInclination, mAzimuth);
 }
 
 /*
@@ -835,9 +835,9 @@ void NPosture2D::readData(Stream& input)
  */
 void NPosture2D::println()
 {
-	PRINT("translation:");
+	PRINT_NAKATA("translation:");
 	mTranslation.println();
-	PRINT("direction:%f\n", mDirection);
+	PRINT_NAKATA("direction:%f\n", mDirection);
 }
 
 /*
@@ -902,7 +902,7 @@ void NPosture3D::normalize()
 	NVector3f& dir = NVector3f();
 	outputRelative(dir);
 	if (NMathF::isZero(dir.length())) {
-		PRINT("?normalize:zero:" MISSING_NEWLINE);
+		PRINT_NAKATA("?normalize:zero:" MISSING_NEWLINE);
 		mWatchpoint.add(NVector3f(0.0f, 0.0f, 1.0f));
 	}
 }
@@ -1185,7 +1185,7 @@ void NLowerMatrix::solve(NVector& inVec, NVector& outVec)
 void NLowerMatrix::println()
 {
 	for (int i = 0; i < mDimension - 1; i++) {
-		PRINT("l[%d]:%f\n", i, mLower[i]);
+		PRINT_NAKATA("l[%d]:%f\n", i, mLower[i]);
 	}
 }
 
@@ -1233,10 +1233,10 @@ void NUpperMatrix::solve(NVector& inVec, NVector& outVec)
 void NUpperMatrix::println()
 {
 	for (int i = 0; i < mDimension; i++) {
-		PRINT("e[%d]:%f\n", i, mCentre[i]);
+		PRINT_NAKATA("e[%d]:%f\n", i, mCentre[i]);
 	}
 	for (int i = 0; i < mDimension - 1; i++) {
-		PRINT("u[%d]:%f\n", i, mUpper[i]);
+		PRINT_NAKATA("u[%d]:%f\n", i, mUpper[i]);
 	}
 }
 
@@ -1317,13 +1317,13 @@ void LUMatrix::decompose()
 void LUMatrix::println()
 {
 	for (int i = 0; i < mDimension; i++) {
-		PRINT("e[%d]:%f\n", i, mCentreVals[i]);
+		PRINT_NAKATA("e[%d]:%f\n", i, mCentreVals[i]);
 	}
 	for (int i = 0; i < mDimension - 1; i++) {
-		PRINT("l[%d]:%f\n", i, mLowerVals[i]);
+		PRINT_NAKATA("l[%d]:%f\n", i, mLowerVals[i]);
 	}
 	for (int i = 0; i < mDimension - 1; i++) {
-		PRINT("u[%d]:%f\n", i, mUpperVals[i]);
+		PRINT_NAKATA("u[%d]:%f\n", i, mUpperVals[i]);
 	}
 }
 
@@ -1703,7 +1703,7 @@ void NVector::println()
 {
 	// UNUSED FUNCTION
 	for (int i = 0; i < mSize; i++) {
-		PRINT("e[%d]:%f\n", i, mValues[i]);
+		PRINT_NAKATA("e[%d]:%f\n", i, mValues[i]);
 	}
 }
 
@@ -1911,7 +1911,7 @@ f32 NVector3f::calcLargerAngle(NVector3f& other)
  */
 void NVector3f::print()
 {
-	PRINT("(%f,%f,%f)", x, y, z);
+	PRINT_NAKATA("(%f,%f,%f)", x, y, z);
 }
 
 /*
@@ -1921,7 +1921,7 @@ void NVector3f::print()
  */
 void NVector3f::println()
 {
-	PRINT("(%f,%f,%f)\n", x, y, z);
+	PRINT_NAKATA("(%f,%f,%f)\n", x, y, z);
 }
 
 /*

--- a/src/plugPikiNakata/nlibgeometry3d.cpp
+++ b/src/plugPikiNakata/nlibgeometry3d.cpp
@@ -193,9 +193,9 @@ void NLine::transform(NTransform3D& transform)
  */
 void NLine::println()
 {
-	PRINT("position:\n");
+	PRINT_NAKATA("position:\n");
 	mPosition.println();
-	PRINT("direction:\n");
+	PRINT_NAKATA("direction:\n");
 	mDirection.println();
 }
 
@@ -474,9 +474,9 @@ void NPlane::transform(NTransform3D& transform)
  */
 void NPlane::println()
 {
-	PRINT("normal:\n");
+	PRINT_NAKATA("normal:\n");
 	mNormal.println();
-	PRINT("difference:%f\n", mDifference);
+	PRINT_NAKATA("difference:%f\n", mDifference);
 }
 
 /*
@@ -597,6 +597,6 @@ void NSegment::makeProjectionY()
 void NSegment::println()
 {
 	NLine::println();
-	PRINT("edge:\n");
+	PRINT_NAKATA("edge:\n");
 	mEdge.println();
 }

--- a/src/plugPikiNakata/nlibspline.cpp
+++ b/src/plugPikiNakata/nlibspline.cpp
@@ -156,7 +156,7 @@ int SplineInterpolator::searchSegmentIndex(f32 targetParam, int startIdx)
 		}
 	}
 
-	PRINT("?searchSegmentIndex:%f,%f,%d\n", targetParam, mFrameArray->get(mFrameArray->getSize() - 1)->getParameter(), startIdx);
+	PRINT_NAKATA("?searchSegmentIndex:%f,%f,%d\n", targetParam, mFrameArray->get(mFrameArray->getSize() - 1)->getParameter(), startIdx);
 	return mFrameArray->getSize() - 2;
 }
 

--- a/src/plugPikiNakata/panianimator.cpp
+++ b/src/plugPikiNakata/panianimator.cpp
@@ -223,8 +223,7 @@ void PaniAnimator::animate(f32 speed)
 	}
 
 	if (speed < 0.0f) {
-		mAnimationCounter;
-		PRINT("!animate:%08x:%f,%f\n", this, mAnimationCounter, speed);
+		PRINT_NAKATA("!animate:%08x:%f,%f\n", this, mAnimationCounter, speed);
 	}
 
 	if (mCurrentKeyIndex < 0) {
@@ -234,8 +233,7 @@ void PaniAnimator::animate(f32 speed)
 	f32 startValue = (f32)mAnimInfo->getKeyValue(mStartKeyIndex);
 	f32 endValue   = (f32)mAnimInfo->getKeyValue(mEndKeyIndex);
 	if (startValue > endValue) {
-		mAnimationCounter;
-		PRINT("!animate:%08x:to<from:%f,%f,%f\n", this, endValue, startValue, mAnimationCounter);
+		PRINT_NAKATA("!animate:%08x:to<from:%f,%f,%f\n", this, endValue, startValue, mAnimationCounter);
 		return;
 	}
 

--- a/src/plugPikiNakata/pcamcamera.cpp
+++ b/src/plugPikiNakata/pcamcamera.cpp
@@ -305,7 +305,7 @@ void PcamCamera::startAttention()
  */
 void PcamCamera::playCameraSound(int soundID)
 {
-	PRINT("playCameraSound:%d\n", soundID);
+	PRINT_NAKATA("playCameraSound:%d\n", soundID);
 	SeSystem::playSysSe(soundID);
 }
 
@@ -500,7 +500,7 @@ void PcamCamera::startMotion(int zoom, int incl)
  */
 void PcamCamera::startMotion(PcamMotionInfo& info)
 {
-	PRINT("startMotion\n");
+	PRINT_NAKATA("startMotion\n");
 	mPrevMotionInfo   = mTargetMotionInfo;
 	mTargetMotionInfo = info;
 	mTimers[0]        = getParameterF(PCAMF_ChangingMotionPeriod);
@@ -513,7 +513,7 @@ void PcamCamera::startMotion(PcamMotionInfo& info)
  */
 void PcamCamera::finishMotion()
 {
-	PRINT("finishMotion\n");
+	PRINT_NAKATA("finishMotion\n");
 	startMotion(PcamMotionInfo(mPrevMotionInfo));
 }
 

--- a/src/plugPikiNakata/pcamcameramanager.cpp
+++ b/src/plugPikiNakata/pcamcameramanager.cpp
@@ -120,7 +120,7 @@ void PcamCameraManager::updateVibrationEvent()
 
 	PeveEvent* event = mVibrationEvents[mCurrEventIndex];
 	if (event->isFinished()) {
-		PRINT("updateVibrationEvent:event->isFinished:%08x\n", event);
+		PRINT_NAKATA("updateVibrationEvent:event->isFinished:%08x\n", event);
 		event->finish();
 		mCurrEventIndex = PCAMVIB_NULL;
 	} else {

--- a/src/plugPikiNakata/pcamcameraparameters.cpp
+++ b/src/plugPikiNakata/pcamcameraparameters.cpp
@@ -162,7 +162,7 @@ PcamCameraParameters::PcamCameraParameters()
 void PcamCameraParameters::read(RandomAccessStream& input)
 {
 	mVersion = input.readInt();
-	PRINT("PcamCameraParameters::read>%d\n", mVersion);
+	PRINT_NAKATA("PcamCameraParameters::read>%d\n", mVersion);
 	ParaMultiParameters* multiP = mParameters;
 	if (mVersion <= 6) {
 		multiP->mIntParams->read(input);
@@ -173,15 +173,15 @@ void PcamCameraParameters::read(RandomAccessStream& input)
 		multiP->read(input);
 	}
 
-	PRINT("PcamCameraParameters::read<\n");
+	PRINT_NAKATA("PcamCameraParameters::read<\n");
 }
 
 #if 0
 void PcamCameraParameters::write(RandomAccessStream& output)
 {
-	PRINT("PcamCameraParameters::write>\n");
+	PRINT_NAKATA("PcamCameraParameters::write>\n");
 	output.writeInt(7);
 	mParameters->write(output);
-	PRINT("PcamCameraParameters::write<\n");
+	PRINT_NAKATA("PcamCameraParameters::write<\n");
 }
 #endif

--- a/src/plugPikiNakata/peve.cpp
+++ b/src/plugPikiNakata/peve.cpp
@@ -122,7 +122,7 @@ void PeveSerialEvent::update()
 {
 	PeveEvent* currEvent = getCurrentEvent();
 	if (currEvent->isFinished()) {
-		PRINT("isFinished:%d\n", mEventIdx);
+		PRINT_NAKATA("isFinished:%d\n", mEventIdx);
 		if (mEventIdx + 1 < getChildCount()) {
 			mEventIdx++;
 			PeveEvent* newEvent = getCurrentEvent();

--- a/src/plugPikiNakata/tai.cpp
+++ b/src/plugPikiNakata/tai.cpp
@@ -137,8 +137,8 @@ bool TaiState::act(Teki& teki)
 	for (int i = 0; i < mCount; i++) {
 		TaiAction* action = mActions[i];
 		if (action->act(teki) && action->hasNextState()) {
-			PRINT("transit:%08x:i:%d:%d->%d(%d),t:%d,m:%d\n", &teki, i, teki.mStateID, action->mNextState, teki.mReturnStateID,
-			      teki.mTekiType, teki.mTekiAnimator->getCurrentMotionIndex());
+			PRINT_NAKATA("transit:%08x:i:%d:%d->%d(%d),t:%d,m:%d\n", &teki, i, teki.mStateID, action->mNextState, teki.mReturnStateID,
+			             teki.mTekiType, teki.mTekiAnimator->getCurrentMotionIndex());
 
 			volatile int& stateID = teki.mStateID;
 			int startVal          = teki.mStateID;
@@ -166,8 +166,8 @@ bool TaiState::eventPerformed(TekiEvent& event)
 	for (int i = 0; i < mCount; i++) {
 		TaiAction* action = mActions[i];
 		if (action->actByEvent(event) && action->hasNextState()) {
-			PRINT("eventPerformed:%08x:i:%d:%d->%d(%d),t:%d,m:%d\n", event.mTeki, i, event.mTeki->mStateID, action->mNextState,
-			      event.mTeki->mReturnStateID, event.mTeki->mTekiType, event.mTeki->mTekiAnimator->getCurrentMotionIndex());
+			PRINT_NAKATA("eventPerformed:%08x:i:%d:%d->%d(%d),t:%d,m:%d\n", event.mTeki, i, event.mTeki->mStateID, action->mNextState,
+			             event.mTeki->mReturnStateID, event.mTeki->mTekiType, event.mTeki->mTekiAnimator->getCurrentMotionIndex());
 
 			Teki* volatile teki = event.mTeki;
 			int startVal        = event.mTeki->mStateID;

--- a/src/plugPikiNakata/taiattackactions.cpp
+++ b/src/plugPikiNakata/taiattackactions.cpp
@@ -100,7 +100,7 @@ void TaiAnimationSwallowingAction::start(Teki& teki)
 bool TaiAnimationSwallowingAction::act(Teki& teki)
 {
 	if (teki.getAnimationKeyOption(BTeki::ANIMATION_KEY_OPTION_ACTION_0)) {
-		PRINT("TaiAnimationSwallowingAction::act:ACTION_0:%08x:\n", &teki);
+		PRINT_NAKATA("TaiAnimationSwallowingAction::act:ACTION_0:%08x:\n", &teki);
 		teki.flickUpper();
 		Vector3f center;
 		teki.outputHitCenter(center);
@@ -113,7 +113,7 @@ bool TaiAnimationSwallowingAction::act(Teki& teki)
 		int numSlots       = 0;
 		CollPart* mouth    = teki.mCollInfo->getSphere('slot');
 		if (!mouth) {
-			PRINT("TaiAnimationSwallowingAction::act:mouthPart==null:%08x\n", &teki);
+			PRINT_NAKATA("TaiAnimationSwallowingAction::act:mouthPart==null:%08x\n", &teki);
 		} else {
 			numSlots = mouth->getChildCount();
 		}
@@ -146,7 +146,7 @@ bool TaiAnimationSwallowingAction::act(Teki& teki)
 			}
 
 			if (mouth && swallowPikiNum < numSlots) {
-				PRINT("TaiAnimationSwallowingAction::act:ACTION_0:swallow:%08x:%08x,%d\n", &teki, piki, swallowPikiNum);
+				PRINT_NAKATA("TaiAnimationSwallowingAction::act:ACTION_0:swallow:%08x:%08x,%d\n", &teki, piki, swallowPikiNum);
 				piki->stimulate(InteractSwallow(&teki, mouth->getChildAt(swallowPikiNum++), 0));
 			} else {
 				piki->stimulate(kill);
@@ -176,15 +176,15 @@ bool TaiAnimationSwallowingAction::act(Teki& teki)
 		CI_LOOP(iter)
 		{
 			Creature* stuck = *iter;
-			PRINT("TaiAnimationSwallowingAction::act:ACTION_1:stick:%08x:%08x\n", &teki, stuck);
-			PRINT("TaiAnimationSwallowingAction::act:ACTION_1:count:%08x:%d\n", &teki, stuckList.getCount());
+			PRINT_NAKATA("TaiAnimationSwallowingAction::act:ACTION_1:stick:%08x:%08x\n", &teki, stuck);
+			PRINT_NAKATA("TaiAnimationSwallowingAction::act:ACTION_1:count:%08x:%d\n", &teki, stuckList.getCount());
 			if (!stuck) {
 				PRINT("?TaiAnimationSwallowingAction::act:ANIMATION_KEY_OPTION_ACTION_1:%08x:creature==null\n", &teki);
 				break;
 			}
 
 			if (stuck->isStickToMouth()) {
-				PRINT("TaiAnimationSwallowingAction::act:ACTION_1:kill:%08x:%08x\n", &teki, stuck);
+				PRINT_NAKATA("TaiAnimationSwallowingAction::act:ACTION_1:kill:%08x:%08x\n", &teki, stuck);
 				stuck->stimulate(InteractKill(&teki, 0));
 				iter.dec();
 			}
@@ -214,14 +214,14 @@ void TaiAnimationSwallowingAction::finish(Teki& teki)
 	CI_LOOP(iter)
 	{
 		Creature* stuck = *iter;
-		PRINT("TaiAnimationSwallowingAction::finish:stick:%08x:%08x\n", &teki, stuck);
+		PRINT_NAKATA("TaiAnimationSwallowingAction::finish:stick:%08x:%08x\n", &teki, stuck);
 		if (!stuck) {
 			PRINT("?TaiAnimationSwallowingAction::finish:%08x:creature==null\n", &teki);
 			return;
 		}
 
 		if (stuck->isStickToMouth()) {
-			PRINT("TaiAnimationSwallowingAction::finish:release:%08x:%08x\n", &teki, stuck);
+			PRINT_NAKATA("TaiAnimationSwallowingAction::finish:release:%08x:%08x\n", &teki, stuck);
 			stuck->endStickMouth();
 			iter.dec();
 		}

--- a/src/plugPikiNakata/taibasicactions.cpp
+++ b/src/plugPikiNakata/taibasicactions.cpp
@@ -84,7 +84,7 @@ void TaiTypeNaviWatchResultOnAction::start(Teki& teki)
 {
 	if (!teki.isCreatureFlag(CF_IsAICullingActive)) {
 		int resFlag = tekiMgr->getResultFlag(teki.mTekiType);
-		PRINT("TaiTypeNaviWatchResultOnAction::start:%08x:%d\n", &teki, resFlag);
+		PRINT_NAKATA("TaiTypeNaviWatchResultOnAction::start:%08x:%d\n", &teki, resFlag);
 		playerState->mResultFlags.setOn(resFlag);
 	}
 }

--- a/src/plugPikiNakata/taicollec.cpp
+++ b/src/plugPikiNakata/taicollec.cpp
@@ -530,7 +530,7 @@ bool TaiCollecImpassableAction::act(Teki& teki)
 		return false;
 	}
 
-	PRINT("TaiCollecImpassableAction::act:%08x:%f,%f,%f\n", &teki, dist, mMaxDistance, mTimerLength);
+	PRINT_NAKATA("TaiCollecImpassableAction::act:%08x:%f,%f,%f\n", &teki, dist, mMaxDistance, mTimerLength);
 	return true;
 
 	STACK_PAD_VAR(2);
@@ -556,7 +556,7 @@ bool TaiCollecLetGoOfPelletAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(2);
 	if (!target) {
-		PRINT("TaiCollecLetGoOfPelletAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiCollecLetGoOfPelletAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
@@ -564,7 +564,7 @@ bool TaiCollecLetGoOfPelletAction::act(Teki& teki)
 	pellet->endStickTeki(&teki);
 	teki.clearCreaturePointer(2);
 	teki.stopParticleGenerator(2);
-	PRINT("TaiCollecLetGoOfPelletAction::act:endStickTeki:%08x\n", &teki);
+	PRINT_NAKATA("TaiCollecLetGoOfPelletAction::act:endStickTeki:%08x\n", &teki);
 	return true;
 }
 
@@ -578,7 +578,7 @@ bool TaiCollecLetGoOfPelletAction::actByEvent(TekiEvent& event)
 	Teki* teki       = event.mTeki;
 	Creature* target = teki->getCreaturePointer(2);
 	if (!target) {
-		PRINT("TaiCollecLetGoOfPelletAction::actByEvent:target==null:%08x\n", teki);
+		PRINT_NAKATA("TaiCollecLetGoOfPelletAction::actByEvent:target==null:%08x\n", &teki);
 		return true;
 	}
 
@@ -586,7 +586,7 @@ bool TaiCollecLetGoOfPelletAction::actByEvent(TekiEvent& event)
 	pellet->endStickTeki(teki);
 	teki->clearCreaturePointer(2);
 	teki->stopParticleGenerator(2);
-	PRINT("TaiCollecLetGoOfPelletAction::actactByEvent:endStickTeki:%08x\n", teki);
+	PRINT_NAKATA("TaiCollecLetGoOfPelletAction::actactByEvent:endStickTeki:%08x\n", &teki);
 	return true;
 }
 
@@ -608,7 +608,7 @@ bool TaiCollecTargetPelletAction::act(Teki& teki)
 	}
 
 	teki.setCreaturePointer(0, nearest);
-	PRINT("TaiCollecTargetPelletAction::act:%08x,%08x,%08x\n", &teki, target, nearest);
+	PRINT_NAKATA("TaiCollecTargetPelletAction::act:%08x,%08x,%08x\n", &teki, target, nearest);
 	return true;
 
 	TekiAndCondition(nullptr, nullptr);
@@ -626,13 +626,13 @@ bool TaiCollecVisibleHeightPelletLostAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("TaiCollecVisibleHeightPelletLostAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiCollecVisibleHeightPelletLostAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
 	TekiVisibleHeightCondition& cond = TekiVisibleHeightCondition(&teki);
 	if (!cond.satisfy(target)) {
-		PRINT("TaiCollecVisibleHeightPelletLostAction::act:!condition.satisfy:%08x,%08x\n", &teki, target);
+		PRINT_NAKATA("TaiCollecVisibleHeightPelletLostAction::act:!condition.satisfy:%08x,%08x\n", &teki, target);
 		teki.setCreaturePointer(3, target);
 		teki.clearCreaturePointer(0);
 		return true;
@@ -664,7 +664,7 @@ bool TaiCollecPelletLostAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("TaiCollecPelletLostAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiCollecPelletLostAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
@@ -715,7 +715,7 @@ bool TaiCollecHoldPelletAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiCollecHoldPelletAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiCollecHoldPelletAction::act:target==null:%08x\n", &teki);
 		return false;
 	}
 
@@ -735,7 +735,7 @@ bool TaiCollecHoldPelletAction::act(Teki& teki)
 	teki.clearCreaturePointer(0);
 	teki.setCreaturePointer(2, pellet);
 	teki.startParticleGenerator(2);
-	PRINT("TaiCollecHoldPelletAction::act:%08x:startStickTeki:target:%08x\n", &teki, pellet);
+	PRINT_NAKATA("TaiCollecHoldPelletAction::act:%08x:startStickTeki:target:%08x\n", &teki, pellet);
 	return true;
 }
 
@@ -767,7 +767,7 @@ void TaiCollecCatchingAction::finish(Teki& teki)
  */
 void TaiCollecCarryingAction::start(Teki& teki)
 {
-	PRINT("TaiCollecCarryingAction::start:%08x\n", &teki);
+	PRINT_NAKATA("TaiCollecCarryingAction::start:%08x\n", &teki);
 	teki.setTekiOption(BTeki::TEKI_OPTION_MANUAL_ANIMATION);
 }
 
@@ -778,7 +778,7 @@ void TaiCollecCarryingAction::start(Teki& teki)
  */
 void TaiCollecCarryingAction::finish(Teki& teki)
 {
-	PRINT("TaiCollecCarryingAction::finish:%08x\n", &teki);
+	PRINT_NAKATA("TaiCollecCarryingAction::finish:%08x\n", &teki);
 	teki.clearTekiOption(BTeki::TEKI_OPTION_MANUAL_ANIMATION);
 }
 
@@ -810,7 +810,7 @@ bool TaiCollecCarryingAction::act(Teki& teki)
  */
 void TaiCollecBeingDraggedAction::start(Teki& teki)
 {
-	PRINT("TaiCollecBeingDraggedAction::start:%08x\n", &teki);
+	PRINT_NAKATA("TaiCollecBeingDraggedAction::start:%08x\n", &teki);
 	teki.startParticleGenerator(3);
 }
 
@@ -821,7 +821,7 @@ void TaiCollecBeingDraggedAction::start(Teki& teki)
  */
 void TaiCollecBeingDraggedAction::finish(Teki& teki)
 {
-	PRINT("TaiCollecBeingDraggedAction::finish:%08x\n", &teki);
+	PRINT_NAKATA("TaiCollecBeingDraggedAction::finish:%08x\n", &teki);
 	teki.stopParticleGenerator(3);
 }
 
@@ -908,7 +908,7 @@ void TaiCollecPuttingPelletAction::start(Teki& teki)
 
 	Creature* target = teki.getCreaturePointer(2);
 	if (!target) {
-		PRINT("TaiCollecPuttingPelletAction::start:target==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiCollecPuttingPelletAction::start:target==null:%08x\n", &teki);
 		return;
 	}
 
@@ -937,7 +937,7 @@ bool TaiCollecPuttingPelletAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(2);
 	if (!target) {
-		PRINT("TaiCollecPuttingPelletAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiCollecPuttingPelletAction::act:target==null:%08x\n", &teki);
 		return false;
 	}
 
@@ -975,16 +975,16 @@ bool TaiCollecCarryingToNestAction::act(Teki& teki)
 	}
 
 	if (teki.mRouteWayPointCount > teki.mRouteWayPointMax && teki.mCurrRouteWayPointID > teki.mRouteWayPointMax - 1) {
-		PRINT("!TaiCollecCarryingToNestAction::act:too long route:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID,
-		      teki.mRouteWayPointCount);
+		PRINT_NAKATA("!TaiCollecCarryingToNestAction::act:too long route:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID,
+		             teki.mRouteWayPointCount);
 		makePositionRoute(teki);
 		return false;
 	}
 
 	f32 val = teki.getParameterF(_0C);
 	if (teki.mRouteWayPointCount == 0 || teki.mCurrRouteWayPointID > teki.mRouteWayPointCount - 1) {
-		PRINT("TaiCollecCarryingToNestAction::act:%08x:%f,%d/%d\n", &teki, teki.getDirection(), teki.mCurrRouteWayPointID,
-		      teki.mRouteWayPointCount);
+		PRINT_NAKATA("TaiCollecCarryingToNestAction::act:%08x:%f,%d/%d\n", &teki, teki.getDirection(), teki.mCurrRouteWayPointID,
+		             teki.mRouteWayPointCount);
 		NVector3f ugPos;
 		TaiCollecStrategy* strat = (TaiCollecStrategy*)teki.getStrategy();
 		strat->outputUndergroundPosition(teki, ugPos);
@@ -1008,7 +1008,7 @@ bool TaiCollecCarryingToNestAction::act(Teki& teki)
 	}
 
 	if (BTeki::moveTowardStatic(target->getPosition(), wp->mPosition, val, teki.mTargetVelocity)) {
-		PRINT("TaiCollecCarryingToNestAction::act2:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID, teki.mRouteWayPointCount);
+		PRINT_NAKATA("TaiCollecCarryingToNestAction::act2:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID, teki.mRouteWayPointCount);
 		teki.mCurrRouteWayPointID++;
 	}
 
@@ -1065,7 +1065,8 @@ bool TaiCollecRouteImpassableAction::act(Teki& teki)
 	}
 
 	if (!wp->mIsOpen) {
-		PRINT("TaiCollecRouteImpassableAction::act:%08x:!wayPoint->on:%d/%d\n", &teki, teki.mCurrRouteWayPointID, teki.mRouteWayPointCount);
+		PRINT_NAKATA("TaiCollecRouteImpassableAction::act:%08x:!wayPoint->on:%d/%d\n", &teki, teki.mCurrRouteWayPointID,
+		             teki.mRouteWayPointCount);
 		// blocked waypoint? that's a paddling.
 		return true;
 	}
@@ -1128,7 +1129,7 @@ bool TaiCollecPelletStartContainerizedAction::act(Teki& teki)
 bool TaiCollecPelletFinishContainerizedAction::act(Teki& teki)
 {
 	if (!teki.getStickObject()) {
-		PRINT("TaiCollecPelletFinishContainerizedAction::act:%08x\n", &teki);
+		PRINT_NAKATA("TaiCollecPelletFinishContainerizedAction::act:%08x\n", &teki);
 		teki.clearCreaturePointer(2);
 		return true;
 	}

--- a/src/plugPikiNakata/taicollisionactions.cpp
+++ b/src/plugPikiNakata/taicollisionactions.cpp
@@ -44,7 +44,7 @@ bool TaiGroundCollisionAction::actByEvent(TekiEvent& event)
  */
 bool TaiWallCollisionAction::actByEvent(TekiEvent& event)
 {
-	PRINT("TaiWallCollisionAction::actByEvent:%08x,%d\n", event.mTeki, event.mEventType);
+	PRINT_NAKATA("TaiWallCollisionAction::actByEvent:%08x,%d\n", event.mTeki, event.mEventType);
 	return event.mEventType == TekiEventType::Wall;
 }
 
@@ -70,7 +70,7 @@ bool TaiPikiCollisionAction::actByEvent(TekiEvent& event)
 	}
 
 	if (!event.mOther) {
-		PRINT("!TaiPikiCollisionAction::actByEvent:%08x\n", event.mTeki);
+		PRINT_NAKATA("!TaiPikiCollisionAction::actByEvent:%08x\n", event.mTeki);
 		return false;
 	}
 
@@ -89,7 +89,7 @@ bool TaiNaviCollisionAction::actByEvent(TekiEvent& event)
 	}
 
 	if (!event.mOther) {
-		PRINT("!TaiNaviCollisionAction::actByEvent:%08x\n", event.mTeki);
+		PRINT_NAKATA("!TaiNaviCollisionAction::actByEvent:%08x\n", event.mTeki);
 		return false;
 	}
 
@@ -108,7 +108,7 @@ bool TaiTekiTypeCollisionAction::actByEvent(TekiEvent& event)
 	}
 
 	if (!event.mOther) {
-		PRINT("!TaiTekiTypeCollisionAction::actByEvent:%08x\n", event.mTeki);
+		PRINT_NAKATA("!TaiTekiTypeCollisionAction::actByEvent:%08x\n", event.mTeki);
 		return false;
 	}
 

--- a/src/plugPikiNakata/taijudgementactions.cpp
+++ b/src/plugPikiNakata/taijudgementactions.cpp
@@ -28,7 +28,7 @@ bool TaiVisibleTargetAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiVisibleTargetAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiVisibleTargetAction::act:target==null:%08x\n", &teki);
 		return false;
 	}
 	if (!teki.visibleCreature(*target)) {
@@ -47,7 +47,7 @@ bool TaiContactTargetAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiContactTargetAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiContactTargetAction::act:target==null:%08x\n", &teki);
 		return false;
 	}
 	if (!teki.contactCreature(*target)) {
@@ -66,7 +66,7 @@ bool TaiSeparateTargetAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiSeparateTargetAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiSeparateTargetAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 	if (!teki.separateCreature(*target)) {
@@ -85,7 +85,7 @@ bool TaiTargetLostAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("TaiTargetLostAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiTargetLostAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 	if (!teki.visibleCreature(*target)) {

--- a/src/plugPikiNakata/taikinoko.cpp
+++ b/src/plugPikiNakata/taikinoko.cpp
@@ -442,7 +442,7 @@ void TaiKinokoTurningOverAction::start(Teki& teki)
 bool TaiKinokoChargingSporesAction::act(Teki& teki)
 {
 	if (teki.getAnimationKeyOption(BTeki::ANIMATION_KEY_OPTION_ACTION_1)) {
-		PRINT("TaiKinokoChargingSporesAction:act:%08x:ACTION_1:\n", &teki);
+		PRINT_NAKATA("TaiKinokoChargingSporesAction:act:%08x:ACTION_1:\n", &teki);
 		NVector3f effectPos(teki.getPosition());
 		effectMgr->create(EffectMgr::EFF_Kinoko_ChargeSpores, effectPos, nullptr, nullptr);
 		STACK_PAD_VAR(1);
@@ -468,10 +468,10 @@ bool TaiKinokoDischargingSporesAction::act(Teki& teki)
 {
 	if (!teki.animationFinished()) {
 		if (teki.getAnimationKeyOption(BTeki::ANIMATION_KEY_OPTION_ACTION_0)) {
-			PRINT("TaiKinokoDischargingSporesAction:act:%08x:ACTION_0:\n", &teki);
+			PRINT_NAKATA("TaiKinokoDischargingSporesAction:act:%08x:ACTION_0:\n", &teki);
 			teki.flickUpper();
 		} else if (teki.getAnimationKeyOption(BTeki::ANIMATION_KEY_OPTION_ACTION_2)) {
-			PRINT("TaiKinokoDischargingSporesAction:act:%08x:ACTION_2:\n", &teki);
+			PRINT_NAKATA("TaiKinokoDischargingSporesAction:act:%08x:ACTION_2:\n", &teki);
 			InteractSpore& spore = InteractSpore(&teki);
 			TekiAndCondition andCond(&TekiRecognitionCondition(&teki), &TekiDistanceCondition(&teki, teki.getAttackRange()));
 			teki.interactNaviPiki(spore, andCond);

--- a/src/plugPikiNakata/taimessageactions.cpp
+++ b/src/plugPikiNakata/taimessageactions.cpp
@@ -24,7 +24,7 @@ DEFINE_PRINT("taimessageactions")
  */
 void TaiSendMessageAction::start(Teki& teki)
 {
-	PRINT("TaiSendMessageAction::start:%08x:type:%d,id:%d\n", &teki, teki.mTekiType, mMessage);
+	PRINT_NAKATA("TaiSendMessageAction::start:%08x:type:%d,id:%d\n", &teki, teki.mTekiType, mMessage);
 	teki.sendMessage(mMessage);
 }
 
@@ -36,7 +36,7 @@ void TaiSendMessageAction::start(Teki& teki)
 bool TaiKeySendMessageAction::act(Teki& teki)
 {
 	if (teki.getAnimationKeyOption(mAnimKeyOpt)) {
-		PRINT("TaiSendMessageAction::act:%08x:type:%d,id:%d\n", &teki, teki.mTekiType, mMessage);
+		PRINT_NAKATA("TaiSendMessageAction::act:%08x:type:%d,id:%d\n", &teki, teki.mTekiType, mMessage);
 		teki.sendMessage(mMessage);
 	}
 	return false;

--- a/src/plugPikiNakata/taimizinko.cpp
+++ b/src/plugPikiNakata/taimizinko.cpp
@@ -92,10 +92,10 @@ void TaiMizigenStrategy::start(Teki& teki)
  */
 void TaiMizigenGeneratingAction::start(Teki& teki)
 {
-	PRINT("TaiMizigenGeneratingAction::start:%08x\n", &teki);
+	PRINT_NAKATA("TaiMizigenGeneratingAction::start:%08x\n", &teki);
 	Teki* wisp = teki.generateTeki(teki.getParameterI(TPI_SpawnType));
 	if (!wisp) {
-		PRINT("TaiMizigenGeneratingAction::start:teki==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiMizigenGeneratingAction::start:teki==null:%08x\n", &teki);
 		return;
 	}
 
@@ -112,7 +112,7 @@ void TaiMizigenGeneratingAction::start(Teki& teki)
 	wisp->mTargetPosition.add2(teki.getPosition(), dir);
 	wisp->setPersonalityF(TekiPersonality::FLT_TerritoryRange, distance);
 	wisp->startAI(0);
-	PRINT("TaiMizigenGeneratingAction::start<%08x\n", &teki);
+	PRINT_NAKATA("TaiMizigenGeneratingAction::start<%08x\n", &teki);
 }
 
 /*
@@ -144,7 +144,7 @@ bool TaiMizigenNaviApprouchAction::act(Teki& teki)
 		return false;
 	}
 
-	PRINT("TaiMizigenNaviApprouchAction::act:%08x:%f,%f\n", &teki, naviDist, range);
+	PRINT_NAKATA("TaiMizigenNaviApprouchAction::act:%08x:%f,%f\n", &teki, naviDist, range);
 	return true;
 }
 
@@ -393,7 +393,7 @@ bool TaiMizinkoStrategy::hasWater(Teki& teki)
 bool TaiMizinkoCryTimerAction::act(Teki& teki)
 {
 	if (teki.timerElapsed(mTimerIdx)) {
-		PRINT("TaiMizinkoCryTimerAction::act:%08x,%f\n", &teki, teki.mTimers[mTimerIdx]);
+		PRINT_NAKATA("TaiMizinkoCryTimerAction::act:%08x,%f\n", &teki, teki.mTimers[mTimerIdx]);
 		teki.playSound(SE_KURIONE_FLYING);
 		resetTimer(teki);
 	}

--- a/src/plugPikiNakata/taimotionactions.cpp
+++ b/src/plugPikiNakata/taimotionactions.cpp
@@ -203,10 +203,10 @@ bool TaiStoppingMoveAction::act(Teki& teki)
 	int currMotionidx = teki.mTekiAnimator->getCurrentMotionIndex();
 	if (currMotionidx == mMotionIdx) {
 		if (teki.getAnimationKeyOption(BTeki::ANIMATION_KEY_OPTION_LOOPEND)) {
-			PRINT("TaiStoppingMoveAction::act:%08x:LOOPEND:%f,%f\n", &teki, teki.mAnimationSpeed, teki.mPreStopAnimationSpeed);
+			PRINT_NAKATA("TaiStoppingMoveAction::act:%08x:LOOPEND:%f,%f\n", &teki, teki.mAnimationSpeed, teki.mPreStopAnimationSpeed);
 			teki.startStoppingMove();
 		} else if (teki.animationFinished()) {
-			PRINT("TaiStoppingMoveAction::act:%08x:animationFinished\n", &teki);
+			PRINT_NAKATA("TaiStoppingMoveAction::act:%08x:animationFinished\n", &teki);
 			teki.finishStoppingMove();
 		}
 	}

--- a/src/plugPikiNakata/taimoveactions.cpp
+++ b/src/plugPikiNakata/taimoveactions.cpp
@@ -210,7 +210,7 @@ bool TaiClampMinVelocityYAction::act(Teki& teki)
 	NVector3f vel;
 	teki.mVelocityIO.output(vel);
 	if (vel.y < mMinVertSpeed) {
-		PRINT("TaiClampMinVelocityYAction::act:%08x:%f,%f\n", &teki, vel.y, mMinVertSpeed);
+		PRINT_NAKATA("TaiClampMinVelocityYAction::act:%08x:%f,%f\n", &teki, vel.y, mMinVertSpeed);
 		vel.y = mMinVertSpeed;
 		teki.mVelocityIO.input(vel);
 		return true;
@@ -245,7 +245,7 @@ bool TaiImpassableAction::act(Teki& teki)
 		return false;
 	}
 
-	PRINT("TaiImpassableAction::act:%08x:%f,%f,%f\n", &teki, distXZ, mMaxDistance, mTimerLength);
+	PRINT_NAKATA("TaiImpassableAction::act:%08x:%f,%f,%f\n", &teki, distXZ, mMaxDistance, mTimerLength);
 	return true;
 
 	STACK_PAD_VAR(2);
@@ -300,8 +300,8 @@ bool TaiRandomWanderingRouteAction::act(Teki& teki)
 	}
 
 	if (teki.mRouteWayPointCount > teki.mRouteWayPointMax && teki.mCurrRouteWayPointID > teki.mRouteWayPointMax - 1) {
-		PRINT("TaiRandomWanderingRouteAction::act:o.routeWayPointCount>o.routeWayPointMax:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID,
-		      teki.mRouteWayPointCount);
+		PRINT_NAKATA("TaiRandomWanderingRouteAction::act:o.routeWayPointCount>o.routeWayPointMax:%08x,%d/%d\n", &teki,
+		             teki.mCurrRouteWayPointID, teki.mRouteWayPointCount);
 		makeTargetPosition(teki);
 		return false;
 	}
@@ -326,7 +326,7 @@ bool TaiRandomWanderingRouteAction::act(Teki& teki)
 	}
 
 	if (teki.moveToward(wp->mPosition, mTargetPosition)) {
-		PRINT("TaiRandomWanderingRouteAction::act:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID, teki.mRouteWayPointCount);
+		PRINT_NAKATA("TaiRandomWanderingRouteAction::act:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID, teki.mRouteWayPointCount);
 		teki.mCurrRouteWayPointID++;
 	}
 	return false;
@@ -359,7 +359,7 @@ bool TaiTracingAction::act(Teki& teki)
 
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiTracingAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiTracingAction::act:target==null:%08x\n", &teki);
 		return false;
 	}
 
@@ -400,7 +400,7 @@ bool TaiDirectTurnAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiDirectTurnAction::start:target==null:%08x\n", &teki); // that's not what this function is, nakata.
+		PRINT_NAKATA("!TaiDirectTurnAction::start:target==null:%08x\n", &teki); // that's not what this function is, nakata.
 		return false;
 	}
 
@@ -422,13 +422,13 @@ bool TaiTurningAction::act(Teki& teki)
 
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiTurnAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiTurnAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
 	TekiRecognitionCondition recogCond(&teki);
 	if (!recogCond.satisfy(target)) {
-		PRINT("!TaiTurnAction::act:!condition.satisfy:%08x\n", &teki);
+		PRINT_NAKATA("!TaiTurnAction::act:!condition.satisfy:%08x\n", &teki);
 		return true;
 	}
 
@@ -455,13 +455,13 @@ bool TaiTurningAwayAction::act(Teki& teki)
 
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiTurningAwayAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiTurningAwayAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
 	TekiRecognitionCondition recogCond(&teki);
 	if (!recogCond.satisfy(target)) {
-		PRINT("!TaiTurningAwayAction::act:!condition.satisfy:%08x\n", &teki);
+		PRINT_NAKATA("!TaiTurningAwayAction::act:!condition.satisfy:%08x\n", &teki);
 		return true;
 	}
 
@@ -489,13 +489,13 @@ bool TaiTraceTurningAction::act(Teki& teki)
 
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiTraceTurnAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiTraceTurnAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
 	TekiRecognitionCondition recogCond(&teki);
 	if (!recogCond.satisfy(target)) {
-		PRINT("!TaiTraceTurnAction2::act:%08x\n", &teki);
+		PRINT_NAKATA("!TaiTraceTurnAction2::act:%08x\n", &teki);
 		return true;
 	}
 
@@ -521,7 +521,7 @@ bool TaiOutOfTraceAngleAction::act(Teki& teki)
 {
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
-		PRINT("!TaiOutOfTraceAngleAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiOutOfTraceAngleAction::act:target==null:%08x\n", &teki);
 		return false;
 	}
 

--- a/src/plugPikiNakata/tainapkid.cpp
+++ b/src/plugPikiNakata/tainapkid.cpp
@@ -687,7 +687,7 @@ bool TaiNapkidWanderingRouteAction::act(Teki& teki)
 	}
 
 	if (teki.moveToward(currWaypoint->mPosition, _0C)) {
-		PRINT("TaiNapkidWanderingRouteAction::act:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID, teki.mRouteWayPointCount);
+		PRINT_NAKATA("TaiNapkidWanderingRouteAction::act:%08x,%d/%d\n", &teki, teki.mCurrRouteWayPointID, teki.mRouteWayPointCount);
 		makeTargetPosition(teki);
 	}
 
@@ -709,8 +709,8 @@ void TaiNapkidWanderingRouteAction::makeTargetPosition(Teki& teki)
 	}
 
 	int randomIndex = NSystem::randomInt(currWaypoint->mLinkCount - 1);
-	PRINT("TaiNapkidWanderingRouteAction::makeTargetPosition::act:%08x,%d,%d,%d\n", &teki, teki.mCurrRouteWayPointID, randomIndex,
-	      currWaypoint->mLinkCount);
+	PRINT_NAKATA("TaiNapkidWanderingRouteAction::makeTargetPosition::act:%08x,%d,%d,%d\n", &teki, teki.mCurrRouteWayPointID, randomIndex,
+	             currWaypoint->mLinkCount);
 
 	int j;
 	int i = 0;
@@ -724,7 +724,7 @@ void TaiNapkidWanderingRouteAction::makeTargetPosition(Teki& teki)
 		}
 	}
 
-	PRINT("TaiNapkidWanderingRouteAction::makeTargetPosition::act:%08x:->%d\n", &teki, teki.mCurrRouteWayPointID);
+	PRINT_NAKATA("TaiNapkidWanderingRouteAction::makeTargetPosition::act:%08x:->%d\n", &teki, teki.mCurrRouteWayPointID);
 }
 
 /*
@@ -757,12 +757,12 @@ bool TaiNapkidPikiLostAction::act(Teki& teki)
 
 	Creature* targetCreature = teki.getCreaturePointer(0);
 	if (targetCreature == nullptr) {
-		PRINT("TaiNapkidPikiLostAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiNapkidPikiLostAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
 	if (!TekiNapkidTargetPikiCondition(&teki).satisfy(targetCreature)) {
-		PRINT("TaiNapkidPikiLostAction::act:!condition.satisfy:%08x\n", &teki);
+		PRINT_NAKATA("TaiNapkidPikiLostAction::act:!condition.satisfy:%08x\n", &teki);
 		teki.clearCreaturePointer(0);
 		return true;
 	}
@@ -782,12 +782,12 @@ bool TaiNapkidShortRangeAction::act(Teki& teki)
 {
 	Creature* targetCreature = teki.getCreaturePointer(0);
 	if (targetCreature == nullptr) {
-		PRINT("TaiNapkidShortRangeAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("TaiNapkidShortRangeAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
 	if (TekiNapkidShortRangeCondition(&teki).satisfy(targetCreature)) {
-		PRINT("TaiNapkidShortRangeAction::act:condition.satisfy:%08x\n", &teki);
+		PRINT_NAKATA("TaiNapkidShortRangeAction::act:condition.satisfy:%08x\n", &teki);
 		return true;
 	}
 
@@ -921,7 +921,7 @@ bool TaiNapkidCirclingAction::act(Teki& teki)
 	teki._3A4 = -NMathF::pi / 4.0f * NMathF::sin(angle);
 
 	if (teki.mCircleMoveEvent->isFinished()) {
-		PRINT("TaiNapkidCirclingAction::act:%08x\n", &teki);
+		PRINT_NAKATA("TaiNapkidCirclingAction::act:%08x\n", &teki);
 		return true;
 	}
 
@@ -960,7 +960,7 @@ bool TaiNapkidApproachPikiAction::act(Teki& teki)
 {
 	Creature* targetCreature = teki.getCreaturePointer(0);
 	if (targetCreature == nullptr) {
-		PRINT("!TaiNapkidApproachPikiAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiNapkidApproachPikiAction::act:target==null:%08x\n", &teki);
 		return false;
 	}
 
@@ -1211,7 +1211,7 @@ void TaiNapkidRisingAscendingAction::start(Teki& teki)
 bool TaiNapkidThrowingPikiAction::act(Teki& teki)
 {
 	if (teki.getAnimationKeyOption(Teki::ANIMATION_KEY_OPTION_ACTION_0)) {
-		PRINT("TaiNapkidThrowingPikiAction::act:%08x:ACTION_0\n", &teki);
+		PRINT_NAKATA("TaiNapkidThrowingPikiAction::act:%08x:ACTION_0\n", &teki);
 		NVector3f throwVel(teki.getVelocity());
 		throwVel.y = -teki.getParameterF(TaiNapkidFloatParms::ThrowVelocity);
 
@@ -1222,7 +1222,7 @@ bool TaiNapkidThrowingPikiAction::act(Teki& teki)
 			Creature* throwPiki = *iter;
 			if (throwPiki != nullptr) {
 				if (throwPiki->isStickToMouth()) {
-					PRINT("TaiNapkidThrowingPikiAction::act:%08x:endStickObject\n", &teki);
+					PRINT_NAKATA("TaiNapkidThrowingPikiAction::act:%08x:endStickObject\n", &teki);
 					throwPiki->endStickMouth();
 
 					throwPiki->stimulate(InteractThrowAway(&teki));
@@ -1237,7 +1237,7 @@ bool TaiNapkidThrowingPikiAction::act(Teki& teki)
 			}
 		}
 	}
-	PRINT("!TaiNapkidThrowingPikiAction::act:%08x\n", &teki);
+	PRINT_NAKATA("!TaiNapkidThrowingPikiAction::act:%08x\n", &teki);
 
 	STACK_PAD_TERNARY(&teki, 1);
 	return false;
@@ -1258,7 +1258,7 @@ bool TaiNapkidFlickAction::act(Teki& teki)
 	cLinearFunc.makeClampLinearFunction(1.0f, 0.1f, 5.0f, 0.7f);
 
 	f32 flickChance = cLinearFunc.getValue(f32(stickCount));
-	PRINT("TaiNapkidFlickAction::act:%08x:%f\n", &teki, flickChance);
+	PRINT_NAKATA("TaiNapkidFlickAction::act:%08x:%f\n", &teki, flickChance);
 	if (NMathF::occurred(flickChance)) {
 		return false;
 	}
@@ -1274,7 +1274,7 @@ bool TaiNapkidFlickAction::act(Teki& teki)
  */
 void TaiNapkidFallingAction::start(Teki& teki)
 {
-	PRINT("TaiNapkidFallingAction::start:%08x\n", &teki);
+	PRINT_NAKATA("TaiNapkidFallingAction::start:%08x\n", &teki);
 	teki.mPositionIO.input(NVector3f(teki.getPosition()));
 
 	NVector3f fallVel(0.0f, -20.0f, 0.0f);
@@ -1286,14 +1286,14 @@ void TaiNapkidFallingAction::start(Teki& teki)
 	CI_LOOP(iter)
 	{
 		Creature* heldPiki = *iter;
-		PRINT("TaiNapkidFallingAction::start:%08x:%08x\n", &teki, heldPiki);
+		PRINT_NAKATA("TaiNapkidFallingAction::start:%08x:%08x\n", &teki, heldPiki);
 		if (heldPiki == nullptr) {
 			PRINT("???TaiNapkidFallingAction::start:%08x:creature==null:%08x\n", &teki, nullptr);
 			return;
 		}
 
 		if (heldPiki != nullptr && heldPiki->isStickToMouth()) {
-			PRINT("TaiNapkidFallingAction::start:%08x:endStickObject:%08x\n", &teki, heldPiki);
+			PRINT_NAKATA("TaiNapkidFallingAction::start:%08x:endStickObject:%08x\n", &teki, heldPiki);
 			heldPiki->endStickMouth();
 			iter.dec();
 		}
@@ -1328,7 +1328,7 @@ void TaiNapkidShockFallingAction::start(Teki& teki)
 void TaiNapkidFallingWaterEffectAction::start(Teki& teki)
 {
 	int mapCode = teki.getPositionMapCode();
-	PRINT("TaiNapkidFallingWaterEffectAction::start:%08x:mapCode:%d\n", &teki, mapCode);
+	PRINT_NAKATA("TaiNapkidFallingWaterEffectAction::start:%08x:mapCode:%d\n", &teki, mapCode);
 
 	Vector3f pos(teki.getPosition());
 	f32 minY = mapMgr->getMinY(pos.x, pos.z, true);
@@ -1351,7 +1351,7 @@ void TaiNapkidFallingWaterEffectAction::start(Teki& teki)
 void TaiNapkidStartDroppingWaterAction::start(Teki& teki)
 {
 	int mapCode = teki.getPositionMapCode();
-	PRINT("TaiNapkidStartDroppingWaterAction::start:%08x:mapCode:%d\n", &teki, mapCode);
+	PRINT_NAKATA("TaiNapkidStartDroppingWaterAction::start:%08x:mapCode:%d\n", &teki, mapCode);
 
 	if (mapCode == ATTR_Water) {
 		teki.startParticleGenerator(0);

--- a/src/plugPikiNakata/taiotimoti.cpp
+++ b/src/plugPikiNakata/taiotimoti.cpp
@@ -566,7 +566,7 @@ void TaiOtimotiStrategy::drawDebugInfo(Teki& teki, Graphics& gfx)
 void TaiOtimotiStartDroppingWaterAction::start(Teki& teki)
 {
 	int attr = teki.getPositionMapCode();
-	PRINT("TaiOtimotiStartDroppingWaterAction::start:%08x:mapCode:%d\n", &teki, attr);
+	PRINT_NAKATA("TaiOtimotiStartDroppingWaterAction::start:%08x:mapCode:%d\n", &teki, attr);
 	if (attr == ATTR_Water) {
 		teki.startParticleGenerator(0);
 	} else {
@@ -585,7 +585,7 @@ bool TaiOtimotiFlickAction::act(Teki& teki)
 	int flickCount = teki.getFlickDamageCount(pikiNum);
 
 	if (teki.mDamageCount >= f32(flickCount)) {
-		PRINT("TaiOtimotiFlickAction::act:%08x:%d,%d,%d\n", &teki, pikiNum, teki.mDamageCount, flickCount);
+		PRINT_NAKATA("TaiOtimotiFlickAction::act:%08x:%d,%d,%d\n", &teki, pikiNum, teki.mDamageCount, flickCount);
 		teki.mTargetPosition.input(teki.getPosition());
 		teki.setCreaturePointer(0, nullptr);
 		return true;
@@ -610,7 +610,7 @@ bool TaiOtimotiFailToJumpAction::act(Teki& teki)
 	linFunc.makeClampLinearFunction(teki.getParameterF(OTIMOTIPF_MissFuncMinCount), teki.getParameterF(OTIMOTIPF_MissFuncMinChance),
 	                                teki.getParameterF(OTIMOTIPF_MissFuncMaxCount), teki.getParameterF(OTIMOTIPF_MissFuncMaxChance));
 	f32 failChance = linFunc.getValue(f32(pikiNum));
-	PRINT("TaiOtimotiFailToJumpAction::act:%08x:%f,%d\n", &teki, failChance, pikiNum);
+	PRINT_NAKATA("TaiOtimotiFailToJumpAction::act:%08x:%f,%d\n", &teki, failChance, pikiNum);
 	if (NMathF::occurred(failChance)) {
 		return true;
 	}
@@ -734,12 +734,12 @@ bool TaiOtimotiAirWaitingAction::act(Teki& teki)
 	}
 
 	if (teki.getAnimationKeyOption(BTeki::ANIMATION_KEY_OPTION_ACTION_0)) {
-		PRINT("TaiOtimotiAirWaiting::act:%08x:ACTION_0\n", &teki);
+		PRINT_NAKATA("TaiOtimotiAirWaiting::act:%08x:ACTION_0\n", &teki);
 		teki.stopParticleGenerator(0);
 		teki.stopParticleGenerator(1);
 
 	} else if (teki.getAnimationKeyOption(BTeki::ANIMATION_KEY_OPTION_LOOPEND)) {
-		PRINT("TaiOtimotiAirWaiting::act:%08x:LOOPEND\n", &teki);
+		PRINT_NAKATA("TaiOtimotiAirWaiting::act:%08x:LOOPEND\n", &teki);
 		return true;
 	}
 	return false;
@@ -780,7 +780,7 @@ bool TaiOtimotiDroppingAction::act(Teki& teki)
 bool TaiOtimotiDroppingAction::actByEvent(TekiEvent& event)
 {
 	if (event.mEventType == TekiEventType::Ground) {
-		PRINT("!TaiOtimotiDroppingAction::actByEvent:EVENT_BOUNCED:%08x\n", event.mTeki);
+		PRINT_NAKATA("!TaiOtimotiDroppingAction::actByEvent:EVENT_BOUNCED:%08x\n", event.mTeki);
 		event.mTeki->finishFlying();
 		event.mTeki->clearTekiOption(BTeki::TEKI_OPTION_GRAVITATABLE);
 	}
@@ -895,7 +895,7 @@ bool TaiOtimotiAttackingAction::act(Teki& teki)
 	f32 unused = teki.mTekiAnimator->getCounter();
 
 	if (teki.mTekiAnimator->isFinished()) {
-		PRINT("!TaiOtimotiAttackingAction::act:%08x:FINISHED\n", &teki);
+		PRINT_NAKATA("!TaiOtimotiAttackingAction::act:%08x:FINISHED\n", &teki);
 		return true;
 	}
 
@@ -920,7 +920,7 @@ bool TaiOtimotiAttackingAction::actByEvent(TekiEvent&)
 void TaiOtimotiAttackingEffectAction::start(Teki& teki)
 {
 	int attr = teki.getPositionMapCode();
-	PRINT("TaiOtimotiAttackingEffectAction::start:%08x:mapCode:%d\n", &teki, attr);
+	PRINT_NAKATA("TaiOtimotiAttackingEffectAction::start:%08x:mapCode:%d\n", &teki, attr);
 	Vector3f pos(teki.getPosition());
 	pos.y = mapMgr->getMinY(pos.x, pos.z, true);
 	if (attr == ATTR_Water) {

--- a/src/plugPikiNakata/taipalm.cpp
+++ b/src/plugPikiNakata/taipalm.cpp
@@ -161,10 +161,10 @@ void TaiPalmStrategy::start(Teki& teki)
 	TekiAndCondition& cond = TekiAndCondition(&TekiNotCondition(&TekiCreaturePointerCondition(&teki)),
 	                                          &TekiAndCondition(&TekiTypeCondition(teki.mTekiType), &TekiDistanceCondition(&teki, rad)));
 	Creature* neighbor     = tekiMgr->findClosest(teki.getPosition(), &cond);
-	PRINT("TaiPalmStrategy::start:%08x:neighbor:%08x\n", &teki, neighbor);
+	PRINT_NAKATA("TaiPalmStrategy::start:%08x:neighbor:%08x\n", &teki, neighbor);
 
 	if (neighbor) {
-		PRINT("TaiPalmStrategy::start:%08x:neighbor!=null:%08x\n", &teki, neighbor);
+		PRINT_NAKATA("TaiPalmStrategy::start:%08x:neighbor!=null:%08x\n", &teki, neighbor);
 		NVector3f::printlnVector3f(teki.getPosition());
 		NVector3f vec1;
 		vec1.sub(teki.getPosition(), neighbor->getPosition());
@@ -207,7 +207,7 @@ void TaiPalmStrategy::draw(Teki& teki, Graphics& gfx)
  */
 void TaiPalmStrategy::createEffect(Teki& teki, int palmEffectID)
 {
-	PRINT("TaiPalmStrategy::createEffect:%08x:%d\n", &teki, palmEffectID);
+	PRINT_NAKATA("TaiPalmStrategy::createEffect:%08x:%d\n", &teki, palmEffectID);
 	TekiStrategy::createEffect(teki, palmEffectID);
 	if (!effectMgr) {
 		return;
@@ -292,7 +292,7 @@ void TaiPalmMotionAction::start(Teki& teki)
 	TaiPalmStrategy* strat = (TaiPalmStrategy*)teki.getStrategy();
 	int motionIdx          = strat->translateMotionIndex(teki, mMotionIdx);
 	teki.startMotion(motionIdx);
-	PRINT("TaiPalmMotionAction::start:%08x:%d->%d\n", &teki, mMotionIdx, motionIdx);
+	PRINT_NAKATA("TaiPalmMotionAction::start:%08x:%d->%d\n", &teki, mMotionIdx, motionIdx);
 }
 
 /*
@@ -335,7 +335,7 @@ void TaiPalmDamagingAction::start(Teki& teki)
 	TaiPalmStrategy* strat = (TaiPalmStrategy*)teki.getStrategy();
 	int motionIdx          = strat->translateMotionIndex(teki, mMotionIdx);
 	teki.startMotion(motionIdx);
-	PRINT("TaiPalmDamagingAction::start:%08x:%d->%d\n", &teki, mMotionIdx, motionIdx);
+	PRINT_NAKATA("TaiPalmDamagingAction::start:%08x:%d->%d\n", &teki, mMotionIdx, motionIdx);
 	teki.makeDamaged();
 }
 
@@ -349,7 +349,7 @@ void TaiPalmGrowingAction::start(Teki& teki)
 	int size = teki.getPersonalityF(TekiPersonality::FLT_Strength);
 	size++;
 	teki.setPersonalityF(TekiPersonality::FLT_Strength, size);
-	PRINT("TaiPalmGrowingAction::start:%08x:%d\n", &teki, size);
+	PRINT_NAKATA("TaiPalmGrowingAction::start:%08x:%d\n", &teki, size);
 }
 
 /*
@@ -382,7 +382,7 @@ bool TaiPalmFlowerDamageAction::act(Teki& teki)
 		return false;
 	}
 	if (teki._344 == 0) {
-		PRINT("TaiPalmFlowerDamageAction::act:%08x:DMG_0\n", &teki);
+		PRINT_NAKATA("TaiPalmFlowerDamageAction::act:%08x:DMG_0\n", &teki);
 		return true;
 	}
 

--- a/src/plugPikiNakata/taireactionactions.cpp
+++ b/src/plugPikiNakata/taireactionactions.cpp
@@ -291,7 +291,7 @@ bool TaiSmashedAction::actByEvent(TekiEvent& event)
 		Teki* teki      = event.mTeki;
 		Creature* other = event.mOther;
 		if (other->mObjType == OBJTYPE_Piki && static_cast<Piki*>(other)->getState() == PIKISTATE_Flying) {
-			PRINT("TaiSmashedAction::actByEvent:FLYING:%08x\n", teki);
+			PRINT_NAKATA("TaiSmashedAction::actByEvent:FLYING:%08x\n", &teki);
 			return true;
 		}
 	}
@@ -318,7 +318,7 @@ void TaiBeingPressedAction::start(Teki& teki)
 bool TaiPressedAction::actByEvent(TekiEvent& event)
 {
 	if (event.mEventType == TekiEventType::Pressed) {
-		PRINT("TaiPressedAction::actByEvent:EVENT_PRESSED:%08x\n", event.mTeki);
+		PRINT_NAKATA("TaiPressedAction::actByEvent:EVENT_PRESSED:%08x\n", event.mTeki);
 		return true;
 	}
 

--- a/src/plugPikiNakata/taishell.cpp
+++ b/src/plugPikiNakata/taishell.cpp
@@ -175,7 +175,7 @@ void TaiShellStrategy::start(Teki& teki)
 	if (hasPart == TRUE) {
 		ID32& id = teki.mPersonality->mID;
 		if (playerState->existUfoParts(id.mId)) {
-			PRINT("!!!TaiShellStrategy::start:%08x:%s already exists\n", teki, id.mStringID);
+			PRINT("!!!TaiShellStrategy::start:%08x:%s already exists\n", &teki, id.mStringID);
 			teki.mPersonality->mID.setID('none');
 		} else {
 			type = TEKI_Rocpe;
@@ -185,14 +185,14 @@ void TaiShellStrategy::start(Teki& teki)
 	Teki* pearl = teki.generateTeki(type);
 
 	if (!pearl) {
-		PRINT("!TaiShellStrategy::start:teki==null:%08x\n", teki);
+		PRINT("!TaiShellStrategy::start:teki==null:%08x\n", &teki);
 		return;
 	}
 
 	NVector3f spawnPos;
 	teki.outputSpawnPosition(spawnPos);
 	ID32& id = teki.mPersonality->mID;
-	PRINT("TaiShellStrategy:%08x:%d,%s\n", this, type, id.mStringID);
+	PRINT_NAKATA("TaiShellStrategy:%08x:%d,%s\n", this, type, id.mStringID);
 	pearl->mPersonality->mID.setID(id.mId);
 	pearl->startAI(0); // unused, will go to default state (PEARLSTATE_Normal)
 
@@ -201,9 +201,6 @@ void TaiShellStrategy::start(Teki& teki)
 	teki.setCreaturePointer(2, pearl);
 	pearl->setCreaturePointer(0, &teki);
 	teki.mPersonality->mID.setID('none');
-
-	// Just for stack.
-	STACK_PAD_TERNARY(pearl, 5);
 }
 
 /*
@@ -273,7 +270,7 @@ bool TaiShellSaveItemPositionAction::act(Teki& teki)
 	Pellet* item = static_cast<Teki*>(teki.getCreaturePointer(2))->mPellet;
 
 	if (!item) {
-		PRINT("TaiShellSaveItemPositionAction::act:item==null:%08x\n", teki);
+		PRINT_NAKATA("TaiShellSaveItemPositionAction::act:item==null:%08x\n", &teki);
 		return false;
 	}
 
@@ -281,15 +278,13 @@ bool TaiShellSaveItemPositionAction::act(Teki& teki)
 	teki.outputSpawnPosition(savePos);
 	f32 dist = savePos.distanceXZ(item->getPosition());
 	if (dist >= teki.getAttackableRange()) {
-		PRINT("TaiShellResetPearlAction::resetPearl:%08x:outside:%f,%f\n", teki, dist, teki.getAttackableRange());
+		PRINT_NAKATA("TaiShellResetPearlAction::resetPearl:%08x:outside:%f,%f\n", &teki, dist, teki.getAttackableRange());
 		return false;
 	}
 
-	PRINT("TaiShellResetPearlAction::resetPearl:%08x:inside:%f,%f\n", teki, dist, teki.getAttackableRange());
+	PRINT_NAKATA("TaiShellResetPearlAction::resetPearl:%08x:inside:%f,%f\n", &teki, dist, teki.getAttackableRange());
 	setPosition(teki, item);
 	return false;
-
-	STACK_PAD_VAR(6);
 }
 
 /*
@@ -486,8 +481,6 @@ void TaiPearlTresureSoundAction::start(Teki& teki)
 		clam->playSound(SE_SHELL_TRESURE);
 		clam->playSound(SE_KURIONE_HIT);
 	} else {
-		PRINT("TaiPearlTresureSoundAction::start:creature==null:%08x\n", teki);
+		PRINT_NAKATA("TaiPearlTresureSoundAction::start:creature==null:%08x\n", &teki);
 	}
-
-	STACK_PAD_VAR(2);
 }

--- a/src/plugPikiNakata/taiswallow.cpp
+++ b/src/plugPikiNakata/taiswallow.cpp
@@ -531,10 +531,10 @@ bool TaiSwallowStrategy::interact(Teki& teki, TekiInteractionKey& key)
 		if (teki.getTekiOption(BTeki::TEKI_OPTION_DAMAGE_COUNTABLE)) {
 			if (attack->getDamagePortion() != 1) {
 				attack->mDamage *= teki.getParameterF(SWALLOWPF_LowerDamageRate);
-				PRINT("TaiSwallowStrategy::interact:%08x:!PART_UPPER\n", &teki);
+				PRINT_NAKATA("TaiSwallowStrategy::interact:%08x:!PART_UPPER\n", &teki);
 				teki.mDamageCount += teki.getParameterF(SWALLOWPF_LowerDamageCountRate);
 			} else {
-				PRINT("TaiSwallowStrategy::interact:%08x:PART_UPPER\n", &teki);
+				PRINT_NAKATA("TaiSwallowStrategy::interact:%08x:PART_UPPER\n", &teki);
 				teki.mDamageCount++;
 			}
 		}
@@ -577,7 +577,7 @@ void TaiSwallowStrategy::drawDebugInfo(Teki& teki, Graphics& gfx)
 bool TaiSwallowReceiveMessageAction::actByEvent(TekiEvent& event)
 {
 	if (event.mEventType == TekiEventType::WakeUpCall) {
-		PRINT("TaiSwallowReceiveMessageAction::act:%08x\n", event.mTeki);
+		PRINT_NAKATA("TaiSwallowReceiveMessageAction::act:%08x\n", event.mTeki);
 		return true;
 	}
 
@@ -599,13 +599,13 @@ bool TaiSwallowTurningAction::act(Teki& teki)
 	Creature* target = teki.getCreaturePointer(0);
 	if (!target) {
 		// Looks like someone was copying and pasting code lol (me too buddy, me too)
-		PRINT("!TaiTurnAction::act:target==null:%08x\n", &teki);
+		PRINT_NAKATA("!TaiTurnAction::act:target==null:%08x\n", &teki);
 		return true;
 	}
 
 	TekiRecognitionCondition recogCond(&teki);
 	if (!recogCond.satisfy(target)) {
-		PRINT("!TaiTurnAction::act:!condition.satisfy:%08x\n", &teki); // And again
+		PRINT_NAKATA("!TaiTurnAction::act:!condition.satisfy:%08x\n", &teki); // And again
 		return true;
 	}
 
@@ -617,7 +617,7 @@ bool TaiSwallowTurningAction::act(Teki& teki)
 	                                teki.getParameterF(SWALLOWPF_TurnVelocityFuncMaxRate));
 
 	f32 factor = linFunc.getValue(f32(pikiCount));
-	PRINT("TaiSwallowTurningAction::act:%08x:%f,%d\n", &teki, factor, pikiCount);
+	PRINT_NAKATA("TaiSwallowTurningAction::act:%08x:%f,%d\n", &teki, factor, pikiCount);
 	f32 speed         = mTurnSpeed * factor;
 	teki.mTargetAngle = teki.calcTargetDirection(target->getPosition());
 	return teki.turnToward(teki.mTargetAngle, speed);
@@ -720,7 +720,7 @@ bool TaiSwallowSwallowingFlickAction::act(Teki& teki)
  */
 void TaiSwallowSnoreAction::start(Teki& teki)
 {
-	PRINT("TaiSwallowSnoreAction::start:%08x\n", &teki);
+	PRINT_NAKATA("TaiSwallowSnoreAction::start:%08x\n", &teki);
 	teki.startParticleGenerator(0);
 }
 
@@ -731,7 +731,7 @@ void TaiSwallowSnoreAction::start(Teki& teki)
  */
 void TaiSwallowSnoreAction::finish(Teki& teki)
 {
-	PRINT("TaiSwallowSnoreAction::finish:%08x\n", &teki);
+	PRINT_NAKATA("TaiSwallowSnoreAction::finish:%08x\n", &teki);
 	teki.stopParticleGenerator(0);
 }
 
@@ -747,7 +747,7 @@ bool TaiSwallowNoticeAction::act(Teki& teki)
 		return false;
 	}
 
-	PRINT("TaiSwallowNoticeAction::act:%08x\n", &teki);
+	PRINT_NAKATA("TaiSwallowNoticeAction::act:%08x\n", &teki);
 	teki.setCreaturePointer(0, naviPiki);
 	return true;
 

--- a/src/plugPikiNakata/tekibteki.cpp
+++ b/src/plugPikiNakata/tekibteki.cpp
@@ -163,7 +163,7 @@ void BTeki::viewKill()
 void BTeki::doStore(CreatureInf* info)
 {
 	info->mObjInfo1 = mTekiType;
-	PRINT("TEKI STORE *****************************************\n");
+	PRINT_NAKATA("TEKI STORE *****************************************\n");
 }
 
 /*
@@ -186,7 +186,7 @@ TekiShapeObject::TekiShapeObject(Shape* shape)
 	mShape               = shape;
 	mShape->mFrameCacher = nullptr;
 	mAnimMgr             = new AnimMgr(shape, nullptr, ANIMMGR_LOAD_BUNDLE, nullptr);
-	PRINT("OVERRIDING ANIM with %08x\n", &mAnimContext);
+	PRINT_NAKATA("OVERRIDING ANIM with %08x\n", &mAnimContext);
 	mShape->overrideAnim(0, &mAnimContext);
 }
 
@@ -295,7 +295,7 @@ BTeki::BTeki()
  */
 void BTeki::init(int tekiType)
 {
-	PRINT("Teki::init:%08x:%d\n", this, tekiType);
+	PRINT_NAKATA("Teki::init:%08x:%d\n", this, tekiType);
 	mTekiType   = (TekiTypes)tekiType;
 	mTekiParams = tekiMgr->getTekiParameters(mTekiType);
 	mSearchBuffer.init(mTekiSearchData, 3);
@@ -310,7 +310,7 @@ void BTeki::init(int tekiType)
  */
 void BTeki::reset()
 {
-	PRINT("Teki::reset>:%08x\n", this);
+	PRINT_NAKATA("Teki::reset>:%08x\n", this);
 	if (tekiOptUpdateMgr) {
 		mOptUpdateContext.init(tekiOptUpdateMgr);
 	}
@@ -396,7 +396,7 @@ void BTeki::reset()
 	prepareEffects();
 	stopMove();
 
-	PRINT("NNNNNreset:%08x:%d:%s:%f\n", this, mTekiType, TekiMgr::getTypeName(mTekiType), getCentreSize());
+	PRINT_NAKATA("NNNNNreset:%08x:%d:%s:%f\n", this, mTekiType, TekiMgr::getTypeName(mTekiType), getCentreSize());
 }
 
 /*
@@ -460,7 +460,7 @@ void BTeki::startAI(int)
 	}
 	strat->start(*static_cast<Teki*>(this));
 	ID32& id = mPersonality->mID;
-	PRINT("BTeki::reset:%08x:item:%s\n", this, id.mStringID);
+	PRINT_NAKATA("BTeki::reset:%08x:item:%s\n", this, id.mStringID);
 	if (Pellet::isUfoPartsID(id.mId)) {
 		radarInfo->attachParts(this);
 		pelletMgr->addUseList(id.mId);
@@ -533,7 +533,7 @@ void BTeki::startMotion(int motionID)
  */
 void BTeki::startStoppingMove()
 {
-	PRINT("startStoppingMove:%08x:%f,%f\n", this, mAnimationSpeed, mPreStopAnimationSpeed);
+	PRINT_NAKATA("startStoppingMove:%08x:%f,%f\n", this, mAnimationSpeed, mPreStopAnimationSpeed);
 	stopMove();
 	setTekiOption(TEKIOPT_StoppingMove);
 	mPreStopAnimationSpeed = mAnimationSpeed;
@@ -546,7 +546,7 @@ void BTeki::startStoppingMove()
  */
 void BTeki::finishStoppingMove()
 {
-	PRINT("finishStoppingMove:%08x:%f,%f\n", this, mAnimationSpeed, mPreStopAnimationSpeed);
+	PRINT_NAKATA("finishStoppingMove:%08x:%f,%f\n", this, mAnimationSpeed, mPreStopAnimationSpeed);
 	clearTekiOption(TEKIOPT_StoppingMove);
 }
 
@@ -656,25 +656,25 @@ void BTeki::die()
  */
 void BTeki::dieSoon()
 {
-	PRINT("dieSoon:%08x:\n", this);
+	PRINT_NAKATA("dieSoon:%08x:\n", this);
 	clearTekiOption(TEKIOPT_Alive | TEKIOPT_Visible | TEKIOPT_ShadowVisible | TEKIOPT_Atari);
 	if (getParameterI(TPI_CorpseType) == TEKICORPSE_LeaveCorpse) {
 		createSoulEffect();
 		u32 typeID = TekiMgr::getTypeId(mTekiType);
 		ID32 id(typeID);
-		PRINT("dieSoon:%08x:%d,%s\n", this, mTekiType, id.mStringID);
+		PRINT_NAKATA("dieSoon:%08x:%d,%s\n", this, mTekiType, id.mStringID);
 
 		NVector3f vec1;
 		CollPart* carcass = mCollInfo->getSphere('carc');
 		if (!carcass) {
 			vec1.set(getCentre());
 		} else {
-			PRINT("dieSoon:%08x:'carc'\n", this);
+			PRINT_NAKATA("dieSoon:%08x:'carc'\n", this);
 			vec1.set(carcass->mCentre);
 		}
 
 		becomePellet(typeID, vec1, getDirection());
-		PRINT("dieSoon:%08x:pellet:%08x\n", this, mPellet);
+		PRINT_NAKATA("dieSoon:%08x:pellet:%08x\n", this, mPellet);
 		if (!mPellet) {
 			ERROR("?dieSoon:%08x:pellet==null:abusan\n", this);
 			return;
@@ -708,7 +708,7 @@ void BTeki::dieSoon()
  */
 void BTeki::becomeCorpse()
 {
-	PRINT("BTeki::becomeCorpse:%08x\n", this);
+	PRINT_NAKATA("BTeki::becomeCorpse:%08x\n", this);
 	for (int i = 0; i < 4; i++) {
 		if (mParticleGenerators[i]) {
 			mParticleGenerators[i]->finish();
@@ -725,7 +725,7 @@ void BTeki::becomeCorpse()
  */
 void BTeki::doKill()
 {
-	PRINT("BTeki::doKill:%08x\n", this);
+	PRINT_NAKATA("BTeki::doKill:%08x\n", this);
 	if (tekiOptUpdateMgr) {
 		mOptUpdateContext.exit();
 	}
@@ -752,7 +752,7 @@ void BTeki::doKill()
  */
 void BTeki::exitCourse()
 {
-	PRINT("BTeki::exitCourse:%08x\n", this);
+	PRINT_NAKATA("BTeki::exitCourse:%08x\n", this);
 	for (int i = 0; i < 4; i++) {
 		if (mParticleGenerators[i]) {
 			mParticleGenerators[i]->forceFinish();
@@ -872,7 +872,7 @@ void BTeki::startDamageMotion(f32 period, f32 amp)
  */
 void BTeki::releasePlatCollisions()
 {
-	PRINT("releasePlatCollisions:%08x:\n", this);
+	PRINT_NAKATA("releasePlatCollisions:%08x:\n", this);
 	mPlatMgr.release();
 }
 
@@ -934,7 +934,7 @@ void BTeki::spawnItems()
 	// spawn item
 	ID32& id = mPersonality->mID;
 	if (!id.match('none')) {
-		PRINT("spawnItems:%08x:spawn item:%s\n", this, id.mStringID);
+		PRINT_NAKATA("spawnItems:%08x:spawn item:%s\n", this, id.mStringID);
 		spawnPellets(id.mId, -2, 1);
 		radarInfo->detachParts(this);
 		detachGenerator();
@@ -961,7 +961,7 @@ void BTeki::spawnItems()
 		int min       = getPersonalityI(TekiPersonality::INT_NectarMinCount);
 		int max       = getPersonalityI(TekiPersonality::INT_NectarMaxCount);
 		int nectarNum = NMathI::rangeRandom(min, max);
-		PRINT("spawnItems:spawnWaters:%08x:%d,%d,%d\n", this, min, max, nectarNum);
+		PRINT_NAKATA("spawnItems:spawnWaters:%08x:%d,%d,%d\n", this, min, max, nectarNum);
 		spawnWaters(nectarNum);
 	}
 }
@@ -973,7 +973,7 @@ void BTeki::spawnItems()
  */
 void BTeki::spawnPellets(int kind, int color, int count)
 {
-	PRINT("spawnPellets:%08x:%d,%d,%d\n", this, kind, color, count);
+	PRINT_NAKATA("spawnPellets:%08x:%d,%d,%d\n", this, kind, color, count);
 	Vector3f spawnPos   = getCentre();
 	f32 spawnSpeedVert  = getParameterF(TPF_SpawnPelletVelocityVert);
 	f32 spawnSpeedHoriz = getParameterF(TPF_SpawnPelletVelocityHoriz);
@@ -1031,7 +1031,7 @@ void BTeki::spawnPellets(int kind, int color, int count)
  */
 void BTeki::spawnWaters(int count)
 {
-	PRINT("spawnWaters:%08x:%d\n", this, count);
+	PRINT_NAKATA("spawnWaters:%08x:%d\n", this, count);
 	Vector3f spawnPos   = getCentre();
 	f32 spawnSpeedVert  = getParameterF(TPF_SpawnPelletVelocityVert);
 	f32 spawnSpeedHoriz = getParameterF(TPF_SpawnPelletVelocityHoriz);
@@ -1321,7 +1321,7 @@ bool BTeki::separateCreature(Creature& target)
 
 	f32 collDist = calcCollisionDistance(target);
 	if (collDist > range) {
-		PRINT("separateCreature1:%08x:%08x:%f,%f\n", this, &target, range, collDist);
+		PRINT_NAKATA("separateCreature1:%08x:%08x:%f,%f\n", this, &target, range, collDist);
 		return true;
 	}
 
@@ -1972,7 +1972,7 @@ void BTeki::makeWayPointRoute(int p1, int p2, bool includeBlockedPaths)
 		PRINT("!makeWayPointRoute:routeWayPointCount>routeWayPointMax:%08x:%d,%d\n", this, mRouteWayPointCount, mTekiType);
 	}
 
-	PRINT("makeWayPointRoute:%08x,%d->%d,%d\n", this, p1, p2, mRouteWayPointCount);
+	PRINT_NAKATA("makeWayPointRoute:%08x,%d->%d,%d\n", this, p1, p2, mRouteWayPointCount);
 	if (mRouteWayPointCount == 0) {
 		PRINT("!makeWayPointRoute:%08x,%d->%d,%d\n", this, p1, p2, mRouteWayPointCount);
 	}
@@ -2311,7 +2311,7 @@ void BTeki::stopSound(int soundID)
  */
 void BTeki::createTekiEffect(int effectID)
 {
-	PRINT("createTekiEffect:%08x,%d:%d\n", this, mTekiType, effectID);
+	PRINT_NAKATA("createTekiEffect:%08x,%d:%d\n", this, mTekiType, effectID);
 	TekiStrategy* strategy = tekiMgr->getStrategy(mTekiType);
 	strategy->createEffect(*(Teki*)this, effectID);
 }

--- a/src/plugPikiNakata/tekimgr.cpp
+++ b/src/plugPikiNakata/tekimgr.cpp
@@ -126,7 +126,7 @@ int TekiMgr::getTypeIndex(char* typeName)
 			return i;
 		}
 	}
-	PRINT("!getType:%s\n", typeName);
+	PRINT_NAKATA("!getType:%s\n", typeName);
 	return -1;
 }
 
@@ -137,7 +137,7 @@ int TekiMgr::getTypeIndex(char* typeName)
  */
 TekiMgr::TekiMgr()
 {
-	PRINT("TekiMgr>\n");
+	PRINT_NAKATA("TekiMgr>\n");
 	memStat->start("tekiMgr");
 	int heapStartSize = NSystem::getFreeHeap();
 	mTekiAnimMgr      = new TekiAnimationManager(this);
@@ -158,7 +158,7 @@ TekiMgr::TekiMgr()
 		if (hasType(i)) {
 			char buf[128];
 			sprintf(buf, "tekipara/%s.bin", typeNames[i]);
-			PRINT("TekiMgr:fileName:%d:%s\n", i, buf);
+			PRINT_NAKATA("TekiMgr:fileName:%d:%s\n", i, buf);
 			mTekiParams[i]->load("", buf, 1);
 		}
 	}
@@ -177,7 +177,7 @@ TekiMgr::TekiMgr()
 	int tekiHeapEndSize = NSystem::getFreeHeap();
 	PRINT("TekiMgr:manager uses %.2f[KB],%d tekis use %.2f[KB]\n", (heapStartSize - heapEndSize) / 1024.0f, 80,
 	      (tekisHeapStartSize - tekiHeapEndSize) / 1024.0f);
-	PRINT("TekiMgr<\n");
+	PRINT_NAKATA("TekiMgr<\n");
 }
 
 /*
@@ -189,7 +189,7 @@ void TekiMgr::startStage()
 {
 	char filename[128];
 	char buf[128];
-	PRINT("startStage>\n");
+	PRINT_NAKATA("startStage>\n");
 	TekiNakata::makeTekis(this);
 	TekiYamashita::makeTekis(this);
 
@@ -202,7 +202,7 @@ void TekiMgr::startStage()
 			sprintf(buf, "%s model data", typeNames[i]);
 			int tekiHeapStartSize = NSystem::getFreeHeap();
 			sprintf(filename, "tekis/%s/%s.mod", typeNames[i], typeNames[i]);
-			PRINT("startStage:fileName:%d:%s\n", i, filename);
+			PRINT_NAKATA("startStage:fileName:%d:%s\n", i, filename);
 			mTekiShapes[i]       = new TekiShapeObject(gameflow.loadShape(filename, true));
 			int modelHeapEndSize = NSystem::getFreeHeap();
 
@@ -210,7 +210,7 @@ void TekiMgr::startStage()
 			int animHeapStartSize = NSystem::getFreeHeap();
 			sprintf(filename, "tekikeys/%s.key", typeNames[i]);
 			mTekiShapes[i]->mAnimMgr->loadAnims(filename, nullptr);
-			PRINT("startStage:%d:%d\n", i, mTekiShapes[i]->mAnimMgr->countAnims());
+			PRINT_NAKATA("startStage:%d:%d\n", i, mTekiShapes[i]->mAnimMgr->countAnims());
 			memStat->end(typeNames[i]);
 			int tekiHeapEndSize = NSystem::getFreeHeap();
 			add(mTekiShapes[i]->mAnimMgr);
@@ -222,7 +222,7 @@ void TekiMgr::startStage()
 	memStat->end("teki data");
 	NSystem::getFreeHeap();
 	reset();
-	PRINT("startStage<\n");
+	PRINT_NAKATA("startStage<\n");
 }
 
 /*
@@ -284,7 +284,7 @@ Teki* TekiMgr::newTeki(int type)
  */
 void TekiMgr::reset()
 {
-	PRINT("reset>\n");
+	PRINT_NAKATA("reset>\n");
 	Iterator iter(this);
 	CI_LOOP(iter)
 	{
@@ -292,7 +292,7 @@ void TekiMgr::reset()
 		teki->reset();
 	}
 
-	PRINT("reset<\n");
+	PRINT_NAKATA("reset<\n");
 }
 
 /*

--- a/src/plugPikiNakata/tekinteki.cpp
+++ b/src/plugPikiNakata/tekinteki.cpp
@@ -49,7 +49,7 @@ NTeki::NTeki()
  */
 void NTeki::sendMessage(int msg)
 {
-	PRINT("sendMessage:%08x:%d\n", this, msg);
+	PRINT_NAKATA("sendMessage:%08x:%d\n", this, msg);
 	Iterator iter(tekiMgr);
 	CI_LOOP(iter)
 	{

--- a/src/plugPikiNakata/tekiparameters.cpp
+++ b/src/plugPikiNakata/tekiparameters.cpp
@@ -206,7 +206,7 @@ void TekiParameters::read(RandomAccessStream& input)
 #if 0
 void TekiParameters::write(RandomAccessStream& output)
 {
-	PRINT("TekiParameters::write>\n");
+	PRINT_NAKATA("TekiParameters::write>\n");
 
 	output.writeInt(11);
 	for (int i = 0; i < 8; i++) {
@@ -214,6 +214,6 @@ void TekiParameters::write(RandomAccessStream& output)
 	}
 	mParameters->write(output);
 
-	PRINT("TekiParameters::write<\n");
+	PRINT_NAKATA("TekiParameters::write<\n");
 }
 #endif

--- a/src/plugPikiNakata/tekipersonality.cpp
+++ b/src/plugPikiNakata/tekipersonality.cpp
@@ -98,7 +98,7 @@ void TekiPersonality::input(TekiPersonality& other)
  */
 void TekiPersonality::read(RandomAccessStream& input, int version)
 {
-	PRINT("TekiPersonality::read:%d\n", version);
+	PRINT_NAKATA("TekiPersonality::read:%d\n", version);
 
 	ParaMultiParameters* params = mParams;
 
@@ -159,7 +159,7 @@ void TekiPersonality::read(RandomAccessStream& input, int version)
 	mPelletColor = (s8)input.readByte();
 	mID.read(input);
 	params->read(input);
-	PRINT("TekiPersonality::read:pelletColor:%d\n", mPelletColor);
+	PRINT_NAKATA("TekiPersonality::read:pelletColor:%d\n", mPelletColor);
 }
 
 /*
@@ -169,19 +169,19 @@ void TekiPersonality::read(RandomAccessStream& input, int version)
  */
 void TekiPersonality::write(RandomAccessStream& output)
 {
-	PRINT("TekiPersonality::write>\n");
+	PRINT_NAKATA("TekiPersonality::write>\n");
 	output.writeByte((s8)mPelletKind);
 	output.writeByte((s8)mPelletColor);
 	mID.write(output);
 	mParams->write(output);
-	PRINT("TekiPersonality::write<\n");
+	PRINT_NAKATA("TekiPersonality::write<\n");
 }
 
 #ifdef WIN32
 
 void TekiPersonality::genAge(AgeServer& server)
 {
-	PRINT("TekiPersonality::genAge>%08x\n", mParams);
+	PRINT_NAKATA("TekiPersonality::genAge>%08x\n", mParams);
 	int id = 0;
 	server.StartOptionBox("pellet kind", &mPelletKind, 252);
 	server.NewOption("pellet 1", id++);
@@ -208,7 +208,7 @@ void TekiPersonality::genAge(AgeServer& server)
 	server.EndOptionBox();
 
 	mParams->genAge(server);
-	PRINT("TekiPersonality::genAge<%08x\n", mParams);
+	PRINT_NAKATA("TekiPersonality::genAge<%08x\n", mParams);
 }
 
 #endif

--- a/src/plugPikiYamashita/drawWorldMap.cpp
+++ b/src/plugPikiYamashita/drawWorldMap.cpp
@@ -244,7 +244,7 @@ struct WorldMapCursorOnyon {
 		if (mOnyonIcon) {
 			mOnyonIcon->setOffset(mOnyonIcon->getWidth() >> 1, mOnyonIcon->getHeight() >> 2);
 		} else {
-			PRINT("Illegal init WorldMapCursorOnyon Class.\n");
+			PRINT_YAMASH("Illegal init WorldMapCursorOnyon Class.\n");
 			ERROR("Illegal initialize.");
 		}
 
@@ -445,7 +445,7 @@ struct WorldMapCursorMgr {
 			mRocketIcon->setOffset(mRocketIcon->getWidth() >> 1, mRocketIcon->getHeight() >> 1);
 			mRocketIcon->setScale(1.0f);
 		} else {
-			PRINT("Illegal initilize.\n");
+			PRINT_YAMASH("Illegal initilize.\n");
 			ERROR("Illegal initilize.\n");
 		}
 
@@ -657,7 +657,7 @@ struct WorldMapCursorMgr {
 			mIsForcedMove = false;
 			setLandingFlag(true);
 		} else {
-			PRINT("can't forceMove.\n");
+			PRINT_YAMASH("can't forceMove.\n");
 			ERROR("can't forceMove.");
 		}
 	}

--- a/src/plugPikiYamashita/tekiyamashita.cpp
+++ b/src/plugPikiYamashita/tekiyamashita.cpp
@@ -100,7 +100,7 @@ void TekiYamashita::makeTekis(TekiMgr* mgr)
  */
 void TekiYamashita::makeDefaultAnimations()
 {
-	PRINT("makeDefaultAnimations>\n");
+	PRINT_NAKATA("makeDefaultAnimations>\n"); // The DLL says the wrong user print was used here.
 	TAItankAnimation().makeDefaultAnimations();
 	TAImarAnimation().makeDefaultAnimations();
 	TAIbeatleAnimation().makeDefaultAnimations();
@@ -113,5 +113,5 @@ void TekiYamashita::makeDefaultAnimations()
 	TAImiurinAnimation().makeDefaultAnimations();
 	TAIusubaAnimation().makeDefaultAnimations();
 	TAIotamaAnimation().makeDefaultAnimations();
-	PRINT("makeDefaultAnimations<\n");
+	PRINT_NAKATA("makeDefaultAnimations<\n"); // The DLL says the wrong user print was used here.
 }


### PR DESCRIPTION
For now, they are functionally identical to the normal `PRINT`.