### PR TITLE
update github actions in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     # Checkout the repository (shallow clone)
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: recursive
@@ -51,14 +51,14 @@ jobs:
 
     # Upload map files
     - name: Upload map
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.version }}_maps
         path: build/${{ matrix.version }}/**/*.MAP
 
     # Upload progress report
     - name: Upload report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.version }}_report
         path: build/${{ matrix.version }}/report.json


### PR DESCRIPTION
Update github actions to latest versions

GitHub will force actions to run on node 24 on September 16th, 2026: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/