### PR TITLE
Replace `DEFINE_ENUM_TYPE` with superior workaround

### DIFF
--- a/include/Animator.h
+++ b/include/Animator.h
@@ -174,26 +174,26 @@ struct AnimParam {
  */
 BEGIN_ENUM_TYPE(AnimDataFlags)
 enum {
-	ScaleXStatic             = 0x1, // Scale X component has single value (no animation)
-	ScaleYStatic             = 0x2, // Scale Y component has single value (no animation)
-	ScaleZStatic             = 0x4, // Scale Z component has single value (no animation)
+	ScaleXStatic             = 1 << 0, // Scale X component has single value (no animation)
+	ScaleYStatic             = 1 << 1, // Scale Y component has single value (no animation)
+	ScaleZStatic             = 1 << 2, // Scale Z component has single value (no animation)
 	AllIndividualScaleStatic = ScaleXStatic | ScaleYStatic | ScaleZStatic,
-	AllScaleStatic           = 0x8, // All scale components are static
+	AllScaleStatic           = 1 << 3, // All scale components are static
 
-	RotationXStatic             = 0x10, // Rotation X component has single value (no animation)
-	RotationYStatic             = 0x20, // Rotation Y component has single value (no animation)
-	RotationZStatic             = 0x40, // Rotation Z component has single value (no animation)
+	RotationXStatic             = 1 << 4, // Rotation X component has single value (no animation)
+	RotationYStatic             = 1 << 5, // Rotation Y component has single value (no animation)
+	RotationZStatic             = 1 << 6, // Rotation Z component has single value (no animation)
 	AllIndividualRotationStatic = RotationXStatic | RotationYStatic | RotationZStatic,
-	AllRotationStatic           = 0x80, // All rotation components are static
+	AllRotationStatic           = 1 << 7, // All rotation components are static
 
-	TranslationXStatic             = 0x100, // Translation X component has single value (no animation)
-	TranslationYStatic             = 0x200, // Translation Y component has single value (no animation)
-	TranslationZStatic             = 0x400, // Translation Z component has single value (no animation)
+	TranslationXStatic             = 1 << 8,  // Translation X component has single value (no animation)
+	TranslationYStatic             = 1 << 9,  // Translation Y component has single value (no animation)
+	TranslationZStatic             = 1 << 10, // Translation Z component has single value (no animation)
 	AllIndividualTranslationStatic = TranslationXStatic | TranslationYStatic | TranslationZStatic,
-	AllTranslationStatic           = 0x800, // All translation components are static
+	AllTranslationStatic           = 1 << 11, // All translation components are static
 
-	AllComponentsStatic = 0x777,  // All individual component flags set (OR of all static flags)
-	MatrixCalculated    = 0x8000, // Transform matrix has been calculated
+	AllComponentsStatic = AllIndividualScaleStatic | AllIndividualRotationStatic | AllIndividualTranslationStatic,
+	MatrixCalculated    = 1 << 15, // Transform matrix has been calculated
 } END_ENUM_TYPE;
 
 /**

--- a/include/Animator.h
+++ b/include/Animator.h
@@ -172,28 +172,29 @@ struct AnimParam {
 /**
  * @brief Flags indicating animation data status for scale/rotation/translation components
  */
-DEFINE_ENUM_TYPE(AnimDataFlags,
-                 ScaleXStatic             = 0x1, // Scale X component has single value (no animation)
-                 ScaleYStatic             = 0x2, // Scale Y component has single value (no animation)
-                 ScaleZStatic             = 0x4, // Scale Z component has single value (no animation)
-                 AllIndividualScaleStatic = ScaleXStatic | ScaleYStatic | ScaleZStatic,
-                 AllScaleStatic           = 0x8, // All scale components are static
+BEGIN_ENUM_TYPE(AnimDataFlags)
+enum {
+	ScaleXStatic             = 0x1, // Scale X component has single value (no animation)
+	ScaleYStatic             = 0x2, // Scale Y component has single value (no animation)
+	ScaleZStatic             = 0x4, // Scale Z component has single value (no animation)
+	AllIndividualScaleStatic = ScaleXStatic | ScaleYStatic | ScaleZStatic,
+	AllScaleStatic           = 0x8, // All scale components are static
 
-                 RotationXStatic             = 0x10, // Rotation X component has single value (no animation)
-                 RotationYStatic             = 0x20, // Rotation Y component has single value (no animation)
-                 RotationZStatic             = 0x40, // Rotation Z component has single value (no animation)
-                 AllIndividualRotationStatic = RotationXStatic | RotationYStatic | RotationZStatic,
-                 AllRotationStatic           = 0x80, // All rotation components are static
+	RotationXStatic             = 0x10, // Rotation X component has single value (no animation)
+	RotationYStatic             = 0x20, // Rotation Y component has single value (no animation)
+	RotationZStatic             = 0x40, // Rotation Z component has single value (no animation)
+	AllIndividualRotationStatic = RotationXStatic | RotationYStatic | RotationZStatic,
+	AllRotationStatic           = 0x80, // All rotation components are static
 
-                 TranslationXStatic             = 0x100, // Translation X component has single value (no animation)
-                 TranslationYStatic             = 0x200, // Translation Y component has single value (no animation)
-                 TranslationZStatic             = 0x400, // Translation Z component has single value (no animation)
-                 AllIndividualTranslationStatic = TranslationXStatic | TranslationYStatic | TranslationZStatic,
-                 AllTranslationStatic           = 0x800, // All translation components are static
+	TranslationXStatic             = 0x100, // Translation X component has single value (no animation)
+	TranslationYStatic             = 0x200, // Translation Y component has single value (no animation)
+	TranslationZStatic             = 0x400, // Translation Z component has single value (no animation)
+	AllIndividualTranslationStatic = TranslationXStatic | TranslationYStatic | TranslationZStatic,
+	AllTranslationStatic           = 0x800, // All translation components are static
 
-                 AllComponentsStatic = 0x777,  // All individual component flags set (OR of all static flags)
-                 MatrixCalculated    = 0x8000, // Transform matrix has been calculated
-);
+	AllComponentsStatic = 0x777,  // All individual component flags set (OR of all static flags)
+	MatrixCalculated    = 0x8000, // Transform matrix has been calculated
+} END_ENUM_TYPE;
 
 /**
  * @brief Information about animation data, read in from a file.

--- a/include/CinematicPlayer.h
+++ b/include/CinematicPlayer.h
@@ -23,31 +23,32 @@ struct ActorInstance;
 /**
  * @brief Enum for cinematic player flags.
  */
-DEFINE_ENUM_TYPE(CinePlayerFlags,
-                 Localized      = 1 << 0,  // 0x1
-                 Unknown        = 1 << 1,  // 0x2
-                 HideNavi       = 1 << 2,  // 0x4
-                 HideBluePiki   = 1 << 3,  // 0x8
-                 HideRedPiki    = 1 << 4,  // 0x10
-                 HideYellowPiki = 1 << 5,  // 0x20
-                 NaviNoAI       = 1 << 6,  // 0x40
-                 UseLights      = 1 << 7,  // 0x80, originally called "NonGameMovie"
-                 Concurrent     = 1 << 8,  // 0x100, use special takeoff cutscene logic
-                 CameraBlend    = 1 << 9,  // 0x200, fade in from black when starting a scene
-                 ShowTekis      = 1 << 10, // 0x400
-                 ShowFreePiki   = 1 << 11, // 0x800
-                 UpdateFreePiki = 1 << 12, // 0x1000
-                 ShowFormPiki   = 1 << 13, // 0x2000
-                 UpdateFormPiki = 1 << 14, // 0x4000
-                 ShowWorkPiki   = 1 << 15, // 0x8000
-                 UpdateWorkPiki = 1 << 16, // 0x10000
-                 ObjWatching    = 1 << 17, // 0x20000, static camera
-                 ShowPellets    = 1 << 18, // 0x40000
-                 PauseAll       = 1 << 19, // 0x80000
-                 HideRedCont    = 1 << 20, // 0x100000
-                 PikiNearUfo    = 1 << 21, // 0x200000
-                 CameraReturn   = 1 << 22, // 0x400000
-);
+BEGIN_ENUM_TYPE(CinePlayerFlags)
+enum {
+	Localized      = 1 << 0,  // 0x1
+	Unknown        = 1 << 1,  // 0x2
+	HideNavi       = 1 << 2,  // 0x4
+	HideBluePiki   = 1 << 3,  // 0x8
+	HideRedPiki    = 1 << 4,  // 0x10
+	HideYellowPiki = 1 << 5,  // 0x20
+	NaviNoAI       = 1 << 6,  // 0x40
+	UseLights      = 1 << 7,  // 0x80, originally called "NonGameMovie"
+	Concurrent     = 1 << 8,  // 0x100, use special takeoff cutscene logic
+	CameraBlend    = 1 << 9,  // 0x200, fade in from black when starting a scene
+	ShowTekis      = 1 << 10, // 0x400
+	ShowFreePiki   = 1 << 11, // 0x800
+	UpdateFreePiki = 1 << 12, // 0x1000
+	ShowFormPiki   = 1 << 13, // 0x2000
+	UpdateFormPiki = 1 << 14, // 0x4000
+	ShowWorkPiki   = 1 << 15, // 0x8000
+	UpdateWorkPiki = 1 << 16, // 0x10000
+	ObjWatching    = 1 << 17, // 0x20000, static camera
+	ShowPellets    = 1 << 18, // 0x40000
+	PauseAll       = 1 << 19, // 0x80000
+	HideRedCont    = 1 << 20, // 0x100000
+	PikiNearUfo    = 1 << 21, // 0x200000
+	CameraReturn   = 1 << 22, // 0x400000
+} END_ENUM_TYPE;
 
 /**
  * @brief Enum for cutscene skipping flags.

--- a/include/DoorItem.h
+++ b/include/DoorItem.h
@@ -21,12 +21,13 @@ struct DoorProp : public CreatureProp {
 	// _00-_58 = CreatureProp
 };
 
-DEFINE_ENUM_TYPE(DoorState,
-                 Active,   // Door is interactive
-                 Killed,   // Door has been destroyed
-                 Inactive, // Door is initialized but not started
-                 Vanishing // Door is disappearing
-);
+BEGIN_ENUM_TYPE(DoorState)
+enum {
+	Active,   // Door is interactive
+	Killed,   // Door has been destroyed
+	Inactive, // Door is initialized but not started
+	Vanishing // Door is disappearing
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/GameCoreSection.h
+++ b/include/GameCoreSection.h
@@ -32,11 +32,12 @@ enum CorePauseFlags {
 	COREPAUSE_Unk16 = 1 << 15, // 0x8000
 };
 
-DEFINE_ENUM_TYPE(GameHideFlags,
-                 ShowPellets             = 1 << 0, // 0x1
-                 ShowPelletsExceptSucked = 1 << 1, // 0x2
-                 ShowTeki                = 1 << 2, // 0x4 aka enemies
-);
+BEGIN_ENUM_TYPE(GameHideFlags)
+enum {
+	ShowPellets             = 1 << 0, // 0x1
+	ShowPelletsExceptSucked = 1 << 1, // 0x2
+	ShowTeki                = 1 << 2, // 0x4 aka enemies
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/KeyItem.h
+++ b/include/KeyItem.h
@@ -23,11 +23,12 @@ struct KeyProp : public CreatureProp {
 	// _00-_58 = CreatureProp
 };
 
-DEFINE_ENUM_TYPE(KeyState,
-                 Active,    // Key is interactive
-                 Collected, // Key has been collected
-                 Inactive,  // Key is initialized but not started
-);
+BEGIN_ENUM_TYPE(KeyState)
+enum {
+	Active,    // Key is interactive
+	Collected, // Key has been collected
+	Inactive,  // Key is initialized but not started
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/Light.h
+++ b/include/Light.h
@@ -213,12 +213,10 @@ struct LightGroup : public CoreNode {
 	LFlareGroup* mFlareGroup; // _68
 };
 
-// clang-format off
-DEFINE_ENUM_TYPE(
-	LightPoolFlags,
+BEGIN_ENUM_TYPE(LightPoolFlags)
+enum {
 	DrawFrustum = 1,
-);
-// clang-format on
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/Menu.h
+++ b/include/Menu.h
@@ -14,9 +14,31 @@ struct Font;
 struct Light;
 
 struct Menu : public Node {
-	DEFINE_ENUM_TYPE(MenuStateType, Idle = 0, FadeIn = 1, Open = 2, FadeOut = 3);
-	DEFINE_ENUM_TYPE(KeyEventType, Null = 0, Press = 1, Hold = 2, Input = 4, Release = 8, Navigate = 16, SpecialRelease = 32);
-	DEFINE_ENUM_TYPE(MenuNavigationType, Unk0 = 0, TopMenu = 1, SubMenu = 2);
+	BEGIN_ENUM_TYPE(MenuStateType)
+	enum {
+		Idle    = 0,
+		FadeIn  = 1,
+		Open    = 2,
+		FadeOut = 3,
+	} END_ENUM_TYPE;
+
+	BEGIN_ENUM_TYPE(KeyEventType)
+	enum {
+		Null           = 0,
+		Press          = 1,
+		Hold           = 2,
+		Input          = 4,
+		Release        = 8,
+		Navigate       = 16,
+		SpecialRelease = 32,
+	} END_ENUM_TYPE;
+
+	BEGIN_ENUM_TYPE(MenuNavigationType)
+	enum {
+		Unk0    = 0,
+		TopMenu = 1,
+		SubMenu = 2,
+	} END_ENUM_TYPE;
 
 	/**
 	 * @brief Linked list of key events.

--- a/include/Menu.h
+++ b/include/Menu.h
@@ -25,12 +25,12 @@ struct Menu : public Node {
 	BEGIN_ENUM_TYPE(KeyEventType)
 	enum {
 		Null           = 0,
-		Press          = 1,
-		Hold           = 2,
-		Input          = 4,
-		Release        = 8,
-		Navigate       = 16,
-		SpecialRelease = 32,
+		Press          = 1 << 0,
+		Hold           = 1 << 1,
+		Input          = 1 << 2,
+		Release        = 1 << 3,
+		Navigate       = 1 << 4,
+		SpecialRelease = 1 << 5,
 	} END_ENUM_TYPE;
 
 	BEGIN_ENUM_TYPE(MenuNavigationType)

--- a/include/PVW.h
+++ b/include/PVW.h
@@ -133,20 +133,21 @@ struct PVWAnimInfo3 {
 /**
  * @brief Lighting control flags for PVW materials
  */
-DEFINE_ENUM_TYPE(LightingControlFlags,
-                 EnableColor0   = 0x0001, ///< Enable lighting for color channel 0
-                 EnableSpecular = 0x0002, ///< Enable specular lighting (color channel 1)
-                 EnableAlpha0   = 0x0004, ///< Enable lighting for alpha channel 0
+BEGIN_ENUM_TYPE(LightingControlFlags)
+enum {
+	EnableColor0   = 0x0001, ///< Enable lighting for color channel 0
+	EnableSpecular = 0x0002, ///< Enable specular lighting (color channel 1)
+	EnableAlpha0   = 0x0004, ///< Enable lighting for alpha channel 0
 
-                 DiffFnColor0Shift   = 3, ///< Diffuse function for color 0 (bits 3-4)
-                 DiffFnAlpha0Shift   = 5, ///< Diffuse function for alpha 0 (bits 5-6)
-                 DiffFnSpecularShift = 7, ///< Diffuse function for specular (bits 7-8)
+	DiffFnColor0Shift   = 3, ///< Diffuse function for color 0 (bits 3-4)
+	DiffFnAlpha0Shift   = 5, ///< Diffuse function for alpha 0 (bits 5-6)
+	DiffFnSpecularShift = 7, ///< Diffuse function for specular (bits 7-8)
 
-                 AmbSrcColor0Vtx = 0x0200, ///< Use vertex color for ambient color 0 (vs register)
-                 AmbSrcAlpha0Vtx = 0x0400, ///< Use vertex alpha for ambient alpha 0 (vs register)
-                 MatSrcColor0Vtx = 0x0800, ///< Use vertex color for material color 0 (vs register)
-                 MatSrcAlpha0Vtx = 0x1000, ///< Use vertex alpha for material alpha 0 (vs register)
-);
+	AmbSrcColor0Vtx = 0x0200, ///< Use vertex color for ambient color 0 (vs register)
+	AmbSrcAlpha0Vtx = 0x0400, ///< Use vertex alpha for ambient alpha 0 (vs register)
+	MatSrcColor0Vtx = 0x0800, ///< Use vertex color for material color 0 (vs register)
+	MatSrcAlpha0Vtx = 0x1000, ///< Use vertex alpha for material alpha 0 (vs register)
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/PVW.h
+++ b/include/PVW.h
@@ -135,18 +135,18 @@ struct PVWAnimInfo3 {
  */
 BEGIN_ENUM_TYPE(LightingControlFlags)
 enum {
-	EnableColor0   = 0x0001, ///< Enable lighting for color channel 0
-	EnableSpecular = 0x0002, ///< Enable specular lighting (color channel 1)
-	EnableAlpha0   = 0x0004, ///< Enable lighting for alpha channel 0
+	EnableColor0   = 1 << 0, ///< Enable lighting for color channel 0
+	EnableSpecular = 1 << 1, ///< Enable specular lighting (color channel 1)
+	EnableAlpha0   = 1 << 2, ///< Enable lighting for alpha channel 0
 
 	DiffFnColor0Shift   = 3, ///< Diffuse function for color 0 (bits 3-4)
 	DiffFnAlpha0Shift   = 5, ///< Diffuse function for alpha 0 (bits 5-6)
 	DiffFnSpecularShift = 7, ///< Diffuse function for specular (bits 7-8)
 
-	AmbSrcColor0Vtx = 0x0200, ///< Use vertex color for ambient color 0 (vs register)
-	AmbSrcAlpha0Vtx = 0x0400, ///< Use vertex alpha for ambient alpha 0 (vs register)
-	MatSrcColor0Vtx = 0x0800, ///< Use vertex color for material color 0 (vs register)
-	MatSrcAlpha0Vtx = 0x1000, ///< Use vertex alpha for material alpha 0 (vs register)
+	AmbSrcColor0Vtx = 1 << 9,  ///< Use vertex color for ambient color 0 (vs register)
+	AmbSrcAlpha0Vtx = 1 << 10, ///< Use vertex alpha for ambient alpha 0 (vs register)
+	MatSrcColor0Vtx = 1 << 11, ///< Use vertex color for material color 0 (vs register)
+	MatSrcAlpha0Vtx = 1 << 12, ///< Use vertex alpha for material alpha 0 (vs register)
 } END_ENUM_TYPE;
 
 /**

--- a/include/Pcam/Camera.h
+++ b/include/Pcam/Camera.h
@@ -37,18 +37,20 @@ enum PcamAngleLevels {
 /**
  * @brief Camera attention states
  */
-DEFINE_ENUM_TYPE(AttentionState,
-                 Inactive = 0, // Camera is not in attention mode
-                 Active   = 1, // Camera is actively tracking attention target
-);
+BEGIN_ENUM_TYPE(AttentionState)
+enum {
+	Inactive = 0, // Camera is not in attention mode
+	Active   = 1, // Camera is actively tracking attention target
+} END_ENUM_TYPE;
 
 /**
  * @brief Radius calculation modes for camera
  */
-DEFINE_ENUM_TYPE(RadiusMode,
-                 Dynamic = 0, // Use calculated goal distance
-                 Stored  = 1, // Use stored previous radius value
-);
+BEGIN_ENUM_TYPE(RadiusMode)
+enum {
+	Dynamic = 0, // Use calculated goal distance
+	Stored  = 1, // Use stored previous radius value
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/Piki.h
+++ b/include/Piki.h
@@ -74,9 +74,9 @@ enum {
  */
 BEGIN_ENUM_TYPE(PikiEmotion)
 enum {
-	Happy = 0,         // General happiness, jumping.
-	Sad   = 1,         // Gakkari animation, disappointment.
-	                   // 2 is unused
+	Happy         = 0, // General happiness, jumping.
+	Sad           = 1, // Gakkari animation, disappointment.
+	Unused        = 2, //
 	ShookDry      = 3, // Shaking off water after getting out.
 	ShipPartGaze  = 4, // Staring at a collected ship part.
 	Excited       = 5, // Excited, a mix of jumping and fist-pumping.

--- a/include/Piki.h
+++ b/include/Piki.h
@@ -40,50 +40,52 @@ enum PikiSituationType {
 	PIKISITCH_Unk14 = 14,
 };
 
-DEFINE_ENUM_TYPE(PikiMode,
-                 FreeMode = 0,  // 0
-                 FormationMode, // 1
-                 AttackMode,    // 2
-                 NukuMode,      // 3
-                 GuardMode,     // 4
-                 PickMode,      // 5
-                 DecoyMode,     // 6
-                 ArrowMode,     // 7
-                 CarryMode,     // 8
-                 TransportMode, // 9
-                 RopeMode,      // 10
-                 EnterMode,     // 11
-                 ExitMode,      // 12
-                 BreakwallMode, // 13
-                 MineMode,      // 14
-                 KinokoMode,    // 15
-                 BridgeMode,    // 16
-                 PushstoneMode, // 17
-                 PutbombMode,   // 18
-                 RescueMode,    // 19
-                 WeedMode,      // 20
-                 PebbleMode,    // 21
-                 BomakeMode,    // 22
-                 BoMode,        // 23
-                 WarriorMode,   // 24
-);
+BEGIN_ENUM_TYPE(PikiMode)
+enum {
+	FreeMode = 0,  // 0
+	FormationMode, // 1
+	AttackMode,    // 2
+	NukuMode,      // 3
+	GuardMode,     // 4
+	PickMode,      // 5
+	DecoyMode,     // 6
+	ArrowMode,     // 7
+	CarryMode,     // 8
+	TransportMode, // 9
+	RopeMode,      // 10
+	EnterMode,     // 11
+	ExitMode,      // 12
+	BreakwallMode, // 13
+	MineMode,      // 14
+	KinokoMode,    // 15
+	BridgeMode,    // 16
+	PushstoneMode, // 17
+	PutbombMode,   // 18
+	RescueMode,    // 19
+	WeedMode,      // 20
+	PebbleMode,    // 21
+	BomakeMode,    // 22
+	BoMode,        // 23
+	WarriorMode,   // 24
+} END_ENUM_TYPE;
 
 /**
  * @brief Defines the different emotions a Pikmin can express.
  */
-DEFINE_ENUM_TYPE(PikiEmotion,
-                 Happy = 0,         // General happiness, jumping.
-                 Sad   = 1,         // Gakkari animation, disappointment.
-                                    // 2 is unused
-                 ShookDry      = 3, // Shaking off water after getting out.
-                 ShipPartGaze  = 4, // Staring at a collected ship part.
-                 Excited       = 5, // Excited, a mix of jumping and fist-pumping.
-                 Victorious    = 6, // Yatta animation, celebrating a victory.
-                 Searching     = 7, // Looking around for something.
-                 Confused      = 8, // A mix of disappointment and searching.
-                 ShipPartCheer = 9, // Cheering for a collected ship part repeatedly.
-                 None          = 10 // No specific emotion.
-);
+BEGIN_ENUM_TYPE(PikiEmotion)
+enum {
+	Happy = 0,         // General happiness, jumping.
+	Sad   = 1,         // Gakkari animation, disappointment.
+	                   // 2 is unused
+	ShookDry      = 3, // Shaking off water after getting out.
+	ShipPartGaze  = 4, // Staring at a collected ship part.
+	Excited       = 5, // Excited, a mix of jumping and fist-pumping.
+	Victorious    = 6, // Yatta animation, celebrating a victory.
+	Searching     = 7, // Looking around for something.
+	Confused      = 8, // A mix of disappointment and searching.
+	ShipPartCheer = 9, // Cheering for a collected ship part repeatedly.
+	None          = 10 // No specific emotion.
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/PikiAI.h
+++ b/include/PikiAI.h
@@ -38,45 +38,42 @@ namespace Reaction {
 extern char* info[9];
 } // namespace Reaction
 
-// clang-format off
-DEFINE_ENUM_TYPE(
-	PikiAction,
-
-	NOACTION = -1,  // -1
-	RandomBoid = 0, // 0
-	Watch,          // 1
-	Escape,         // 2
-	Chase,          // 3
-	Goto,           // 4
-	PickCreature,   // 5
-	PutItem,        // 6
-	Formation,      // 7
-	Attack,         // 8
-	Shoot,          // 9
-	Guard,          // 10
-	Pullout,        // 11
-	PickItem,       // 12
-	Decoy,          // 13
-	Crowd,          // 14
-	Free,           // 15
-	Rope,           // 16
-	Enter,          // 17
-	Exit,           // 18
-	BreakWall,      // 19
-	Mine,           // 20
-	Transport,      // 21
-	Kinoko,         // 22
-	Bridge,         // 23
-	Push,           // 24
-	PutBomb,        // 25
-	Rescue,         // 26
-	Weed,           // 27
-	Stone,          // 28
-	BoMake,         // 29
-	Bou,            // 30
-	COUNT,          // 31
-);
-// clang-format on
+BEGIN_ENUM_TYPE(PikiAction)
+enum {
+	NOACTION   = -1, // -1
+	RandomBoid = 0,  // 0
+	Watch,           // 1
+	Escape,          // 2
+	Chase,           // 3
+	Goto,            // 4
+	PickCreature,    // 5
+	PutItem,         // 6
+	Formation,       // 7
+	Attack,          // 8
+	Shoot,           // 9
+	Guard,           // 10
+	Pullout,         // 11
+	PickItem,        // 12
+	Decoy,           // 13
+	Crowd,           // 14
+	Free,            // 15
+	Rope,            // 16
+	Enter,           // 17
+	Exit,            // 18
+	BreakWall,       // 19
+	Mine,            // 20
+	Transport,       // 21
+	Kinoko,          // 22
+	Bridge,          // 23
+	Push,            // 24
+	PutBomb,         // 25
+	Rescue,          // 26
+	Weed,            // 27
+	Stone,           // 28
+	BoMake,          // 29
+	Bou,             // 30
+	COUNT,           // 31
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/Route.h
+++ b/include/Route.h
@@ -130,9 +130,9 @@ struct RouteGroup : public EditNode {
  */
 BEGIN_ENUM_TYPE(WayPointFlags)
 enum {
-	InWater     = 1, // Waypoint is in water
-	Pebble      = 2, // Waypoint has pebble obstacle
-	Destination = 4  // Either the start or destination waypoint in a pathfinding request
+	InWater     = 1 << 0, // Waypoint is in water
+	Pebble      = 1 << 1, // Waypoint has pebble obstacle
+	Destination = 1 << 2, // Either the start or destination waypoint in a pathfinding request
 } END_ENUM_TYPE;
 
 /**
@@ -241,9 +241,9 @@ struct RouteMgr : public Node {
  */
 BEGIN_ENUM_TYPE(PathFinderMode)
 enum {
-	None       = 0, // No special pathfinding mode
-	AvoidWater = 1, // Avoid water waypoints when pathfinding
-	Unk2       = 2  // Avoid specific waypoint index
+	None       = 0,      // No special pathfinding mode
+	AvoidWater = 1 << 0, // Avoid water waypoints when pathfinding
+	Unk2       = 1 << 1, // Avoid specific waypoint index
 } END_ENUM_TYPE;
 
 /**

--- a/include/Route.h
+++ b/include/Route.h
@@ -128,11 +128,12 @@ struct RouteGroup : public EditNode {
 /**
  * @brief Waypoint flags for pathfinding
  */
-DEFINE_ENUM_TYPE(WayPointFlags,
-                 InWater     = 1, // Waypoint is in water
-                 Pebble      = 2, // Waypoint has pebble obstacle
-                 Destination = 4  // Either the start or destination waypoint in a pathfinding request
-);
+BEGIN_ENUM_TYPE(WayPointFlags)
+enum {
+	InWater     = 1, // Waypoint is in water
+	Pebble      = 2, // Waypoint has pebble obstacle
+	Destination = 4  // Either the start or destination waypoint in a pathfinding request
+} END_ENUM_TYPE;
 
 /**
  * @brief Runtime waypoint used for pathfinding
@@ -238,11 +239,12 @@ struct RouteMgr : public Node {
 /**
  * @brief Pathfinding mode flags
  */
-DEFINE_ENUM_TYPE(PathFinderMode,
-                 None       = 0, // No special pathfinding mode
-                 AvoidWater = 1, // Avoid water waypoints when pathfinding
-                 Unk2       = 2  // Avoid specific waypoint index
-);
+BEGIN_ENUM_TYPE(PathFinderMode)
+enum {
+	None       = 0, // No special pathfinding mode
+	AvoidWater = 1, // Avoid water waypoints when pathfinding
+	Unk2       = 2  // Avoid specific waypoint index
+} END_ENUM_TYPE;
 
 /**
  * @brief Implements pathfinding algorithms for route navigation
@@ -271,11 +273,12 @@ struct PathFinder {
 	/**
 	 * @brief Status of pathfinding client request
 	 */
-	DEFINE_ENUM_TYPE(PathStatus,
-	                 Searching = 0, // Currently searching for path
-	                 Success   = 1, // Path found successfully
-	                 Failed    = 2, // No path exists to destination
-	);
+	BEGIN_ENUM_TYPE(PathStatus)
+	enum {
+		Searching = 0, // Currently searching for path
+		Success   = 1, // Path found successfully
+		Failed    = 2, // No path exists to destination
+	} END_ENUM_TYPE;
 
 	/**
 	 * @brief Asynchronous pathfinding client

--- a/include/Shape.h
+++ b/include/Shape.h
@@ -126,12 +126,13 @@ struct ShapeDynMaterials {
 	BaseShape* mShape;          // _0C
 };
 
-DEFINE_ENUM_TYPE(DisplayListFlags,
-                 Front    = 0,         //
-                 Other    = 1,         //
-                 Both     = 2,         //
-                 Stripped = 0x1000000, //
-);
+BEGIN_ENUM_TYPE(DisplayListFlags)
+enum {
+	Front    = 0,         //
+	Other    = 1,         //
+	Both     = 2,         //
+	Stripped = 0x1000000, //
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO
@@ -167,58 +168,61 @@ struct DlobjInfo : public GfxobjInfo {
 	DlobjInfo();
 };
 
-DEFINE_ENUM_TYPE(BaseShapeChunk,
-                 Header           = 0x00,   //
-                 Vertex           = 0x10,   //
-                 VertexNormal     = 0x11,   //
-                 VertexNBT        = 0x12,   //
-                 VertexColour     = 0x13,   //
-                 TexCoord0        = 0x18,   //
-                 TexCoord1        = 0x19,   //
-                 TexCoord2        = 0x1A,   //
-                 TexCoord3        = 0x1B,   //
-                 TexCoord4        = 0x1C,   //
-                 TexCoord5        = 0x1D,   //
-                 TexCoord6        = 0x1E,   //
-                 TexCoord7        = 0x1F,   //
-                 Texture          = 0x20,   //
-                 TextureAttribute = 0x22,   //
-                 Material         = 0x30,   //
-                 VertexMatrix     = 0x40,   //
-                 MatrixEnvelope   = 0x41,   //
-                 Mesh             = 0x50,   //
-                 Joint            = 0x60,   //
-                 JointName        = 0x61,   //
-                 CollisionPrism   = 0x100,  //
-                 CollisionGrid    = 0x110,  //
-                 EndOfFile        = 0xFFFF, //
-);
+BEGIN_ENUM_TYPE(BaseShapeChunk)
+enum {
+	Header           = 0x00,   //
+	Vertex           = 0x10,   //
+	VertexNormal     = 0x11,   //
+	VertexNBT        = 0x12,   //
+	VertexColour     = 0x13,   //
+	TexCoord0        = 0x18,   //
+	TexCoord1        = 0x19,   //
+	TexCoord2        = 0x1A,   //
+	TexCoord3        = 0x1B,   //
+	TexCoord4        = 0x1C,   //
+	TexCoord5        = 0x1D,   //
+	TexCoord6        = 0x1E,   //
+	TexCoord7        = 0x1F,   //
+	Texture          = 0x20,   //
+	TextureAttribute = 0x22,   //
+	Material         = 0x30,   //
+	VertexMatrix     = 0x40,   //
+	MatrixEnvelope   = 0x41,   //
+	Mesh             = 0x50,   //
+	Joint            = 0x60,   //
+	JointName        = 0x61,   //
+	CollisionPrism   = 0x100,  //
+	CollisionGrid    = 0x110,  //
+	EndOfFile        = 0xFFFF, //
+} END_ENUM_TYPE;
 
-DEFINE_ENUM_TYPE(ShapeFlags,
-                 None         = 0x00, //
-                 AllowCaching = 0x02, // Allows caching of shape geometry into a display list.
-                 AlwaysRedraw = 0x04, // Forces the shape to be redrawn every frame, bypassing any cached display list.
-                 IsPlatform   = 0x10, // Indicates the shape is a platform or has platform collision.
-);
+BEGIN_ENUM_TYPE(ShapeFlags)
+enum {
+	None         = 0x00, //
+	AllowCaching = 0x02, // Allows caching of shape geometry into a display list.
+	AlwaysRedraw = 0x04, // Forces the shape to be redrawn every frame, bypassing any cached display list.
+	IsPlatform   = 0x10, // Indicates the shape is a platform or has platform collision.
+} END_ENUM_TYPE;
 
 /**
  * @brief Flags indicating which vertex data needs cache flushing
  */
-DEFINE_ENUM_TYPE(VertexCacheFlags,
-                 None       = 0x0,    //
-                 VertexList = 0x1,    // Vertex position data needs cache flush
-                 NormalList = 0x2,    // Normal vector data needs cache flush
-                 NBTList    = 0x4,    // Normal/Binormal/Tangent data needs cache flush
-                 ColorList  = 0x10,   // Vertex color data needs cache flush
-                 TexCoord0  = 0x20,   // Texture coordinate 0 needs cache flush
-                 TexCoord1  = 0x40,   // Texture coordinate 1 needs cache flush
-                 TexCoord2  = 0x80,   // Texture coordinate 2 needs cache flush
-                 TexCoord3  = 0x100,  // Texture coordinate 3 needs cache flush
-                 TexCoord4  = 0x200,  // Texture coordinate 4 needs cache flush
-                 TexCoord5  = 0x400,  // Texture coordinate 5 needs cache flush
-                 TexCoord6  = 0x800,  // Texture coordinate 6 needs cache flush
-                 TexCoord7  = 0x1000, // Texture coordinate 7 needs cache flush
-);
+BEGIN_ENUM_TYPE(VertexCacheFlags)
+enum {
+	None       = 0x0,    //
+	VertexList = 0x1,    // Vertex position data needs cache flush
+	NormalList = 0x2,    // Normal vector data needs cache flush
+	NBTList    = 0x4,    // Normal/Binormal/Tangent data needs cache flush
+	ColorList  = 0x10,   // Vertex color data needs cache flush
+	TexCoord0  = 0x20,   // Texture coordinate 0 needs cache flush
+	TexCoord1  = 0x40,   // Texture coordinate 1 needs cache flush
+	TexCoord2  = 0x80,   // Texture coordinate 2 needs cache flush
+	TexCoord3  = 0x100,  // Texture coordinate 3 needs cache flush
+	TexCoord4  = 0x200,  // Texture coordinate 4 needs cache flush
+	TexCoord5  = 0x400,  // Texture coordinate 5 needs cache flush
+	TexCoord6  = 0x800,  // Texture coordinate 6 needs cache flush
+	TexCoord7  = 0x1000, // Texture coordinate 7 needs cache flush
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/Shape.h
+++ b/include/Shape.h
@@ -198,10 +198,10 @@ enum {
 
 BEGIN_ENUM_TYPE(ShapeFlags)
 enum {
-	None         = 0x00, //
-	AllowCaching = 0x02, // Allows caching of shape geometry into a display list.
-	AlwaysRedraw = 0x04, // Forces the shape to be redrawn every frame, bypassing any cached display list.
-	IsPlatform   = 0x10, // Indicates the shape is a platform or has platform collision.
+	None         = 0,      //
+	AllowCaching = 1 << 1, // Allows caching of shape geometry into a display list.
+	AlwaysRedraw = 1 << 2, // Forces the shape to be redrawn every frame, bypassing any cached display list.
+	IsPlatform   = 1 << 4, // Indicates the shape is a platform or has platform collision.
 } END_ENUM_TYPE;
 
 /**
@@ -209,19 +209,19 @@ enum {
  */
 BEGIN_ENUM_TYPE(VertexCacheFlags)
 enum {
-	None       = 0x0,    //
-	VertexList = 0x1,    // Vertex position data needs cache flush
-	NormalList = 0x2,    // Normal vector data needs cache flush
-	NBTList    = 0x4,    // Normal/Binormal/Tangent data needs cache flush
-	ColorList  = 0x10,   // Vertex color data needs cache flush
-	TexCoord0  = 0x20,   // Texture coordinate 0 needs cache flush
-	TexCoord1  = 0x40,   // Texture coordinate 1 needs cache flush
-	TexCoord2  = 0x80,   // Texture coordinate 2 needs cache flush
-	TexCoord3  = 0x100,  // Texture coordinate 3 needs cache flush
-	TexCoord4  = 0x200,  // Texture coordinate 4 needs cache flush
-	TexCoord5  = 0x400,  // Texture coordinate 5 needs cache flush
-	TexCoord6  = 0x800,  // Texture coordinate 6 needs cache flush
-	TexCoord7  = 0x1000, // Texture coordinate 7 needs cache flush
+	None       = 0,       //
+	VertexList = 1 << 0,  // Vertex position data needs cache flush
+	NormalList = 1 << 1,  // Normal vector data needs cache flush
+	NBTList    = 1 << 2,  // Normal/Binormal/Tangent data needs cache flush
+	ColorList  = 1 << 4,  // Vertex color data needs cache flush
+	TexCoord0  = 1 << 5,  // Texture coordinate 0 needs cache flush
+	TexCoord1  = 1 << 6,  // Texture coordinate 1 needs cache flush
+	TexCoord2  = 1 << 7,  // Texture coordinate 2 needs cache flush
+	TexCoord3  = 1 << 8,  // Texture coordinate 3 needs cache flush
+	TexCoord4  = 1 << 9,  // Texture coordinate 4 needs cache flush
+	TexCoord5  = 1 << 10, // Texture coordinate 5 needs cache flush
+	TexCoord6  = 1 << 11, // Texture coordinate 6 needs cache flush
+	TexCoord7  = 1 << 12, // Texture coordinate 7 needs cache flush
 } END_ENUM_TYPE;
 
 /**

--- a/include/Snake.h
+++ b/include/Snake.h
@@ -176,31 +176,28 @@ struct SnakeProp : public BossProp, public CoreNode {
 	SnakeProperties mSnakeProps; // _200
 };
 
-// clang-format off
 // https://intns.github.io/media/snake_joints.png
-DEFINE_ENUM_TYPE(
-	SnakeJointType,
-
-	Root = 0,     // bodyjnt1
-	Segment1 = 1, // bodyjnt2
-	Segment2 = 2, // bodyjnt3
-	Segment4 = 3, // bodyjnt4
-	Segment5 = 4, // bodyjnt5, middle
-	Segment6 = 5, // bodyjnt6
-	Segment7 = 6, // bodyjnt7
-	Neck = 7,     // bodyjnt8
+BEGIN_ENUM_TYPE(SnakeJointType)
+enum {
+	Root         = 0, // bodyjnt1
+	Segment1     = 1, // bodyjnt2
+	Segment2     = 2, // bodyjnt3
+	Segment4     = 3, // bodyjnt4
+	Segment5     = 4, // bodyjnt5, middle
+	Segment6     = 5, // bodyjnt6
+	Segment7     = 6, // bodyjnt7
+	Neck         = 7, // bodyjnt8
 	SegmentCount = 8,
 
 	// 8 is the eye root
 	RightEye = 9,  // bb_rme
 	LeftEye  = 10, // bb_lme
 
-	JawHinge = 11,	 // kutijnt1
-	LeftCheek = 12,	 // kamujnt3
+	JawHinge   = 11, // kutijnt1
+	LeftCheek  = 12, // kamujnt3
 	RightCheek = 13, // kamujnt2
-	Beak = 14,		 // kamujnt1
-);
-// clang-format on
+	Beak       = 14, // kamujnt1
+} END_ENUM_TYPE;
 
 /**
  * @brief Snake Body controller

--- a/include/Spider.h
+++ b/include/Spider.h
@@ -214,11 +214,12 @@ struct Spider : public Boss {
 /**
  * @brief Spider leg motion types
  */
-DEFINE_ENUM_TYPE(SpiderLegMotionType,
-                 Walk      = 0, // Normal walking motion
-                 ShakeOff  = 1, // Shaking off stuck pikmin (moves knees)
-                 BodyShake = 2, // Full body shake motion
-);
+BEGIN_ENUM_TYPE(SpiderLegMotionType)
+enum {
+	Walk      = 0, // Normal walking motion
+	ShakeOff  = 1, // Shaking off stuck pikmin (moves knees)
+	BodyShake = 2, // Full body shake motion
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/UtEffect.h
+++ b/include/UtEffect.h
@@ -14,10 +14,8 @@ struct Navi;
 // NB: could maybe split these into smaller headers down the line
 // Most of their functions are in uteffect in Kando, so they're here for now.
 
-// clang-format off
-DEFINE_ENUM_TYPE(
-	KandoEffect,
-
+BEGIN_ENUM_TYPE(KandoEffect)
+enum {
 	Goal = 0,         // 0
 	NaviWhistle0,     // 1
 	NaviWhistle1,     // 2
@@ -48,12 +46,11 @@ DEFINE_ENUM_TYPE(
 	IdleYellowPiki,   // 27
 	COUNT,            // 28
 
-	START = Goal,         // 0
-	END = IdleYellowPiki, // 27
+	START = Goal,           // 0
+	END   = IdleYellowPiki, // 27
 
 	SmokeOffset = SmokeSoil, // 3, for different map code attributes
-);
-// clang-format on
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/system.h
+++ b/include/system.h
@@ -128,7 +128,10 @@ struct SystemCache : public ARQRequest {
 	SystemCache* mPrev; // _24
 };
 
-DEFINE_ENUM_TYPE(SystemFlags, Shutdown = 0x80000000);
+BEGIN_ENUM_TYPE(SystemFlags)
+enum {
+	Shutdown = 0x80000000,
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO
@@ -298,15 +301,16 @@ struct AramAllocator {
 /**
  * @brief DVD error states for disc reading operations
  */
-DEFINE_ENUM_TYPE(DvdError,
-                 None        = -1, // No error, normal operation
-                 ReadingDisc = 0,  // Currently reading game disc
-                 FatalError  = 1,  // Fatal disc read error occurred
-                 RetryError  = 2,  // Disc read error, retrying
-                 NoDisc      = 3,  // No disc inserted
-                 CoverOpen   = 4,  // Disc cover is open
-                 WrongDisc   = 5   // Non-Pikmin disc inserted
-);
+BEGIN_ENUM_TYPE(DvdError)
+enum {
+	None        = -1, // No error, normal operation
+	ReadingDisc = 0,  // Currently reading game disc
+	FatalError  = 1,  // Fatal disc read error occurred
+	RetryError  = 2,  // Disc read error, retrying
+	NoDisc      = 3,  // No disc inserted
+	CoverOpen   = 4,  // Disc cover is open
+	WrongDisc   = 5   // Non-Pikmin disc inserted
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/teki.h
+++ b/include/teki.h
@@ -112,7 +112,11 @@ enum TekiTypes {
 	TEKI_TypeCount,     // 35
 };
 
-DEFINE_ENUM_TYPE(TekiInteractType, Attack = 0, HitEffect = 1);
+BEGIN_ENUM_TYPE(TekiInteractType)
+enum {
+	Attack    = 0,
+	HitEffect = 1,
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO
@@ -124,7 +128,14 @@ struct TekiInteractionKey {
 	Interaction* mInteraction; // _04
 };
 
-DEFINE_ENUM_TYPE(TekiEventType, Ground = 0, Entity = 1, Wall = 2, Pressed = 3, WakeUpCall = 4);
+BEGIN_ENUM_TYPE(TekiEventType)
+enum {
+	Ground     = 0,
+	Entity     = 1,
+	Wall       = 2,
+	Pressed    = 3,
+	WakeUpCall = 4,
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/types.h
+++ b/include/types.h
@@ -40,14 +40,7 @@ typedef volatile f128 vf128;
 typedef u16 wchar_t;
 #endif
 
-// Workaround for strongly typed enums (our version of C++ doesn't support them)
-#define DEFINE_ENUM_TYPE(name, ...)  \
-	struct name {                    \
-		enum Values { __VA_ARGS__ }; \
-		typedef Values Type;         \
-	}
-
-// Workaround for Visual Studio and VS Code not recognising the above macro as a valid type
+// Workaround to introduce scoped enums (A feature of C++11 and onward).
 #define BEGIN_ENUM_TYPE(name) \
 	struct name {             \
 		typedef

--- a/include/zen/DrawGameOver.h
+++ b/include/zen/DrawGameOver.h
@@ -27,11 +27,12 @@ struct DrawGameOverScreen;
 /**
  * @brief The current state of the "Game Over" screen logic.
  */
-DEFINE_ENUM_TYPE(GameOverState,
-                 Inactive  = 0, // The screen is not active.
-                 Start     = 1, // The screen has started and is in an initial delay period.
-                 WaitInput = 2  // The screen is waiting for player input or a timeout to finish.
-);
+BEGIN_ENUM_TYPE(GameOverState)
+enum {
+	Inactive  = 0, // The screen is not active.
+	Start     = 1, // The screen has started and is in an initial delay period.
+	WaitInput = 2  // The screen is waiting for player input or a timeout to finish.
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/include/zen/DrawWorldMap.h
+++ b/include/zen/DrawWorldMap.h
@@ -65,11 +65,12 @@ enum WorldMapScreenID {
 /**
  * @brief Animation states for world map title objects
  */
-DEFINE_ENUM_TYPE(TitleAnimState,
-                 Idle      = 0, // Title is stationary or hidden
-                 Appearing = 1, // Title is animating into view
-                 Hiding    = 2, // Title is animating out of view
-);
+BEGIN_ENUM_TYPE(TitleAnimState)
+enum {
+	Idle      = 0, // Title is stationary or hidden
+	Appearing = 1, // Title is animating into view
+	Hiding    = 2, // Title is animating out of view
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO
@@ -220,12 +221,13 @@ struct DrawWorldMapDateCallBack : public P2DPaneCallBack, public zen::NumberTex 
 /**
  * @brief Appearance states for course point animations
  */
-DEFINE_ENUM_TYPE(CourseAppearState,
-                 Ready          = 0, // Course point is ready/idle
-                 RocketIncoming = 1, // Rocket is approaching (0.5s timer)
-                 Exploding      = 2, // Explosion effects playing (1.0s timer)
-                 Revealing      = 3, // Final reveal animation (1.0s timer)
-);
+BEGIN_ENUM_TYPE(CourseAppearState)
+enum {
+	Ready          = 0, // Course point is ready/idle
+	RocketIncoming = 1, // Rocket is approaching (0.5s timer)
+	Exploding      = 2, // Explosion effects playing (1.0s timer)
+	Revealing      = 3, // Final reveal animation (1.0s timer)
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO
@@ -589,18 +591,19 @@ struct WorldMapShootingStarMgr {
 /**
  * @brief Main operational modes for the world map screen
  */
-DEFINE_ENUM_TYPE(DrawWorldMapMode,
-                 Null         = -1, // Invalid or uninitialized mode
-                 Start        = 0,  // Initial setup and transition in
-                 Appear       = 1,  // Course unlock animation playing
-                 Operation    = 2,  // Normal user interaction mode
-                 Paused       = 3,  // Pause menu is open
-                 Confirm      = 4,  // Course selection confirmation dialog
-                 DiaryClosing = 5,  // Transitioning to diary
-                 Diary        = 6,  // Captain's diary is open
-                 DiaryOpening = 7,  // Returning from diary
-                 End          = 8,  // Transition out of world map
-);
+BEGIN_ENUM_TYPE(DrawWorldMapMode)
+enum {
+	Null         = -1, // Invalid or uninitialized mode
+	Start        = 0,  // Initial setup and transition in
+	Appear       = 1,  // Course unlock animation playing
+	Operation    = 2,  // Normal user interaction mode
+	Paused       = 3,  // Pause menu is open
+	Confirm      = 4,  // Course selection confirmation dialog
+	DiaryClosing = 5,  // Transitioning to diary
+	Diary        = 6,  // Captain's diary is open
+	DiaryOpening = 7,  // Returning from diary
+	End          = 8,  // Transition out of world map
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/src/plugPikiYamashita/drawGameOver.cpp
+++ b/src/plugPikiYamashita/drawGameOver.cpp
@@ -22,12 +22,13 @@ namespace zen {
 /**
  * @brief The animation state for an individual letter in the "Game Over" text.
  */
-DEFINE_ENUM_TYPE(LetterState,
-                 Idle   = 0, // The letter is in its initial, unmoving state.
-                 Wait   = 1, // The letter is waiting for a staggered delay before starting its animation.
-                 Fall   = 2, // The letter is falling, bouncing, and rotating into its final position.
-                 Settle = 3  // The letter has landed and is settling into its final scale and rotation.
-);
+BEGIN_ENUM_TYPE(LetterState)
+enum {
+	Idle   = 0, // The letter is in its initial, unmoving state.
+	Wait   = 1, // The letter is waiting for a staggered delay before starting its animation.
+	Fall   = 2, // The letter is falling, bouncing, and rotating into its final position.
+	Settle = 3  // The letter has landed and is settling into its final scale and rotation.
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO

--- a/src/plugPikiYamashita/drawWorldMap.cpp
+++ b/src/plugPikiYamashita/drawWorldMap.cpp
@@ -98,11 +98,12 @@ struct WorldMapWipe {
 /**
  * @brief Wipe transition states for world map screen
  */
-DEFINE_ENUM_TYPE(WipeState,
-                 Idle    = 0, // Wipe is not animating
-                 Closing = 1, // Wipe is closing (covering screen)
-                 Opening = 2, // Wipe is opening (revealing screen)
-);
+BEGIN_ENUM_TYPE(WipeState)
+enum {
+	Idle    = 0, // Wipe is not animating
+	Closing = 1, // Wipe is closing (covering screen)
+	Opening = 2, // Wipe is opening (revealing screen)
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO
@@ -1215,10 +1216,11 @@ struct WorldMapConfirmMgr {
 /**
  * @brief Course point manager operational modes
  */
-DEFINE_ENUM_TYPE(CoursePointMode,
-                 Operation = 0, // Normal user interaction mode
-                 Appear    = 1, // Course point appearance animation
-);
+BEGIN_ENUM_TYPE(CoursePointMode)
+enum {
+	Operation = 0, // Normal user interaction mode
+	Appear    = 1, // Course point appearance animation
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO
@@ -1453,11 +1455,12 @@ struct WorldMapCoursePointMgr {
 /**
  * @brief Map image display states
  */
-DEFINE_ENUM_TYPE(MapImageState,
-                 Shown   = 0, // Map image is fully visible
-                 Closing = 1, // Map image is animating out
-                 Opening = 2, // Map image is animating in
-);
+BEGIN_ENUM_TYPE(MapImageState)
+enum {
+	Shown   = 0, // Map image is fully visible
+	Closing = 1, // Map image is animating out
+	Opening = 2, // Map image is animating in
+} END_ENUM_TYPE;
 
 /**
  * @brief TODO


### PR DESCRIPTION
`BEGIN_ENUM_TYPE` + `END_ENUM_TYPE` plays nicer with clang-format and are, imo, more elegant.