### PR TITLE
DLL Decomp In A Post DOL Matching World: Tread Carefully!

### DIFF
--- a/include/CoreNode.h
+++ b/include/CoreNode.h
@@ -126,4 +126,8 @@ public:
 #define FOREACH_NODE(type, first, varname) \
 	for (type* varname = static_cast<type*>(first); varname; varname = static_cast<type*>(varname->mNext))
 
+// Sometimes a `CoreNode` derivate pointer gets reused and that affects matching.
+#define FOREACH_NODE_REUSE(type, first, varname) \
+	for (varname = static_cast<type*>(first); varname; varname = static_cast<type*>(varname->mNext))
+
 #endif

--- a/include/KMath.h
+++ b/include/KMath.h
@@ -55,8 +55,8 @@ bool isNan(f32 x);
 void makePostureMatrix(immut Vector3f& col0, immut Vector3f& col1, immut Vector3f& col2, Matrix4f& outMtx);
 f32 calcImpulse(immut Vector3f& relativePos, f32 mass, immut Vector3f& collisionNormal, immut Matrix4f& inertiaTensor,
                 immut Vector3f& relativeVel, immut Vector3f& separationVel);
-Vector3f CRSpline(f32 t, immut Vector3f* ctrlPts);
-Vector3f CRSplineTangent(f32 t, immut Vector3f* ctrlPts);
+Vector3f CRSpline(f32 t, immut Vector3f* const ctrlPts);
+Vector3f CRSplineTangent(f32 t, immut Vector3f* const ctrlPts);
 Vector3f getThrowVelocity(immut Vector3f& startPos, f32 horizSpeed, immut Vector3f& targetPos, Vector3f NRef targetDir);
 f32 getCameraSafeAngle(immut Vector3f& cameraPos, f32 checkDistance, f32 heightWeighting);
 

--- a/include/NsMath.h
+++ b/include/NsMath.h
@@ -6,7 +6,7 @@
 #include "types.h"
 
 struct NsCalculation {
-	static void calcLagrange(f32, const Vector3f*, Vector3f&);
+	static void calcLagrange(f32, const Vector3f* const, Vector3f&);
 	static void calcMatrix(const Vector3f&, const Vector3f&, const Vector3f&, const Vector3f&, Matrix4f&);
 	static void calcMatrix3f(const Vector3f&, const Vector3f&, const Vector3f&, Matrix3f&);
 	static void calcJointPos(const Vector3f&, const Vector3f&, f32, f32, Vector3f&, Vector3f&);
@@ -60,7 +60,7 @@ struct NsLibMath {
 	static T revice(T value, T min, T max) { return (value < min) ? min : (value > max) ? max : value; }
 
 	// these just exist for f32
-	static T lagrange3(const T* points, T val)
+	static T lagrange3(immut T* const points, T val)
 	{
 		return points[0] * 0.5f * (val - 1.0f) * (val - 2.0f) - points[1] * val * (val - 2.0f) + points[2] * 0.5f * val * (val - 1.0f);
 	}

--- a/include/PSU/LinkList.h
+++ b/include/PSU/LinkList.h
@@ -58,7 +58,7 @@ template <typename T>
 class PSULink : public PSUPtrLink {
 public:
 	inline PSULink(T* object)
-	    : PSUPtrLink((void*)object)
+	    : PSUPtrLink(static_cast<void*>(object))
 	{
 	}
 
@@ -80,8 +80,8 @@ public:
 	~PSUList() { } // unused/inlined
 
 	// only DLL inlines:
-	bool append(PSULink<T>* link) { return PSUPtrList::append((PSUPtrLink*)link); }
-	bool remove(PSULink<T>* link) { return PSUPtrList::remove((PSUPtrLink*)link); }
+	bool append(PSULink<T>* link) { return PSUPtrList::append(link); }
+	bool remove(PSULink<T>* link) { return PSUPtrList::remove(link); }
 
 	// _00-_0C = PSUPtrList
 };

--- a/include/PSU/Tree.h
+++ b/include/PSU/Tree.h
@@ -20,13 +20,13 @@ public:
 
 	~PSUTree() { }
 
-	PSUTree<T>* getFirstChild() const { return (PSUTree<T>*)PSUList<T>::getFirstLink(); }
+	PSUTree<T>* getFirstChild() const { return static_cast<PSUTree<T>*>(PSUList<T>::getFirstLink()); }
 	PSUTree<T>* getEndChild() const { return nullptr; }
-	PSUTree<T>* getNextChild() const { return (PSUTree<T>*)PSULink<T>::mNext; }
-	T* getObject() const { return (T*)PSULink<T>::mObject; }
+	PSUTree<T>* getNextChild() const { return static_cast<PSUTree<T>*>(PSULink<T>::mNext); }
+	T* getObject() const { return static_cast<T*>(PSULink<T>::mObject); }
 
 	bool appendChild(PSUTree<T>* child) { return PSUList<T>::append(child); }
-	PSUTree<T>* getParent() const { return (PSUTree<T>*)PSULink<T>::mList; }
+	PSUTree<T>* getParent() const { return static_cast<PSUTree<T>*>(PSULink<T>::mList); }
 
 	// DLL inlines to do:
 	bool removeChild(PSUTree<T>* child) { return PSUList<T>::remove(child); }

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -25,7 +25,7 @@ public:
 	 * @brief Construct a new ID from an input string.
 	 * @param id String to convert to a fourcc ID.
 	 */
-	ayuID(immut char* id) { Set(id); }
+	ayuID(immut char* const id) { Set(id); }
 
 	/**
 	 * @brief Converts a string to a fourcc ID and sets it as the ID.

--- a/include/RadarInfo.h
+++ b/include/RadarInfo.h
@@ -40,7 +40,7 @@ public:
 	void detachParts(Creature*);
 
 	// DLL inlines:
-	PartsInfo* getFirst() { return (PartsInfo*)mAlivePartsList.mChild; }
+	PartsInfo* getFirst() { return static_cast<PartsInfo*>(mAlivePartsList.mChild); }
 
 	PartsInfo mAlivePartsList; // _00
 	PartsInfo mDeadPartsList;  // _18

--- a/include/Route.h
+++ b/include/Route.h
@@ -249,9 +249,9 @@ protected:
  */
 BEGIN_ENUM_TYPE(PathFinderMode)
 enum {
-	None       = 0,      // No special pathfinding mode
-	AvoidWater = 1 << 0, // Avoid water waypoints when pathfinding
-	Unk2       = 1 << 1, // Avoid specific waypoint index
+	None          = 0,      // No special pathfinding mode
+	AvoidWater    = 1 << 0, // Avoid water waypoints when pathfinding
+	AvoidOwnIndex = 1 << 1, // Avoid own waypoint index when pathfinding
 } END_ENUM_TYPE;
 
 /**

--- a/include/Spider.h
+++ b/include/Spider.h
@@ -255,7 +255,7 @@ private:
 	void setHalfDeadEffect(u32, int, int);
 	void setHalfDeadFallEffect(u32);
 	void setDeadBombEffect(u32);
-	void setSmallSparkEffect(u32, int*);
+	void setSmallSparkEffect(u32, int* const);
 	void setPerishEffect(u32, int);
 	void setLegParameter();
 	void setWalkNewParameter();

--- a/include/UtilityKando.h
+++ b/include/UtilityKando.h
@@ -56,7 +56,7 @@ int selectRandomly(immut Choice* choiceList, int numChoices);
 void drawBatten(Graphics&, immut Vector3f&, f32);
 void drawBattenPole(Graphics&, immut Vector3f&, f32, immut char*);
 void drawArrow(Graphics&, immut Vector3f&, immut Vector3f&, f32);
-void CRSplineDraw(Graphics&, int, immut Vector3f*);
+void CRSplineDraw(Graphics&, int, immut Vector3f* const);
 void drawCube(Graphics&, immut Vector3f&, f32);
 
 #endif

--- a/include/nlib/Array.h
+++ b/include/nlib/Array.h
@@ -71,7 +71,6 @@ struct NArray {
 		for (int i = 0; i < numToRemove; i++) {
 			mArray[startIdx + i] = nullptr;
 		}
-
 		for (int i = 0; i < mCount - (startIdx + numToRemove); i++) {
 			mArray[startIdx + i] = mArray[numToRemove + i];
 		}

--- a/include/nlib/Array.h
+++ b/include/nlib/Array.h
@@ -68,10 +68,11 @@ struct NArray {
 	}
 	virtual void remove(int startIdx, int numToRemove) // _20
 	{
-		for (int i = 0; i < numToRemove; i++) {
+		int i;
+		for (i = 0; i < numToRemove; i++) {
 			mArray[startIdx + i] = nullptr;
 		}
-		for (int i = 0; i < mCount - (startIdx + numToRemove); i++) {
+		for (i = 0; i < mCount - (startIdx + numToRemove); i++) {
 			mArray[startIdx + i] = mArray[numToRemove + i];
 		}
 		mCount -= numToRemove;

--- a/include/nlib/Function.h
+++ b/include/nlib/Function.h
@@ -52,7 +52,7 @@ struct NLinearFunction : public NPolynomialFunction {
 	NLinearFunction(f32* const); // unused/inlined
 
 	// unused/inlined:
-	void construct(f32*);
+	void construct(f32* const);
 	void makeLinearFunction(f32, f32, f32, f32);
 
 	// _00     = VTBL

--- a/include/nlib/Geometry.h
+++ b/include/nlib/Geometry.h
@@ -108,7 +108,7 @@ public:
 	NMatrix4f();
 	NMatrix4f(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32);
 	NMatrix4f(immut Matrix4f&); // unused/inlined
-	NMatrix4f(immut Mtx);       // unused/inlined
+	NMatrix4f(immut Mtx44);     // unused/inlined
 
 	void construct(immut Matrix4f&);
 	void input(immut Matrix4f&);
@@ -118,9 +118,9 @@ public:
 
 	// unused/inlined:
 	void construct(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32);
-	void construct(immut Mtx);
-	void input(immut Mtx);
-	void output(Mtx) immut;
+	void construct(immut Mtx44);
+	void input(immut Mtx44);
+	void output(Mtx44) immut;
 	void setRow(int, f32, f32, f32);
 	void inputRow(int, immut Vector3f&);
 	void inputRow(int, immut Vector3f&, f32);

--- a/include/timers.h
+++ b/include/timers.h
@@ -77,7 +77,7 @@ public:
 // For some reason, certain functions cannot have known timers added to them without messing up matching.  At the same time, other functions
 // require known timers to be added in order to match, so it's not like they were *all* originally behind a macro.  This macro aims to solve
 // the first case (timers that cannot exist in retail but did exist in demo versions), but one should avoid these macros whenever possible.
-#if defined(BUILD_MATCHING) && (defined(VERSION_GPIJ01) || defined(VERSION_GPIE01) || defined(VERSION_GPIP01))
+#if defined(BUILD_MATCHING) && !defined(WIN32) && (defined(VERSION_GPIJ01) || defined(VERSION_GPIE01) || defined(VERSION_GPIP01))
 #define MATCHING_START_TIMER(name, p2) TERNARY_BUILD_MATCHING((void)0, gsys->mTimer->start(name, p2))
 #define MATCHING_STOP_TIMER(name)      TERNARY_BUILD_MATCHING((void)0, gsys->mTimer->stop(name))
 #else

--- a/include/types.h
+++ b/include/types.h
@@ -86,6 +86,16 @@ typedef int BOOL;
 // #define DEVELOP
 #endif
 
+// The value of this macro controls the conditional compilation of all uses for JAudio (audio library) in the codebase.
+#ifndef PIKI_USE_JAUDIO
+#define PIKI_USE_JAUDIO TRUE
+#endif
+
+// The value of this macro controls the conditional compilation of all uses for Dolphin GX (graphics API) in the codebase.
+#ifndef PIKI_USE_DGX
+#define PIKI_USE_DGX TRUE
+#endif
+
 // For when you have to pass something as a macro argument that contains commas.
 #define MACRO_ARG(...) __VA_ARGS__
 

--- a/include/zen/DrawContainer.h
+++ b/include/zen/DrawContainer.h
@@ -208,7 +208,7 @@ public:
 	    : P2DPaneCallBack(pane, PANETYPE_Picture)
 	    , ArrowBasicCallBack(pane, container, p3)
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		// There is no file named "ys_u.bti" on the disc, but there is one named "ya_u.bti".
 		pUpTex   = loadTexExp(TERNARY_BUGFIX("ya_u.bti", "ys_u.bti"), true, true);
 		pDownTex = loadTexExp("ya_l.bti", true, true);
@@ -223,7 +223,7 @@ public:
 
 	virtual bool invoke(P2DPane* pane) // _08
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		setTexture(pic);
 		update(pic);
 		return true;
@@ -275,7 +275,7 @@ public:
 	    : P2DPaneCallBack(pane, PANETYPE_Picture)
 	    , ArrowBasicCallBack(pane, container, p3)
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		judgeArrowType();
 		if (mArrowType != ARROW_Both) {
 			pic->setAlpha(0);
@@ -284,7 +284,7 @@ public:
 
 	virtual bool invoke(P2DPane* pane) // _08
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		judgeArrowType();
 		if (mArrowType == ARROW_Both) {
 			active();
@@ -480,7 +480,7 @@ public:
 
 	virtual bool invoke(P2DPane* pane) // _08
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		TexAnim* anim;
 		Texture* tex;
 		if (mContainerScreen->getContainerPikiDisp() > 0) {
@@ -623,8 +623,8 @@ public:
 	{
 		P2DPane* parent;
 
-		P2DTextBox* tBox1 = (P2DTextBox*)screen.search(tag1, true);
-		P2DTextBox* tBox2 = (P2DTextBox*)screen.search(tag2, true);
+		P2DTextBox* tBox1 = static_cast<P2DTextBox*>(screen.search(tag1, true));
+		P2DTextBox* tBox2 = static_cast<P2DTextBox*>(screen.search(tag2, true));
 
 		parent = screen.search('pall', true);
 		P2DPaneLibrary::changeParent(tBox2, parent);

--- a/include/zen/DrawMenu.h
+++ b/include/zen/DrawMenu.h
@@ -81,7 +81,7 @@ public:
 	{
 		bool isNotPic = true;
 		if (iconPane->getTypeID() == PANETYPE_Picture) {
-			mIconLPane = (P2DPicture*)iconPane;
+			mIconLPane = static_cast<P2DPicture*>(iconPane);
 			mIconLPane->hide();
 			P2DPaneLibrary::changeParent(mIconLPane, iconParent);
 			isNotPic = false;
@@ -94,7 +94,7 @@ public:
 	{
 		bool isNotPic = true;
 		if (iconPane->getTypeID() == PANETYPE_Picture) {
-			mIconRPane = (P2DPicture*)iconPane;
+			mIconRPane = static_cast<P2DPicture*>(iconPane);
 			mIconRPane->hide();
 			P2DPaneLibrary::changeParent(mIconRPane, iconParent);
 			isNotPic = false;

--- a/include/zen/MenuPanelMgr.h
+++ b/include/zen/MenuPanelMgr.h
@@ -107,7 +107,7 @@ public:
 
 	void update(P2DPane* pane)
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		f32 t;
 		switch (mPanelMgr->getStatusFlag()) {
 		case MenuPanelMgr::STATE_Wait:

--- a/include/zen/Number.h
+++ b/include/zen/Number.h
@@ -123,10 +123,10 @@ public:
 	void setTexture(P2DPane* pane)
 	{
 		if (mUseShadowTex) {
-			P2DPicture* pic = (P2DPicture*)pane;
+			P2DPicture* pic = static_cast<P2DPicture*>(pane);
 			pic->setTexture(FigureTex<T>::getShadowTexPtr(), 0);
 		} else {
-			P2DPicture* pic = (P2DPicture*)pane;
+			P2DPicture* pic = static_cast<P2DPicture*>(pane);
 			pic->setTexture(FigureTex<T>::getTexPtr(), 0);
 		}
 	}

--- a/include/zen/ogMessage.h
+++ b/include/zen/ogMessage.h
@@ -47,7 +47,7 @@ public:
 	void setPage(int);
 	void nextPage();
 	void backPage();
-	void MakeAndSetPageInfo(immut char***);
+	void MakeAndSetPageInfo(immut char*** const);
 	void dispAll();
 	void fadeOut();
 	MessageStatus update(Controller*);
@@ -88,7 +88,7 @@ public:
 private:
 	s16 SearchTopPage(int);
 	void setMessagePage(int);
-	s16 makePageInfo(immut char***);
+	s16 makePageInfo(immut char*** const);
 	void cnvSingleMulti(char*);
 	void cnvButtonIcon(char*);
 	void setPageInfoSub();

--- a/src/plugPikiColin/cinePlayer.cpp
+++ b/src/plugPikiColin/cinePlayer.cpp
@@ -725,11 +725,11 @@ void ActorInstance::checkEventKeys(f32 curTime, f32 prevTime, Vector3f& pos)
 				case 9:
 				{
 					mMeteorFlag = false;
-					for (int i = 0; i < 4; i++) {
-						for (int j = 0; j < 4; j++) {
-							if (mEffectGrid[i][j]) {
-								effectMgr->kill(mEffectGrid[i][j], false);
-								mEffectGrid[i][j] = nullptr;
+					for (int row = 0; row < 4; row++) {
+						for (int col = 0; col < 4; col++) {
+							if (mEffectGrid[row][col]) {
+								effectMgr->kill(mEffectGrid[row][col], false);
+								mEffectGrid[row][col] = nullptr;
 							}
 						}
 					}
@@ -1554,15 +1554,15 @@ void SceneCut::genCutSection(AgeServer& server)
 		if (key->mEventType == ANIMEVENT_Action) {
 			server.setOnChange(new Delegate1<SceneCut, AgeServer&>(this, ageRefresh));
 			server.StartOptionBox("", &key->mEventCmdID, 90);
-			for (int i = 0; i < demoEventMgr->getSenderMax(); i++) {
-				server.NewOption(demoEventMgr->getSenderName(i), i);
+			for (int senderIdx = 0; senderIdx < demoEventMgr->getSenderMax(); senderIdx++) {
+				server.NewOption(demoEventMgr->getSenderName(senderIdx), senderIdx);
 			}
 			server.EndOptionBox();
 			server.setOnChange((IDelegate*)nullptr);
 
 			server.StartOptionBox("", &key->mKeyType, 80);
-			for (int i = 0; i < demoEventMgr->getEventMax(); i++) {
-				server.NewOption(demoEventMgr->getEventName(key->mEventCmdID, i), i);
+			for (int eventIdx = 0; eventIdx < demoEventMgr->getEventMax(); eventIdx++) {
+				server.NewOption(demoEventMgr->getEventName(key->mEventCmdID, eventIdx), eventIdx);
 			}
 			server.EndOptionBox();
 		} else {

--- a/src/plugPikiColin/dayMgr.cpp
+++ b/src/plugPikiColin/dayMgr.cpp
@@ -903,13 +903,14 @@ void DayMgr::menuDecreaseTime(Menu& parent)
  */
 void DayMgr::refresh(Graphics& gfx, f32 time, int numLights)
 {
+	TimeSetting* timeSettingStart;
+	TimeSetting* timeSettingEnd;
+
 	// cap number of lights at active light count (default: 2)
-	int lights = (numLights < mActiveLightCount) ? numLights : mActiveLightCount;
+	int lightCount = (numLights < mActiveLightCount) ? numLights : mActiveLightCount;
 
 	// get blending parameters based on time of day
 	f32 blendRatio = 0.0f;
-	TimeSetting* timeSettingStart;
-	TimeSetting* timeSettingEnd;
 	if (time == MOVIE_TIME) {
 		// special movie lighting
 		timeSettingStart = timeSettingEnd = &mTimeSettings[TIME_Movie];
@@ -954,11 +955,10 @@ void DayMgr::refresh(Graphics& gfx, f32 time, int numLights)
 		    = (time - gameflow.mParameters->mEveningMid()) / (gameflow.mParameters->mEveningEnd() - gameflow.mParameters->mEveningMid());
 	}
 
-	// lerp lighting and colour settings the appropriate amount between our parameters for all used lights
-	// ambient colour
+	// lerp lighting and colour settings the appropriate amount between our parameters for all used lights ambient colour
 	timeSettingStart->mAmbientColour.lerpTo(timeSettingEnd->mAmbientColour, blendRatio, mCurrentTimeSetting.mAmbientColour);
 
-	for (int i1 = 0; i1 < lights; i1++) {
+	for (int i1 = 0; i1 < lightCount; i1++) {
 		// light colour
 		timeSettingStart->mLights[i1].mDiffuseColour.lerpTo(timeSettingEnd->mLights[i1].mDiffuseColour, blendRatio,
 		                                                    mCurrentTimeSetting.mLights[i1].mDiffuseColour);
@@ -1010,8 +1010,8 @@ void DayMgr::refresh(Graphics& gfx, f32 time, int numLights)
 		mMapMgr->_08.set(mCurrentSunPosition.x / 20.0f, mCurrentSunPosition.y / 5.0f, mCurrentSunPosition.z / 20.0f);
 	}
 
-	//
-	for (int i2 = 0; i2 < lights; i2++) {
+	// Move and rotate lights based on the sun or the captain
+	for (int i2 = 0; i2 < lightCount; i2++) {
 		if (GET_LIGHT_TYPE(mCurrentTimeSetting.mLights[i2].mLightFlag) == LIGHT_Parallel) {
 			// calculate appropriate parallel light directions/positions for sun and underlighting
 			if (!(i2 & 1)) {
@@ -1038,7 +1038,7 @@ void DayMgr::refresh(Graphics& gfx, f32 time, int numLights)
 	}
 
 	// push lights to graphics unit
-	for (int i3 = 0; i3 < lights; i3++) {
+	for (int i3 = 0; i3 < lightCount; i3++) {
 		mCurrentTimeSetting.mLights[i3].update();
 		gfx.addLight(&mCurrentTimeSetting.mLights[i3]);
 	}

--- a/src/plugPikiColin/dayMgr.cpp
+++ b/src/plugPikiColin/dayMgr.cpp
@@ -958,29 +958,29 @@ void DayMgr::refresh(Graphics& gfx, f32 time, int numLights)
 	// ambient colour
 	timeSettingStart->mAmbientColour.lerpTo(timeSettingEnd->mAmbientColour, blendRatio, mCurrentTimeSetting.mAmbientColour);
 
-	for (int i = 0; i < lights; i++) {
+	for (int i1 = 0; i1 < lights; i1++) {
 		// light colour
-		timeSettingStart->mLights[i].mDiffuseColour.lerpTo(timeSettingEnd->mLights[i].mDiffuseColour, blendRatio,
-		                                                   mCurrentTimeSetting.mLights[i].mDiffuseColour);
+		timeSettingStart->mLights[i1].mDiffuseColour.lerpTo(timeSettingEnd->mLights[i1].mDiffuseColour, blendRatio,
+		                                                    mCurrentTimeSetting.mLights[i1].mDiffuseColour);
 
 		// light types
-		mCurrentTimeSetting.mLights[i].mLightFlag = timeSettingStart->mLights[i].mLightFlag;
-		mCurrentTimeSetting.mLightMoveTypes[i]    = timeSettingStart->mLightMoveTypes[i];
+		mCurrentTimeSetting.mLights[i1].mLightFlag = timeSettingStart->mLights[i1].mLightFlag;
+		mCurrentTimeSetting.mLightMoveTypes[i1]    = timeSettingStart->mLightMoveTypes[i1];
 
 		// light ranges/angles/positions/directions
-		mCurrentTimeSetting.mLights[i].mDistancedRange
-		    = timeSettingStart->mLights[i].mDistancedRange
-		    + (timeSettingEnd->mLights[i].mDistancedRange - timeSettingStart->mLights[i].mDistancedRange) * blendRatio;
+		mCurrentTimeSetting.mLights[i1].mDistancedRange
+		    = timeSettingStart->mLights[i1].mDistancedRange
+		    + (timeSettingEnd->mLights[i1].mDistancedRange - timeSettingStart->mLights[i1].mDistancedRange) * blendRatio;
 
-		mCurrentTimeSetting.mLights[i].mSpotAngle
-		    = timeSettingStart->mLights[i].mSpotAngle
-		    + (timeSettingEnd->mLights[i].mSpotAngle - timeSettingStart->mLights[i].mSpotAngle) * blendRatio;
+		mCurrentTimeSetting.mLights[i1].mSpotAngle
+		    = timeSettingStart->mLights[i1].mSpotAngle
+		    + (timeSettingEnd->mLights[i1].mSpotAngle - timeSettingStart->mLights[i1].mSpotAngle) * blendRatio;
 
-		timeSettingStart->mLights[i].mPosition.lerpTo(timeSettingEnd->mLights[i].mPosition, blendRatio,
-		                                              mCurrentTimeSetting.mLights[i].mPosition);
+		timeSettingStart->mLights[i1].mPosition.lerpTo(timeSettingEnd->mLights[i1].mPosition, blendRatio,
+		                                               mCurrentTimeSetting.mLights[i1].mPosition);
 
-		timeSettingStart->mLights[i].mDirection.lerpTo(timeSettingEnd->mLights[i].mDirection, blendRatio,
-		                                               mCurrentTimeSetting.mLights[i].mDirection);
+		timeSettingStart->mLights[i1].mDirection.lerpTo(timeSettingEnd->mLights[i1].mDirection, blendRatio,
+		                                                mCurrentTimeSetting.mLights[i1].mDirection);
 	}
 
 	// lerp fog settings
@@ -1011,36 +1011,36 @@ void DayMgr::refresh(Graphics& gfx, f32 time, int numLights)
 	}
 
 	//
-	for (int i = 0; i < lights; i++) {
-		if (GET_LIGHT_TYPE(mCurrentTimeSetting.mLights[i].mLightFlag) == LIGHT_Parallel) {
+	for (int i2 = 0; i2 < lights; i2++) {
+		if (GET_LIGHT_TYPE(mCurrentTimeSetting.mLights[i2].mLightFlag) == LIGHT_Parallel) {
 			// calculate appropriate parallel light directions/positions for sun and underlighting
-			if (!(i & 1)) {
+			if (!(i2 & 1)) {
 				// even-numbered lights (main, +1, +3, +5) - sun
-				mCurrentTimeSetting.mLights[i].mPosition.set(mCurrentSunPosition.x, mCurrentSunPosition.y, mCurrentSunPosition.z);
-				mCurrentTimeSetting.mLights[i].mDirection.set(-mCurrentSunPosition.x, -mCurrentSunPosition.y, -mCurrentSunPosition.z);
-				mCurrentTimeSetting.mLights[i].mDirection.normalise();
+				mCurrentTimeSetting.mLights[i2].mPosition.set(mCurrentSunPosition.x, mCurrentSunPosition.y, mCurrentSunPosition.z);
+				mCurrentTimeSetting.mLights[i2].mDirection.set(-mCurrentSunPosition.x, -mCurrentSunPosition.y, -mCurrentSunPosition.z);
+				mCurrentTimeSetting.mLights[i2].mDirection.normalise();
 			} else {
 				// odd-numbered lights (sub, +2, +4) - underlighting
-				mCurrentTimeSetting.mLights[i].mPosition.set(-mCurrentSunPosition.x, -mCurrentSunPosition.y, -mCurrentSunPosition.z);
-				mCurrentTimeSetting.mLights[i].mDirection.set(mCurrentSunPosition.x, mCurrentSunPosition.y, mCurrentSunPosition.z);
-				mCurrentTimeSetting.mLights[i].mDirection.normalise();
+				mCurrentTimeSetting.mLights[i2].mPosition.set(-mCurrentSunPosition.x, -mCurrentSunPosition.y, -mCurrentSunPosition.z);
+				mCurrentTimeSetting.mLights[i2].mDirection.set(mCurrentSunPosition.x, mCurrentSunPosition.y, mCurrentSunPosition.z);
+				mCurrentTimeSetting.mLights[i2].mDirection.normalise();
 			}
-		} else if (mCurrentTimeSetting.mLightMoveTypes[i] == LIGHTMOVE_AttachToNavi && naviMgr && naviMgr->getNavi()) {
+		} else if (mCurrentTimeSetting.mLightMoveTypes[i2] == LIGHTMOVE_AttachToNavi && naviMgr && naviMgr->getNavi()) {
 			// (non-parallel) light moves with captain, calculate directions and positions
 			// calc rotation in navi local coordinates, then move with navi
 			Matrix4f naviLocalMtx;
 			naviLocalMtx.makeSRT(Vector3f(1.0f, 1.0f, 1.0f), Vector3f(0.0f, naviMgr->getNavi()->mFaceDirection, 0.0f),
 			                     Vector3f(0.0f, 0.0f, 0.0f));
-			mCurrentTimeSetting.mLights[i].mDirection.rotate(naviLocalMtx);
-			mCurrentTimeSetting.mLights[i].mPosition.rotate(naviLocalMtx);
-			mCurrentTimeSetting.mLights[i].mPosition.add(naviMgr->getNavi()->mSRT.t);
+			mCurrentTimeSetting.mLights[i2].mDirection.rotate(naviLocalMtx);
+			mCurrentTimeSetting.mLights[i2].mPosition.rotate(naviLocalMtx);
+			mCurrentTimeSetting.mLights[i2].mPosition.add(naviMgr->getNavi()->mSRT.t);
 		}
 	}
 
 	// push lights to graphics unit
-	for (int i = 0; i < lights; i++) {
-		mCurrentTimeSetting.mLights[i].update();
-		gfx.addLight(&mCurrentTimeSetting.mLights[i]);
+	for (int i3 = 0; i3 < lights; i3++) {
+		mCurrentTimeSetting.mLights[i3].update();
+		gfx.addLight(&mCurrentTimeSetting.mLights[i3]);
 	}
 
 	// push fog settings to graphics unit

--- a/src/plugPikiColin/dynsimulator.cpp
+++ b/src/plugPikiColin/dynsimulator.cpp
@@ -275,48 +275,50 @@ void RigidBody::applyGroundForces(int configIdx, CollGroup* collGroup)
 
 		// check each supplied triangle for a collision
 		for (int triIdx = 0; !skipCollCalc && triIdx < collGroup->mTriCount; triIdx++) {
-			CollTriInfo* triangle  = collGroup->mTriangleList[triIdx];
-			Plane* triPlane        = &triangle->mTriangle;
-			immut Vector3f& comPos = config.mPosition;
+			CollTriInfo* triangle = collGroup->mTriangleList[triIdx];
+			Plane* triPlane       = &triangle->mTriangle;
+			if (true) {
+				immut Vector3f& comPos = config.mPosition;
 
-			f32 boundingPtDist = triPlane->dist(boundingPtPos);
-			f32 comDist        = triPlane->dist(comPos);
+				f32 boundingPtDist = triPlane->dist(boundingPtPos);
+				f32 comDist        = triPlane->dist(comPos);
 
-			// if bounding point is "below" the ground and center of mass if "above" the ground, we're colliding
-			if (boundingPtDist < 0.0f && comDist > 0.0f) {
-				// calc intersection point between object line (CoM to bounding point) and triangle plane
-				f32 intersectRatio = boundingPtDist / (boundingPtDist - comDist);
-				Vector3f intersectPt((comPos.x - boundingPtPos.x) * intersectRatio + boundingPtPos.x,
-				                     (comPos.y - boundingPtPos.y) * intersectRatio + boundingPtPos.y,
-				                     (comPos.z - boundingPtPos.z) * intersectRatio + boundingPtPos.z);
+				// if bounding point is "below" the ground and center of mass if "above" the ground, we're colliding
+				if (boundingPtDist < 0.0f && comDist > 0.0f) {
+					// calc intersection point between object line (CoM to bounding point) and triangle plane
+					f32 intersectRatio = boundingPtDist / (boundingPtDist - comDist);
+					Vector3f intersectPt((comPos.x - boundingPtPos.x) * intersectRatio + boundingPtPos.x,
+					                     (comPos.y - boundingPtPos.y) * intersectRatio + boundingPtPos.y,
+					                     (comPos.z - boundingPtPos.z) * intersectRatio + boundingPtPos.z);
 
-				STACK_PAD_VAR(1);
-
-				// check if intersection point is inside the triangle
-				bool isInsideTri = true;
-				for (int edgeIdx = 0; isInsideTri && edgeIdx < 3; edgeIdx++) {
-					if (triangle->mEdgePlanes[edgeIdx].dist(intersectPt) < 0.0f) {
-						isInsideTri = false;
+					// check if intersection point is inside the triangle
+					bool isInsideTri = true;
+					for (int edgeIdx = 0; isInsideTri && edgeIdx < 3; edgeIdx++) {
+						f32 dist = triangle->mEdgePlanes[edgeIdx].dist(intersectPt);
+						if (dist < 0.0f) {
+							isInsideTri = false;
+						}
 					}
-				}
 
-				if (isInsideTri) {
-					// compute (linear + angular) velocity at bounding point
-					Vector3f offsetToBoundingPt = boundingPtPos - config.mPosition;
-					Vector3f boundingPtVel(config.mAngularVel);
-					boundingPtVel.CP(offsetToBoundingPt);
-					boundingPtVel.x += config.mLinearVel.x;
-					boundingPtVel.y += config.mLinearVel.y;
-					boundingPtVel.z += config.mLinearVel.z;
+					if (isInsideTri) {
+						// compute (linear + angular) velocity at bounding point
+						Vector3f offsetToBoundingPt = boundingPtPos - config.mPosition;
+						Vector3f boundingPtVel(config.mAngularVel);
+						boundingPtVel.CP(offsetToBoundingPt);
+						boundingPtVel.x += config.mLinearVel.x;
+						boundingPtVel.y += config.mLinearVel.y;
+						boundingPtVel.z += config.mLinearVel.z;
 
-					// if we're moving toward the triangle, apply collision response and friction
-					if (boundingPtVel.DP(triPlane->mNormal) < 0.0f) {
-						mBoundingPointHitCounts[vert2]++;
-						Collision coll;
-						coll.mContactPoint = intersectPt;
-						coll.mNormal       = triPlane->mNormal;
-						resolveCollisions(configIdx, coll);
-						applyBodyFriction(configIdx, triPlane->mNormal, intersectPt, boundingPtVel);
+						// if we're moving toward the triangle, apply collision response and friction
+						if (boundingPtVel.DP(triPlane->mNormal) < 0.0f) {
+							mBoundingPointHitCounts[vert2]++;
+							Collision coll;
+							coll.mContactPoint = intersectPt;
+							coll.mNormal       = triPlane->mNormal;
+							resolveCollisions(configIdx, coll);
+							applyBodyFriction(configIdx, triPlane->mNormal, intersectPt, boundingPtVel);
+							continue;
+						}
 					}
 				}
 			}
@@ -432,10 +434,10 @@ void DynSimulator::resetWorld()
  */
 void DynSimulator::doSimulation(f32 totalTime, f32 maxTimeStep, Shape* mapModel)
 {
-	f32 remainingTime, dt;
-	for (remainingTime = totalTime; remainingTime > 0.0f; remainingTime -= dt) {
-		dt = remainingTime;
-		if (remainingTime > maxTimeStep) {
+	f32 remainingTime = totalTime;
+	while (remainingTime > 0.0f) {
+		f32 dt = remainingTime;
+		if (dt > maxTimeStep) {
 			dt = maxTimeStep;
 		}
 		if (!isPaused()) {
@@ -468,6 +470,7 @@ void DynSimulator::doSimulation(f32 totalTime, f32 maxTimeStep, Shape* mapModel)
 			// advance config state to use for next calculations
 			mCurrentConfigIdx ^= 1;
 		}
+		remainingTime -= dt;
 	}
 
 	FOREACH_NODE(RigidBody, mChild, body)

--- a/src/plugPikiColin/dynsimulator.cpp
+++ b/src/plugPikiColin/dynsimulator.cpp
@@ -446,15 +446,16 @@ void DynSimulator::doSimulation(f32 totalTime, f32 maxTimeStep, Shape* mapModel)
 			// 4. calculate all vertices
 			// 5. reset accelerations
 
-			FOREACH_NODE(RigidBody, mChild, body)
+			RigidBody* body;
+			FOREACH_NODE_REUSE(RigidBody, mChild, body)
 			{
 				body->initCollisions(mCurrentConfigIdx);
 			}
-			FOREACH_NODE(RigidBody, mChild, body)
+			FOREACH_NODE_REUSE(RigidBody, mChild, body)
 			{
 				body->computeForces(mCurrentConfigIdx, dt);
 			}
-			FOREACH_NODE(RigidBody, mChild, body)
+			FOREACH_NODE_REUSE(RigidBody, mChild, body)
 			{
 				body->integrate(mCurrentConfigIdx, mCurrentConfigIdx ^ 1, dt);
 				body->calculateVertices(mCurrentConfigIdx ^ 1);

--- a/src/plugPikiColin/dynsimulator.cpp
+++ b/src/plugPikiColin/dynsimulator.cpp
@@ -96,9 +96,9 @@ void RigidBody::initializeBody()
 		updateViewInfo(i, i);
 	}
 
-	for (int i = 0; i < mSpringCount; i++) {
-		Vector3f hookWorldPos = mBodyPoints[mSprings[i].mHookIdx] + mInitPosition;
-		mSprings[i].mAnchorPoint.add(hookWorldPos);
+	for (int springIdx = 0; springIdx < mSpringCount; springIdx++) {
+		Vector3f hookWorldPos = mBodyPoints[mSprings[springIdx].mHookIdx] + mInitPosition;
+		mSprings[springIdx].mAnchorPoint.add(hookWorldPos);
 	}
 }
 
@@ -261,21 +261,21 @@ void RigidBody::applyGroundForces(int configIdx, CollGroup* collGroup)
 	configuration& config = mIntegrationStates[configIdx];
 
 	// reset all bounding point hit counts
-	for (int i = 0; i < mBoundingPointCount; i++) {
-		mBoundingPointHitCounts[i] = 0;
+	for (int vert1 = 0; vert1 < mBoundingPointCount; vert1++) {
+		mBoundingPointHitCounts[vert1] = 0;
 	}
 
 	// check for ground collision for each bounding point
-	for (int i = 0; i < mBoundingPointCount; i++) {
-		immut Vector3f& boundingPtPos = config.mBodyPoints[i + mHookPointCount];
+	for (int vert2 = 0; vert2 < mBoundingPointCount; vert2++) {
+		immut Vector3f& boundingPtPos = config.mBodyPoints[vert2 + mHookPointCount];
 
 		// only do collision calculations if we have collision triangles to check
 		// (weird way to do this check but fine)
 		bool skipCollCalc = collGroup ? false : true;
 
 		// check each supplied triangle for a collision
-		for (int j = 0; !skipCollCalc && j < collGroup->mTriCount; j++) {
-			CollTriInfo* triangle  = collGroup->mTriangleList[j];
+		for (int triIdx = 0; !skipCollCalc && triIdx < collGroup->mTriCount; triIdx++) {
+			CollTriInfo* triangle  = collGroup->mTriangleList[triIdx];
 			Plane* triPlane        = &triangle->mTriangle;
 			immut Vector3f& comPos = config.mPosition;
 
@@ -294,8 +294,8 @@ void RigidBody::applyGroundForces(int configIdx, CollGroup* collGroup)
 
 				// check if intersection point is inside the triangle
 				bool isInsideTri = true;
-				for (int k = 0; isInsideTri && k < 3; k++) {
-					if (triangle->mEdgePlanes[k].dist(intersectPt) < 0.0f) {
+				for (int edgeIdx = 0; isInsideTri && edgeIdx < 3; edgeIdx++) {
+					if (triangle->mEdgePlanes[edgeIdx].dist(intersectPt) < 0.0f) {
 						isInsideTri = false;
 					}
 				}
@@ -311,7 +311,7 @@ void RigidBody::applyGroundForces(int configIdx, CollGroup* collGroup)
 
 					// if we're moving toward the triangle, apply collision response and friction
 					if (boundingPtVel.DP(triPlane->mNormal) < 0.0f) {
-						mBoundingPointHitCounts[i]++;
+						mBoundingPointHitCounts[vert2]++;
 						Collision coll;
 						coll.mContactPoint = intersectPt;
 						coll.mNormal       = triPlane->mNormal;
@@ -324,9 +324,9 @@ void RigidBody::applyGroundForces(int configIdx, CollGroup* collGroup)
 	}
 
 	// debug print to check if any bounding points have gotten hit more than once
-	for (int i = 0; i < mBoundingPointCount; i++) {
-		if (mBoundingPointHitCounts[i] > 1) {
-			PRINT("vert %d hit %d times\n", i, mBoundingPointHitCounts[i]);
+	for (int vert3 = 0; vert3 < mBoundingPointCount; vert3++) {
+		if (mBoundingPointHitCounts[vert3] > 1) {
+			PRINT("vert %d hit %d times\n", vert3, mBoundingPointHitCounts[vert3]);
 		}
 	}
 }

--- a/src/plugPikiColin/gamePrefs.cpp
+++ b/src/plugPikiColin/gamePrefs.cpp
@@ -214,8 +214,10 @@ void GamePrefs::getChallengeScores(GameChalQuickInfo& info)
  */
 void GamePrefs::checkIsHiscore(GameChalQuickInfo& info)
 {
-	info.mRank         = -1;
-	gsys->mTogglePrint = TRUE; // "you're gonna wanna hear about this"
+	info.mRank = -1;
+
+	bool oldTogglePrint = gsys->mTogglePrint;
+	gsys->mTogglePrint  = TRUE; // "you're gonna wanna hear about this"
 
 #if defined(VERSION_PIKIDEMO)
 	// This somehow doesn't generate a function call.  How.
@@ -251,7 +253,7 @@ void GamePrefs::checkIsHiscore(GameChalQuickInfo& info)
 		mHiscores.mChalModeRecords[info.mStageID].mScores[info.mRank] = info.mScore;
 	}
 
-	gsys->mTogglePrint = FALSE; // "back to scheduled programming"
+	gsys->mTogglePrint = TERNARY_BUGFIX(oldTogglePrint, FALSE); // "back to scheduled programming"
 
 	// update the leaderboard stored in the quick info
 	getChallengeScores(info);

--- a/src/plugPikiColin/gamePrefs.cpp
+++ b/src/plugPikiColin/gamePrefs.cpp
@@ -224,7 +224,9 @@ void GamePrefs::checkIsHiscore(GameChalQuickInfo& info)
 	PRINT("checking challenge info for course %d, top scores are :-\n", info.mStageID);
 #endif
 
-	for (int i = 0; i < MAX_HI_SCORES; i++) {
+	int i;
+
+	for (i = 0; i < MAX_HI_SCORES; i++) {
 #if defined(VERSION_PIKIDEMO)
 		// This somehow doesn't generate a function call.  How.
 		_Print("\t[%d] ... %d\n", i, mHiscores.mChalModeRecords[info.mStageID].mScores[i]);
@@ -234,7 +236,7 @@ void GamePrefs::checkIsHiscore(GameChalQuickInfo& info)
 	}
 
 	// check if score is better than any existing hiscores - if so, store its appropriate rank
-	for (int i = 0; i < MAX_HI_SCORES; i++) {
+	for (i = 0; i < MAX_HI_SCORES; i++) {
 		if (info.mScore > mHiscores.mChalModeRecords[info.mStageID].mScores[i]) {
 			info.mRank = i;
 			break;
@@ -269,8 +271,10 @@ void GamePrefs::checkIsHiscore(GameQuickInfo& info)
 	info.mDeadPikisRank = -1;
 	info.mPartsDaysRank = -1;
 
+	int i;
+
 	// check parts and days - priority is parts, then break ties with lower day count
-	for (int i = 0; i < MAX_HI_SCORES; i++) {
+	for (i = 0; i < MAX_HI_SCORES; i++) {
 		if (info.mParts > mHiscores.mMinDayRecords[i].mNumParts) {
 			info.mPartsDaysRank = i;
 			break;
@@ -293,7 +297,7 @@ void GamePrefs::checkIsHiscore(GameQuickInfo& info)
 	}
 
 	// check born pikmin for a new hiscore
-	for (int i = 0; i < MAX_HI_SCORES; i++) {
+	for (i = 0; i < MAX_HI_SCORES; i++) {
 		if (info.mBornPikis > mHiscores.mBornPikminRecords[i].mNumBorn) {
 			info.mBornPikisRank = i;
 			break;
@@ -310,7 +314,7 @@ void GamePrefs::checkIsHiscore(GameQuickInfo& info)
 
 	// NOTE: we only check/update dead pikmin ranking if we finish the ship!
 	if (info.mParts == MAX_UFO_PARTS) {
-		for (int i = 0; i < MAX_HI_SCORES; i++) {
+		for (i = 0; i < MAX_HI_SCORES; i++) {
 			if (info.mDeadPikis < mHiscores.mDeadPikminRecords[i].mNumDead) {
 				info.mDeadPikisRank = i;
 				break;

--- a/src/plugPikiColin/gamePrefs.cpp
+++ b/src/plugPikiColin/gamePrefs.cpp
@@ -202,8 +202,8 @@ void GamePrefs::setChildMode(bool set)
  */
 void GamePrefs::getChallengeScores(GameChalQuickInfo& info)
 {
-	for (int i = 0; i < MAX_HI_SCORES; i++) {
-		info.mCourseScores[i] = mHiscores.mChalModeRecords[info.mStageID].mScores[i];
+	for (int rank = 0; rank < MAX_HI_SCORES; rank++) {
+		info.mCourseScores[rank] = mHiscores.mChalModeRecords[info.mStageID].mScores[rank];
 	}
 }
 
@@ -224,21 +224,21 @@ void GamePrefs::checkIsHiscore(GameChalQuickInfo& info)
 	PRINT("checking challenge info for course %d, top scores are :-\n", info.mStageID);
 #endif
 
-	int i;
+	int rank;
 
-	for (i = 0; i < MAX_HI_SCORES; i++) {
+	for (rank = 0; rank < MAX_HI_SCORES; rank++) {
 #if defined(VERSION_PIKIDEMO)
 		// This somehow doesn't generate a function call.  How.
-		_Print("\t[%d] ... %d\n", i, mHiscores.mChalModeRecords[info.mStageID].mScores[i]);
+		_Print("\t[%d] ... %d\n", rank, mHiscores.mChalModeRecords[info.mStageID].mScores[rank]);
 #else
-		PRINT("\t[%d] ... %d\n", i, mHiscores.mChalModeRecords[info.mStageID].mScores[i]);
+		PRINT("\t[%d] ... %d\n", rank, mHiscores.mChalModeRecords[info.mStageID].mScores[rank]);
 #endif
 	}
 
 	// check if score is better than any existing hiscores - if so, store its appropriate rank
-	for (i = 0; i < MAX_HI_SCORES; i++) {
-		if (info.mScore > mHiscores.mChalModeRecords[info.mStageID].mScores[i]) {
-			info.mRank = i;
+	for (rank = 0; rank < MAX_HI_SCORES; rank++) {
+		if (info.mScore > mHiscores.mChalModeRecords[info.mStageID].mScores[rank]) {
+			info.mRank = rank;
 			break;
 		}
 	}
@@ -271,17 +271,17 @@ void GamePrefs::checkIsHiscore(GameQuickInfo& info)
 	info.mDeadPikisRank = -1;
 	info.mPartsDaysRank = -1;
 
-	int i;
+	int rank;
 
 	// check parts and days - priority is parts, then break ties with lower day count
-	for (i = 0; i < MAX_HI_SCORES; i++) {
-		if (info.mParts > mHiscores.mMinDayRecords[i].mNumParts) {
-			info.mPartsDaysRank = i;
+	for (rank = 0; rank < MAX_HI_SCORES; rank++) {
+		if (info.mParts > mHiscores.mMinDayRecords[rank].mNumParts) {
+			info.mPartsDaysRank = rank;
 			break;
 		}
 
-		if (info.mParts == mHiscores.mMinDayRecords[i].mNumParts && info.mDay <= mHiscores.mMinDayRecords[i].mNumDays) {
-			info.mPartsDaysRank = i;
+		if (info.mParts == mHiscores.mMinDayRecords[rank].mNumParts && info.mDay <= mHiscores.mMinDayRecords[rank].mNumDays) {
+			info.mPartsDaysRank = rank;
 			break;
 		}
 	}
@@ -297,9 +297,9 @@ void GamePrefs::checkIsHiscore(GameQuickInfo& info)
 	}
 
 	// check born pikmin for a new hiscore
-	for (i = 0; i < MAX_HI_SCORES; i++) {
-		if (info.mBornPikis > mHiscores.mBornPikminRecords[i].mNumBorn) {
-			info.mBornPikisRank = i;
+	for (rank = 0; rank < MAX_HI_SCORES; rank++) {
+		if (info.mBornPikis > mHiscores.mBornPikminRecords[rank].mNumBorn) {
+			info.mBornPikisRank = rank;
 			break;
 		}
 	}
@@ -314,9 +314,9 @@ void GamePrefs::checkIsHiscore(GameQuickInfo& info)
 
 	// NOTE: we only check/update dead pikmin ranking if we finish the ship!
 	if (info.mParts == MAX_UFO_PARTS) {
-		for (i = 0; i < MAX_HI_SCORES; i++) {
-			if (info.mDeadPikis < mHiscores.mDeadPikminRecords[i].mNumDead) {
-				info.mDeadPikisRank = i;
+		for (rank = 0; rank < MAX_HI_SCORES; rank++) {
+			if (info.mDeadPikis < mHiscores.mDeadPikminRecords[rank].mNumDead) {
+				info.mDeadPikisRank = rank;
 				break;
 			}
 		}

--- a/src/plugPikiColin/gamePrefs.cpp
+++ b/src/plugPikiColin/gamePrefs.cpp
@@ -243,7 +243,7 @@ void GamePrefs::checkIsHiscore(GameChalQuickInfo& info)
 
 	// if we got a new hiscore, shift the current scores and store the new one
 	if (info.mRank >= 0 && info.mRank < MAX_HI_SCORES) {
-		for (int i = 4; i > info.mRank; i--) {
+		for (int i = (MAX_HI_SCORES - 1); i > info.mRank; i--) {
 			mHiscores.mChalModeRecords[info.mStageID].mScores[i] = mHiscores.mChalModeRecords[info.mStageID].mScores[i - 1];
 		}
 		mHiscores.mChalModeRecords[info.mStageID].mScores[info.mRank] = info.mScore;

--- a/src/plugPikiColin/mapMgr.cpp
+++ b/src/plugPikiColin/mapMgr.cpp
@@ -280,8 +280,10 @@ DynMapObject::DynMapObject(MapMgr* map, MapAnimShapeObject* shapeObj)
 	mSRT.r.set(0.0f, 0.0f, 0.0f);
 	mSRT.t.set(0.0f, 0.0f, 0.0f);
 
+	ObjCollInfo* info;
+
 	mPlatObjCount = 0;
-	FOREACH_NODE(ObjCollInfo, mCollisionModel->mCollisionInfo.mParentShape->Child(), info)
+	FOREACH_NODE_REUSE(ObjCollInfo, mCollisionModel->mCollisionInfo.Child(), info)
 	{
 		if (info->mPlatShape) {
 			mPlatObjCount++;
@@ -290,7 +292,7 @@ DynMapObject::DynMapObject(MapMgr* map, MapAnimShapeObject* shapeObj)
 
 	mPlatObjects = new MapObjectPart*[mPlatObjCount];
 	int i        = 0;
-	FOREACH_NODE(ObjCollInfo, mCollisionModel->mCollisionInfo.mParentShape->Child(), info)
+	FOREACH_NODE_REUSE(ObjCollInfo, mCollisionModel->mCollisionInfo.Child(), info)
 	{
 		if (info->mPlatShape) {
 			MapObjectPart* part = new MapObjectPart(info->mPlatShape);

--- a/src/plugPikiColin/mapMgr.cpp
+++ b/src/plugPikiColin/mapMgr.cpp
@@ -71,8 +71,8 @@ void DynCollShape::createDupCollData()
 
 	// dupe joint visibility information
 	mJointVisibility = new bool[mCollisionModel->mJointCount];
-	for (int i = 0; i < mCollisionModel->mJointCount; i++) {
-		mJointVisibility[i] = mCollisionModel->mJointList[i].mVisibilityFlag != Joint::NotVisible;
+	for (int jointIdx = 0; jointIdx < mCollisionModel->mJointCount; jointIdx++) {
+		mJointVisibility[jointIdx] = mCollisionModel->mJointList[jointIdx].mVisibilityFlag != Joint::NotVisible;
 	}
 
 	// almost every model should have at least 1 "room" (group of collision)
@@ -86,8 +86,8 @@ void DynCollShape::createDupCollData()
 	// the only common objects that have more than 1 group are bridges (short have 12, long have 30 - 2 groups per stage)
 	for (int i = 0; i < mCollisionModel->mBaseRoomCount; i++) {
 		int triCount = 0;
-		for (int j = 0; j < mCollisionModel->mTriCount; j++) {
-			if (i == mCollTriList[j].mCollRoomIndex) {
+		for (int triIdx1 = 0; triIdx1 < mCollisionModel->mTriCount; triIdx1++) {
+			if (i == mCollTriList[triIdx1].mCollRoomIndex) {
 				triCount++;
 			}
 		}
@@ -99,9 +99,9 @@ void DynCollShape::createDupCollData()
 
 		// populate triangle list
 		int triIdx = 0;
-		for (int j = 0; j < mCollisionModel->mTriCount; j++) {
-			if (mCollTriList[j].mCollRoomIndex == i) {
-				mCollGroupList[i]->mTriangleList[triIdx] = &mCollTriList[j];
+		for (int triIdx2 = 0; triIdx2 < mCollisionModel->mTriCount; triIdx2++) {
+			if (mCollTriList[triIdx2].mCollRoomIndex == i) {
+				mCollGroupList[i]->mTriangleList[triIdx] = &mCollTriList[triIdx2];
 				triIdx++;
 			}
 		}
@@ -145,29 +145,31 @@ void DynCollShape::updatePos()
 	// shrink box back down so it can be a minimum bound
 	mBoundingBox.resetBound();
 	// transform all vertices
-	for (int i = 0; i < mCollisionModel->mVertexCount; i++) {
-		mVertexList[i].x = mTransformMtx.mMtx[0][0] * mCollisionModel->mVertexList[i].x
-		                 + mTransformMtx.mMtx[0][1] * mCollisionModel->mVertexList[i].y
-		                 + mTransformMtx.mMtx[0][2] * mCollisionModel->mVertexList[i].z + mTransformMtx.mMtx[0][3];
-		mVertexList[i].y = mTransformMtx.mMtx[1][0] * mCollisionModel->mVertexList[i].x
-		                 + mTransformMtx.mMtx[1][1] * mCollisionModel->mVertexList[i].y
-		                 + mTransformMtx.mMtx[1][2] * mCollisionModel->mVertexList[i].z + mTransformMtx.mMtx[1][3];
-		mVertexList[i].z = mTransformMtx.mMtx[2][0] * mCollisionModel->mVertexList[i].x
-		                 + mTransformMtx.mMtx[2][1] * mCollisionModel->mVertexList[i].y
-		                 + mTransformMtx.mMtx[2][2] * mCollisionModel->mVertexList[i].z + mTransformMtx.mMtx[2][3];
-		mBoundingBox.expandBound(mVertexList[i]);
+	for (int vtxIdx = 0; vtxIdx < mCollisionModel->mVertexCount; vtxIdx++) {
+		mVertexList[vtxIdx].x = mTransformMtx.mMtx[0][0] * mCollisionModel->mVertexList[vtxIdx].x
+		                      + mTransformMtx.mMtx[0][1] * mCollisionModel->mVertexList[vtxIdx].y
+		                      + mTransformMtx.mMtx[0][2] * mCollisionModel->mVertexList[vtxIdx].z + mTransformMtx.mMtx[0][3];
+		mVertexList[vtxIdx].y = mTransformMtx.mMtx[1][0] * mCollisionModel->mVertexList[vtxIdx].x
+		                      + mTransformMtx.mMtx[1][1] * mCollisionModel->mVertexList[vtxIdx].y
+		                      + mTransformMtx.mMtx[1][2] * mCollisionModel->mVertexList[vtxIdx].z + mTransformMtx.mMtx[1][3];
+		mVertexList[vtxIdx].z = mTransformMtx.mMtx[2][0] * mCollisionModel->mVertexList[vtxIdx].x
+		                      + mTransformMtx.mMtx[2][1] * mCollisionModel->mVertexList[vtxIdx].y
+		                      + mTransformMtx.mMtx[2][2] * mCollisionModel->mVertexList[vtxIdx].z + mTransformMtx.mMtx[2][3];
+		mBoundingBox.expandBound(mVertexList[vtxIdx]);
 	}
 
 	// transform normals (and edge plane normals)
-	for (int i = 0; i < mCollisionModel->mTriCount; i++) {
-		mCollisionModel->mTriList[i].mTriangle.mNormal.rotateTo(mTransformMtx, mCollTriList[i].mTriangle.mNormal);
-		mCollTriList[i].mTriangle.mNormal.normalise();
-		mCollTriList[i].mTriangle.mOffset = mCollTriList[i].mTriangle.mNormal.DP(mVertexList[mCollTriList[i].mVertexIndices[0]]);
-		for (int j = 0; j < 3; j++) {
-			mCollisionModel->mTriList[i].mEdgePlanes[j].mNormal.rotateTo(mTransformMtx, mCollTriList[i].mEdgePlanes[j].mNormal);
-			mCollTriList[i].mEdgePlanes[j].mNormal.normalise();
-			mCollTriList[i].mEdgePlanes[j].mOffset
-			    = mCollTriList[i].mEdgePlanes[j].mNormal.DP(mVertexList[mCollTriList[i].mVertexIndices[j]]);
+	for (int triIdx = 0; triIdx < mCollisionModel->mTriCount; triIdx++) {
+		mCollisionModel->mTriList[triIdx].mTriangle.mNormal.rotateTo(mTransformMtx, mCollTriList[triIdx].mTriangle.mNormal);
+		mCollTriList[triIdx].mTriangle.mNormal.normalise();
+		mCollTriList[triIdx].mTriangle.mOffset
+		    = mCollTriList[triIdx].mTriangle.mNormal.DP(mVertexList[mCollTriList[triIdx].mVertexIndices[0]]);
+		for (int edgeIdx = 0; edgeIdx < 3; edgeIdx++) {
+			mCollisionModel->mTriList[triIdx].mEdgePlanes[edgeIdx].mNormal.rotateTo(mTransformMtx,
+			                                                                        mCollTriList[triIdx].mEdgePlanes[edgeIdx].mNormal);
+			mCollTriList[triIdx].mEdgePlanes[edgeIdx].mNormal.normalise();
+			mCollTriList[triIdx].mEdgePlanes[edgeIdx].mOffset
+			    = mCollTriList[triIdx].mEdgePlanes[edgeIdx].mNormal.DP(mVertexList[mCollTriList[triIdx].mVertexIndices[edgeIdx]]);
 		}
 	}
 }
@@ -290,8 +292,8 @@ DynMapObject::DynMapObject(MapMgr* map, MapAnimShapeObject* shapeObj)
 		}
 	}
 
-	mPlatObjects = new MapObjectPart*[mPlatObjCount];
-	int i        = 0;
+	mPlatObjects   = new MapObjectPart*[mPlatObjCount];
+	int platObjIdx = 0;
 	FOREACH_NODE_REUSE(ObjCollInfo, mCollisionModel->mCollisionInfo.Child(), info)
 	{
 		if (info->mPlatShape) {
@@ -299,8 +301,8 @@ DynMapObject::DynMapObject(MapMgr* map, MapAnimShapeObject* shapeObj)
 			part->mParentObject = this;
 			part->mJointIndex   = info->mJointIndex;
 			mMapMgr->mCollShapeList->add(part);
-			mPlatObjects[i] = part;
-			i++;
+			mPlatObjects[platObjIdx] = part;
+			platObjIdx++;
 		}
 	}
 }
@@ -1189,10 +1191,11 @@ void MapMgr::initShape()
 	// set up instances for every animated material used by the map model
 	mMapModel->makeInstance(mAnimatedMaterials, 0);
 
-	for (int i = 0; i < mMapModel->mJointCount; i++) {
-		PRINT("got bound (%.1f, %.1f, %.1f) - (%.1f, %.1f, %.1f)\n", mMapModel->mJointList[i].mBounds.mMin.x,
-		      mMapModel->mJointList[i].mBounds.mMin.y, mMapModel->mJointList[i].mBounds.mMin.z, mMapModel->mJointList[i].mBounds.mMax.x,
-		      mMapModel->mJointList[i].mBounds.mMax.y, mMapModel->mJointList[i].mBounds.mMax.z);
+	for (int jointIdx = 0; jointIdx < mMapModel->mJointCount; jointIdx++) {
+		PRINT("got bound (%.1f, %.1f, %.1f) - (%.1f, %.1f, %.1f)\n", mMapModel->mJointList[jointIdx].mBounds.mMin.x,
+		      mMapModel->mJointList[jointIdx].mBounds.mMin.y, mMapModel->mJointList[jointIdx].mBounds.mMin.z,
+		      mMapModel->mJointList[jointIdx].mBounds.mMax.x, mMapModel->mJointList[jointIdx].mBounds.mMax.y,
+		      mMapModel->mJointList[jointIdx].mBounds.mMax.z);
 	}
 
 	// set up collisions (with grid size of 64)
@@ -1208,7 +1211,7 @@ void MapMgr::initShape()
 
 	// sigh. this is really there.
 	// similar code exists in GenObjectMapObject::birth, but the assembly is actually stripped there.
-	for (int i = 0; i < 0; i++) {
+	for (int dynObjBodyCount = 0; dynObjBodyCount < 0; dynObjBodyCount++) {
 		DynObjBody* body = new DynObjBody();
 		body->mMapShape  = mMapModel;
 		body->readScript(this, "traffic/specLog.ini");
@@ -1486,16 +1489,16 @@ void MapMgr::showCollisions(immut Vector3f& focusPos)
 	CollGroup* collGroup = nullptr;
 
 	// first, check list of dynamic collision
-	FOREACH_NODE(DynCollShape, mCollShapeList->mChild, coll)
+	FOREACH_NODE(DynCollShape, mCollShapeList->mChild, dynCollShape)
 	{
-		if (focusBox.intersects(coll->mBoundingBox)) {
-			for (int i = 0; i < coll->mCollGroupCount; i++) {
-				if (coll->mJointVisibility[coll->mCollGroupList[i]->mJointIndex]) {
-					coll->mCollGroupList[i]->mModel         = coll->mCollisionModel;
-					coll->mCollGroupList[i]->mVertexList    = coll->mVertexList;
-					coll->mCollGroupList[i]->mPlatCollision = coll;
-					coll->mCollGroupList[i]->mNextCollGroup = collGroup;
-					collGroup                               = coll->mCollGroupList[i];
+		if (focusBox.intersects(dynCollShape->mBoundingBox)) {
+			for (int i = 0; i < dynCollShape->mCollGroupCount; i++) {
+				if (dynCollShape->mJointVisibility[dynCollShape->mCollGroupList[i]->mJointIndex]) {
+					dynCollShape->mCollGroupList[i]->mModel         = dynCollShape->mCollisionModel;
+					dynCollShape->mCollGroupList[i]->mVertexList    = dynCollShape->mVertexList;
+					dynCollShape->mCollGroupList[i]->mPlatCollision = dynCollShape;
+					dynCollShape->mCollGroupList[i]->mNextCollGroup = collGroup;
+					collGroup                                       = dynCollShape->mCollGroupList[i];
 				}
 			}
 		}
@@ -1739,18 +1742,18 @@ void MapMgr::postrefresh(Graphics& gfx)
 
 			Vector3f vecs[3];
 
-			for (int i = 0; i < mDebugCollCount; i++) {
-				vecs[0] = mDebugCollisions[i].mTriangle->mTriangle.mNormal * 0.1f
-				        + mDebugCollisions[i].mParentCollGroup->mVertexList[mDebugCollisions[i].mTriangle->mVertexIndices[0]];
-				vecs[1] = mDebugCollisions[i].mTriangle->mTriangle.mNormal * 0.1f
-				        + mDebugCollisions[i].mParentCollGroup->mVertexList[mDebugCollisions[i].mTriangle->mVertexIndices[1]];
-				vecs[2] = mDebugCollisions[i].mTriangle->mTriangle.mNormal * 0.1f
-				        + mDebugCollisions[i].mParentCollGroup->mVertexList[mDebugCollisions[i].mTriangle->mVertexIndices[2]];
+			for (int collIdx1 = 0; collIdx1 < mDebugCollCount; collIdx1++) {
+				vecs[0] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
+				        + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[0]];
+				vecs[1] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
+				        + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[1]];
+				vecs[2] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
+				        + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[2]];
 
-				for (int j = 0; j < 3; j++) {
-					gfx.setColour(colours[mDebugCollisions[i].mColorCategory], true);
-					gfx.drawLine(vecs[j % 3], vecs[(j + 1) % 3]);
-					gfx.drawPoints(&vecs[j % 3], 1);
+				for (int vertIdx = 0; vertIdx < 3; vertIdx++) {
+					gfx.setColour(colours[mDebugCollisions[collIdx1].mColorCategory], true);
+					gfx.drawLine(vecs[vertIdx % 3], vecs[(vertIdx + 1) % 3]);
+					gfx.drawPoints(&vecs[vertIdx % 3], 1);
 				}
 			}
 
@@ -1770,10 +1773,13 @@ void MapMgr::postrefresh(Graphics& gfx)
 			gfx.perspPrintf(gsys->mConsFont, triCountTextPos, -(gsys->mConsFont->stringWidth(debugText) / 2), 0, debugText);
 
 			// draw each triangle's distance from our local collision box
-			for (int i = 0; i < mDebugCollCount; i++) {
-				Vector3f vert1(mDebugCollisions[i].mParentCollGroup->mVertexList[mDebugCollisions[i].mTriangle->mVertexIndices[0]]);
-				Vector3f vert2(mDebugCollisions[i].mParentCollGroup->mVertexList[mDebugCollisions[i].mTriangle->mVertexIndices[1]]);
-				Vector3f vert3(mDebugCollisions[i].mParentCollGroup->mVertexList[mDebugCollisions[i].mTriangle->mVertexIndices[2]]);
+			for (int collIdx2 = 0; collIdx2 < mDebugCollCount; collIdx2++) {
+				Vector3f vert1(
+				    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[0]]);
+				Vector3f vert2(
+				    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[1]]);
+				Vector3f vert3(
+				    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[2]]);
 
 				// round vertices down for less jitter I suppose?
 				vert1.x = (int)vert1.x;
@@ -1789,7 +1795,7 @@ void MapMgr::postrefresh(Graphics& gfx)
 
 				Vector3f triangleTextPos = vert1 + vert2 + vert3;
 				triangleTextPos.multiply(1.0f / 3.0f);
-				triangleTextPos = triangleTextPos + mDebugCollisions[i].mTriangle->mTriangle.mNormal * 10.0f;
+				triangleTextPos = triangleTextPos + mDebugCollisions[collIdx2].mTriangle->mTriangle.mNormal * 10.0f;
 				triangleTextPos.multMatrix(gfx.mCamera->mLookAtMtx);
 				sprintf(debugText, "%.1f", distFromCaptainCollision);
 				gfx.perspPrintf(gsys->mConsFont, triangleTextPos, -(gsys->mConsFont->stringWidth(debugText) / 2), 0, debugText);
@@ -2263,7 +2269,8 @@ void MapMgr::traceMove(Creature* creature, MoveTrace& trace, f32 timeStep)
 	// double our step count until we can safely stay within the trace radius on a given step
 	int safeSubStepCount = 1;
 	int doublingCount    = 0;
-	for (f32 i = trace.mVelocity.length() * timeStep; doublingCount < 100 && i >= trace.mRadius; i *= 0.5f) {
+	for (f32 travelDistance = trace.mVelocity.length() * timeStep; doublingCount < 100 && travelDistance >= trace.mRadius;
+	     travelDistance *= 0.5f) {
 		doublingCount++;
 		safeSubStepCount *= 2;
 	}
@@ -2279,7 +2286,7 @@ void MapMgr::traceMove(Creature* creature, MoveTrace& trace, f32 timeStep)
 	// calc fraction so we can calc our displacement for each step correctly
 	trace.mStepFraction = 1.0f / safeSubStepCount;
 
-	for (int i = 0; i < safeSubStepCount; i++) {
+	for (int stepCount = 0; stepCount < safeSubStepCount; stepCount++) {
 		// for each step, set up a box for checking collision
 		BoundBox collCheckBox;
 		collCheckBox.expandBound(trace.mPosition);

--- a/src/plugPikiColin/mapMgr.cpp
+++ b/src/plugPikiColin/mapMgr.cpp
@@ -76,33 +76,33 @@ void DynCollShape::createDupCollData()
 	}
 
 	// almost every model should have at least 1 "room" (group of collision)
-	if (mCollisionModel->mBaseRoomCount <= 0) {
-		return;
-	}
+	if (mCollisionModel->mBaseRoomCount > 0) {
 
-	mCollGroupCount = mCollisionModel->mBaseRoomCount;
-	mCollGroupList  = new CollGroup*[mCollGroupCount];
+		mCollGroupCount = mCollisionModel->mBaseRoomCount;
+		mCollGroupList  = new CollGroup*[mCollGroupCount];
 
-	// the only common objects that have more than 1 group are bridges (short have 12, long have 30 - 2 groups per stage)
-	for (int i = 0; i < mCollisionModel->mBaseRoomCount; i++) {
-		int triCount = 0;
-		for (int triIdx1 = 0; triIdx1 < mCollisionModel->mTriCount; triIdx1++) {
-			if (i == mCollTriList[triIdx1].mCollRoomIndex) {
-				triCount++;
+		// the only common objects that have more than 1 group are bridges (short have 12, long have 30 - 2 groups per stage)
+		for (int room = 0; room < mCollisionModel->mBaseRoomCount; room++) {
+
+			int triCount = 0;
+			for (int triIdx1 = 0; triIdx1 < mCollisionModel->mTriCount; triIdx1++) {
+				if (mCollTriList[triIdx1].mCollRoomIndex == room) {
+					triCount++;
+				}
 			}
-		}
 
-		mCollGroupList[i]                = new CollGroup;
-		mCollGroupList[i]->mJointIndex   = mCollisionModel->mRoomInfoList[i].mJointIndex;
-		mCollGroupList[i]->mTriCount     = triCount;
-		mCollGroupList[i]->mTriangleList = new CollTriInfo*[mCollGroupList[i]->mTriCount];
+			mCollGroupList[room]                = new CollGroup;
+			mCollGroupList[room]->mJointIndex   = mCollisionModel->mRoomInfoList[room].mJointIndex;
+			mCollGroupList[room]->mTriCount     = triCount;
+			mCollGroupList[room]->mTriangleList = new CollTriInfo*[mCollGroupList[room]->mTriCount];
 
-		// populate triangle list
-		int triIdx = 0;
-		for (int triIdx2 = 0; triIdx2 < mCollisionModel->mTriCount; triIdx2++) {
-			if (mCollTriList[triIdx2].mCollRoomIndex == i) {
-				mCollGroupList[i]->mTriangleList[triIdx] = &mCollTriList[triIdx2];
-				triIdx++;
+			// populate triangle list
+			triCount = 0;
+			for (int triIdx2 = 0; triIdx2 < mCollisionModel->mTriCount; triIdx2++) {
+				if (mCollTriList[triIdx2].mCollRoomIndex == room) {
+					mCollGroupList[room]->mTriangleList[triCount] = &mCollTriList[triIdx2];
+					triCount++;
+				}
 			}
 		}
 	}
@@ -1616,211 +1616,218 @@ void MapMgr::drawXLU(Graphics& gfx)
  */
 void MapMgr::postrefresh(Graphics& gfx)
 {
-	if (mMapModel) {
-		MATCHING_START_TIMER("mapPost", true);
-		mDayMgr->setFog(gfx, nullptr);
+	if (!mMapModel) {
+		return;
+	}
 
-		// draw shadows
-		drawShadowCasters(gfx);
+	MATCHING_START_TIMER("mapPost", true);
+	mDayMgr->setFog(gfx, nullptr);
 
-		// queue up carry info text
-		if (lgMgr) {
-			lgMgr->update();
-			lgMgr->refresh(gfx);
-		}
+	// draw shadows
+	drawShadowCasters(gfx);
 
-		// draw carry info text (and any other light flares)
-		gfx.useMatrix(Matrix4f::ident, 0);
-		gfx.flushCachedShapes();
-		gsys->flushLFlares(gfx);
+	// queue up carry info text
+	if (lgMgr) {
+		lgMgr->update();
+		lgMgr->refresh(gfx);
+	}
 
-		// draw effects
-		if (effectMgr) {
-			gsys->mTimer->start("eff draw", true);
-			effectMgr->drawshapes(gfx);
-			gsys->mTimer->stop("eff draw");
-		}
+	// draw carry info text (and any other light flares)
+	gfx.useMatrix(Matrix4f::ident, 0);
+	gfx.flushCachedShapes();
+	gsys->flushLFlares(gfx);
 
-		// make and draw infamous blur effect - on by default
-		if (gsys->mToggleBlur) {
-			// set up screen environment for drawing
-			Matrix4f orthoMtx;
-			gfx.setOrthogonal(orthoMtx.mMtx, AREA_FULL_SCREEN(gfx));
-			bool lighting = gfx.setLighting(false, nullptr);
-			gfx.setFog(false);
-			gfx.setColour(COLOUR_WHITE, true);
-			gfx.setAuxColour(COLOUR_WHITE);
+	// draw effects
+	if (effectMgr) {
+		gsys->mTimer->start("eff draw", true);
+		effectMgr->drawshapes(gfx);
+		gsys->mTimer->stop("eff draw");
+	}
 
-			// store this frame's non-blurred scene into mBlurSourceTexture's pixel data
-			mBlurSourceTexture->grabBuffer(mBlurSourceTexture->mWidth, mBlurSourceTexture->mHeight, false, true);
-			gfx.useTexture(mBlurResultTexture, GX_TEXMAP0); // previous frame's blur
-			gfx.useTexture(mBlurSourceTexture, GX_TEXMAP1); // current frame's data
+#if PIKI_USE_DGX
+	// make and draw infamous blur effect - on by default
+	if (gsys->mToggleBlur) {
+		// set up screen environment for drawing
+		Matrix4f orthoMtx;
+		gfx.setOrthogonal(orthoMtx.mMtx, AREA_FULL_SCREEN(gfx));
+		bool lighting = gfx.setLighting(false, nullptr);
+		gfx.setFog(false);
+		gfx.setColour(COLOUR_WHITE, true);
+		gfx.setAuxColour(COLOUR_WHITE);
 
-			// Fun fact: the map manager's blur setting does *nothing* to adjust the blur, despite there being a
-			// day manager debug menu option for it. This re-hooks it up as the actual blur alpha, to let you adjust it.
+		// store this frame's non-blurred scene into mBlurSourceTexture's pixel data
+		mBlurSourceTexture->grabBuffer(mBlurSourceTexture->mWidth, mBlurSourceTexture->mHeight, false, true);
+		gfx.useTexture(mBlurResultTexture, GX_TEXMAP0); // previous frame's blur
+		gfx.useTexture(mBlurSourceTexture, GX_TEXMAP1); // current frame's data
+
+		// Fun fact: the map manager's blur setting does *nothing* to adjust the blur, despite there being a
+		// day manager debug menu option for it. This re-hooks it up as the actual blur alpha, to let you adjust it.
 #if defined(BUGFIX)
-			gfx.mCamera->mBlurAlpha = mBlur;
+		gfx.mCamera->mBlurAlpha = mBlur;
 #endif
 
 #if defined(VERSION_PIKIDEMO)
 #else
-			if (gameflow.mMoviePlayer->mIsActive) {
-				gfx.mCamera->mBlurAlpha = 0.0f;
-			}
+		if (gameflow.mMoviePlayer->mIsActive) {
+			gfx.mCamera->mBlurAlpha = 0.0f;
+		}
 #endif
 
-			int blend = gfx.setCBlending(BLEND_MultiTexture);
-			gfx.setPrimEnv(stack_new(Colour)(255, 255, 255, gfx.mCamera->mBlurAlpha), nullptr);
+		int blend = gfx.setCBlending(BLEND_MultiTexture);
+		gfx.setPrimEnv(stack_new(Colour)(255, 255, 255, gfx.mCamera->mBlurAlpha), nullptr);
 
-			// render multi-texture blend (blur)
-			gfx.blatRectangle(AREA_FULL_SCREEN(gfx));
+		// render multi-texture blend (blur)
+		gfx.blatRectangle(AREA_FULL_SCREEN(gfx));
 
-			// clean up graphics settings + store current blur result for use next frame
-			gfx.setCBlending(blend);
-			mBlurResultTexture->grabBuffer(mBlurResultTexture->mWidth, mBlurResultTexture->mHeight, false, true);
-			gfx.resetCopyFilter();
-			gfx.setFog(true);
-			gfx.setLighting(lighting, nullptr);
-			gfx.setPerspective(gfx.mCamera->mPerspectiveMatrix.mMtx, gfx.mCamera->mFov, gfx.mCamera->mAspectRatio, gfx.mCamera->mNear,
-			                   gfx.mCamera->mFar, 1.0f);
-		}
-
-		// handle fading and desaturating
-		if (mCurrFadeLevel < mTargetFadeLevel) {
-			mCurrFadeLevel += 2.0f * gsys->getFrameTime();
-			if (mCurrFadeLevel > mTargetFadeLevel) {
-				mCurrFadeLevel = mTargetFadeLevel;
-			}
-		} else if (mCurrFadeLevel > mTargetFadeLevel) {
-			mCurrFadeLevel -= 2.0f * gsys->getFrameTime();
-			if (mCurrFadeLevel < mTargetFadeLevel) {
-				mCurrFadeLevel = mTargetFadeLevel;
-			}
-		}
-
-		if (mCurrDesaturationLevel < mTargetDesaturationLevel) {
-			mCurrDesaturationLevel += 2.0f * gsys->getFrameTime();
-			if (mCurrDesaturationLevel > mTargetDesaturationLevel) {
-				mCurrDesaturationLevel = mTargetDesaturationLevel;
-			}
-		} else if (mCurrDesaturationLevel > mTargetDesaturationLevel) {
-			mCurrDesaturationLevel -= 2.0f * gsys->getFrameTime();
-			if (mCurrDesaturationLevel < mTargetDesaturationLevel) {
-				mCurrDesaturationLevel = mTargetDesaturationLevel;
-			}
-		}
-
-		// draw any fading or desaturation that's happening
-		if (mCurrDesaturationLevel > 0.0f || mCurrFadeLevel > 0.0f) {
-			Matrix4f orthoMtx;
-			gfx.setOrthogonal(orthoMtx.mMtx, AREA_FULL_SCREEN(gfx));
-
-			// apply desaturated blur texture to desired level
-			GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_RED, GX_CH_RED, GX_CH_ALPHA);
-			gfx.setColour(Colour(160, 160, 160, (int)(mCurrDesaturationLevel * 255.0f)), true);
-			gfx.useTexture(mBlurResultTexture, GX_TEXMAP0);
-			gfx.drawRectangle(AREA_FULL_SCREEN(gfx), RectArea(0, 0, mBlurResultTexture->mWidth, mBlurResultTexture->mHeight), nullptr);
-
-			GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
-			gfx.setColour(Colour(0, 0, 0, int(mCurrFadeLevel * 255.0f)), true);
-			gfx.useTexture(nullptr, GX_TEXMAP0);
-			gfx.fillRectangle(AREA_FULL_SCREEN(gfx));
-		}
-
-		// draw debug triangle outlines
-		if (mDebugCollCount) {
-			int blend     = gfx.setCBlending(BLEND_Alpha);
-			bool lighting = gfx.setLighting(false, nullptr);
-			gfx.setFog(false);
-			gfx.useTexture(nullptr, GX_TEXMAP0);
-			gfx.useMatrix(gfx.mCamera->mLookAtMtx, 0);
-
-			Colour colours[DCLR_COUNT];
-			colours[DCLR_Yellow].set(255, 255, 0, 255); // yellow
-			colours[DCLR_Red].set(255, 0, 0, 255);      // red
-			colours[DCLR_Blue].set(0, 0, 255, 255);     // blue
-
-			Vector3f vecs[3];
-
-			for (int collIdx1 = 0; collIdx1 < mDebugCollCount; collIdx1++) {
-				vecs[0] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
-				        + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[0]];
-				vecs[1] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
-				        + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[1]];
-				vecs[2] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
-				        + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[2]];
-
-				for (int vertIdx = 0; vertIdx < 3; vertIdx++) {
-					gfx.setColour(colours[mDebugCollisions[collIdx1].mColorCategory], true);
-					gfx.drawLine(vecs[vertIdx % 3], vecs[(vertIdx + 1) % 3]);
-					gfx.drawPoints(&vecs[vertIdx % 3], 1);
-				}
-			}
-
-			// draw triangle counts to screen
-			gfx.setColour(COLOUR_WHITE, true);
-			Vector3f triCountTextPos(mDebugFocusPosition.x, mDebugFocusPosition.y + 50.0f, mDebugFocusPosition.z);
-			triCountTextPos.multMatrix(gfx.mCamera->mLookAtMtx);
-
-			char debugText[PATH_MAX];
-			if (AIPerf::showColls) {
-				sprintf(debugText, "%d / %d", mActiveTriCount, mDebugCollCount);
-			} else {
-				sprintf(debugText, "%d", mDebugCollCount);
-			}
-
-			gfx.useMatrix(Matrix4f::ident, 0);
-			gfx.perspPrintf(gsys->mConsFont, triCountTextPos, -(gsys->mConsFont->stringWidth(debugText) / 2), 0, debugText);
-
-			// draw each triangle's distance from our local collision box
-			for (int collIdx2 = 0; collIdx2 < mDebugCollCount; collIdx2++) {
-				Vector3f vert1(
-				    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[0]]);
-				Vector3f vert2(
-				    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[1]]);
-				Vector3f vert3(
-				    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[2]]);
-
-				// round vertices down for less jitter I suppose?
-				vert1.x = (int)vert1.x;
-				vert1.z = (int)vert1.z;
-
-				vert2.x = (int)vert2.x;
-				vert2.z = (int)vert2.z;
-
-				vert3.x = (int)vert3.x;
-				vert3.z = (int)vert3.z;
-
-				f32 distFromCaptainCollision = triRectDistance(&vert1, &vert2, &vert3, collExtents, false);
-
-				Vector3f triangleTextPos = vert1 + vert2 + vert3;
-				triangleTextPos.multiply(1.0f / 3.0f);
-				triangleTextPos = triangleTextPos + mDebugCollisions[collIdx2].mTriangle->mTriangle.mNormal * 10.0f;
-				triangleTextPos.multMatrix(gfx.mCamera->mLookAtMtx);
-				sprintf(debugText, "%.1f", distFromCaptainCollision);
-				gfx.perspPrintf(gsys->mConsFont, triangleTextPos, -(gsys->mConsFont->stringWidth(debugText) / 2), 0, debugText);
-			}
-
-			// draw our fun two boxes indicating collision and far culling
-			gfx.useMatrix(gfx.mCamera->mLookAtMtx, 0);
-
-			if (AIPerf::showColls) {
-				gfx.setColour(Colour(255, 128, 255, 255), true); // magenta, inner box
-				mActiveCollisionBounds.draw(gfx);
-			}
-
-			gfx.setColour(Colour(64, 255, 255, 255), true); // cyan, outer box
-			mOuterCollRenderBounds.draw(gfx);
-			gfx.setFog(true);
-			gfx.setLighting(lighting, nullptr);
-			gfx.setCBlending(blend);
-		}
-
-		mDebugCollCount = 0;
-		mActiveTriCount = 0;
-		MATCHING_STOP_TIMER("mapPost");
-		gfx.mHasTexGen = FALSE;
+		// clean up graphics settings + store current blur result for use next frame
+		gfx.setCBlending(blend);
+		mBlurResultTexture->grabBuffer(mBlurResultTexture->mWidth, mBlurResultTexture->mHeight, false, true);
+		gfx.resetCopyFilter();
+		gfx.setFog(true);
+		gfx.setLighting(lighting, nullptr);
+		gfx.setPerspective(gfx.mCamera->mPerspectiveMatrix.mMtx, gfx.mCamera->mFov, gfx.mCamera->mAspectRatio, gfx.mCamera->mNear,
+		                   gfx.mCamera->mFar, 1.0f);
 	}
+#endif
+
+	// handle fading and desaturating
+	if (mCurrFadeLevel < mTargetFadeLevel) {
+		mCurrFadeLevel += 2.0f * gsys->getFrameTime();
+		if (mCurrFadeLevel > mTargetFadeLevel) {
+			mCurrFadeLevel = mTargetFadeLevel;
+		}
+	} else if (mCurrFadeLevel > mTargetFadeLevel) {
+		mCurrFadeLevel -= 2.0f * gsys->getFrameTime();
+		if (mCurrFadeLevel < mTargetFadeLevel) {
+			mCurrFadeLevel = mTargetFadeLevel;
+		}
+	}
+
+	if (mCurrDesaturationLevel < mTargetDesaturationLevel) {
+		mCurrDesaturationLevel += 2.0f * gsys->getFrameTime();
+		if (mCurrDesaturationLevel > mTargetDesaturationLevel) {
+			mCurrDesaturationLevel = mTargetDesaturationLevel;
+		}
+	} else if (mCurrDesaturationLevel > mTargetDesaturationLevel) {
+		mCurrDesaturationLevel -= 2.0f * gsys->getFrameTime();
+		if (mCurrDesaturationLevel < mTargetDesaturationLevel) {
+			mCurrDesaturationLevel = mTargetDesaturationLevel;
+		}
+	}
+
+	// draw any fading or desaturation that's happening
+	if (mCurrDesaturationLevel > 0.0f || mCurrFadeLevel > 0.0f) {
+		Matrix4f orthoMtx;
+		gfx.setOrthogonal(orthoMtx.mMtx, AREA_FULL_SCREEN(gfx));
+
+		// apply desaturated blur texture to desired level
+#if PIKI_USE_DGX
+		GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_RED, GX_CH_RED, GX_CH_ALPHA);
+#endif
+		gfx.setColour(Colour(160, 160, 160, (int)(mCurrDesaturationLevel * 255.0f)), true);
+		gfx.useTexture(mBlurResultTexture, GX_TEXMAP0);
+		gfx.drawRectangle(AREA_FULL_SCREEN(gfx), RectArea(0, 0, mBlurResultTexture->mWidth, mBlurResultTexture->mHeight), nullptr);
+
+#if PIKI_USE_DGX
+		GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+#endif
+		gfx.setColour(Colour(0, 0, 0, int(mCurrFadeLevel * 255.0f)), true);
+		gfx.useTexture(nullptr, GX_TEXMAP0);
+		gfx.fillRectangle(AREA_FULL_SCREEN(gfx));
+	}
+
+	// draw debug triangle outlines
+	if (mDebugCollCount) {
+		int blend     = gfx.setCBlending(BLEND_Alpha);
+		bool lighting = gfx.setLighting(false, nullptr);
+		gfx.setFog(false);
+		gfx.useTexture(nullptr, GX_TEXMAP0);
+		gfx.useMatrix(gfx.mCamera->mLookAtMtx, 0);
+
+		Colour colours[DCLR_COUNT];
+		colours[DCLR_Yellow].set(255, 255, 0, 255); // yellow
+		colours[DCLR_Red].set(255, 0, 0, 255);      // red
+		colours[DCLR_Blue].set(0, 0, 255, 255);     // blue
+
+		Vector3f verts[3];
+		for (int collIdx1 = 0; collIdx1 < mDebugCollCount; collIdx1++) {
+			verts[0] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
+			         + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[0]];
+			verts[1] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
+			         + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[1]];
+			verts[2] = mDebugCollisions[collIdx1].mTriangle->mTriangle.mNormal * 0.1f
+			         + mDebugCollisions[collIdx1].mParentCollGroup->mVertexList[mDebugCollisions[collIdx1].mTriangle->mVertexIndices[2]];
+
+			for (int vertIdx = 0; vertIdx < 3; vertIdx++) {
+				gfx.setColour(colours[mDebugCollisions[collIdx1].mColorCategory], true);
+				gfx.drawLine(verts[vertIdx % 3], verts[(vertIdx + 1) % 3]);
+				gfx.drawPoints(&verts[vertIdx % 3], 1);
+			}
+		}
+
+		// draw triangle counts to screen
+		gfx.setColour(COLOUR_WHITE, true);
+		Vector3f triCountTextPos(mDebugFocusPosition.x, mDebugFocusPosition.y + 50.0f, mDebugFocusPosition.z);
+		triCountTextPos.multMatrix(gfx.mCamera->mLookAtMtx);
+
+		char debugText[PATH_MAX];
+		if (AIPerf::showColls) {
+			sprintf(debugText, "%d / %d", mActiveTriCount, mDebugCollCount);
+		} else {
+			sprintf(debugText, "%d", mDebugCollCount);
+		}
+
+		gfx.useMatrix(Matrix4f::ident, 0);
+		gfx.perspPrintf(gsys->mConsFont, triCountTextPos, -(gsys->mConsFont->stringWidth(debugText) / 2), 0, debugText);
+
+		// draw each triangle's distance from our local collision box
+		for (int collIdx2 = 0; collIdx2 < mDebugCollCount; collIdx2++) {
+			Vector3f vert1(
+			    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[0]]);
+			Vector3f vert2(
+			    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[1]]);
+			Vector3f vert3(
+			    mDebugCollisions[collIdx2].mParentCollGroup->mVertexList[mDebugCollisions[collIdx2].mTriangle->mVertexIndices[2]]);
+
+			// round vertices down for less jitter I suppose?
+			vert1.x = (int)vert1.x;
+			vert1.z = (int)vert1.z;
+
+			vert2.x = (int)vert2.x;
+			vert2.z = (int)vert2.z;
+
+			vert3.x = (int)vert3.x;
+			vert3.z = (int)vert3.z;
+
+			f32 distFromCaptainCollision = triRectDistance(&vert1, &vert2, &vert3, collExtents, false);
+
+			Vector3f triangleTextPos = vert1 + vert2 + vert3;
+			triangleTextPos.multiply(1.0f / 3.0f);
+			triangleTextPos = triangleTextPos + mDebugCollisions[collIdx2].mTriangle->mTriangle.mNormal * 10.0f;
+			triangleTextPos.multMatrix(gfx.mCamera->mLookAtMtx);
+			sprintf(debugText, "%.1f", distFromCaptainCollision);
+			gfx.perspPrintf(gsys->mConsFont, triangleTextPos, -(gsys->mConsFont->stringWidth(debugText) / 2), 0, debugText);
+		}
+
+		// draw our fun two boxes indicating collision and far culling
+		gfx.useMatrix(gfx.mCamera->mLookAtMtx, 0);
+
+		if (AIPerf::showColls) {
+			gfx.setColour(Colour(255, 128, 255, 255), true); // magenta, inner box
+			mActiveCollisionBounds.draw(gfx);
+		}
+
+		gfx.setColour(Colour(64, 255, 255, 255), true); // cyan, outer box
+		mOuterCollRenderBounds.draw(gfx);
+		gfx.setFog(true);
+		gfx.setLighting(lighting, nullptr);
+		gfx.setCBlending(blend);
+	}
+
+	mDebugCollCount = 0;
+	mActiveTriCount = 0;
+	MATCHING_STOP_TIMER("mapPost");
+	gfx.mHasTexGen = FALSE;
 }
 
 /**
@@ -2269,10 +2276,11 @@ void MapMgr::traceMove(Creature* creature, MoveTrace& trace, f32 timeStep)
 	// double our step count until we can safely stay within the trace radius on a given step
 	int safeSubStepCount = 1;
 	int doublingCount    = 0;
-	for (f32 travelDistance = trace.mVelocity.length() * timeStep; doublingCount < 100 && travelDistance >= trace.mRadius;
-	     travelDistance *= 0.5f) {
+	f32 travelDistance   = trace.mVelocity.length() * timeStep;
+	while (doublingCount < 100 && travelDistance >= trace.mRadius) {
 		doublingCount++;
 		safeSubStepCount *= 2;
+		travelDistance *= 0.5f;
 	}
 
 	// report if we're in insane "we're tracing this object for WAY too long given its speed" territory
@@ -2290,8 +2298,8 @@ void MapMgr::traceMove(Creature* creature, MoveTrace& trace, f32 timeStep)
 		// for each step, set up a box for checking collision
 		BoundBox collCheckBox;
 		collCheckBox.expandBound(trace.mPosition);
-		collCheckBox.mMin.sub(Vector3f(2.0f * trace.mRadius, 4.0f * trace.mRadius, 2.0f * trace.mRadius));
-		collCheckBox.mMax.add(Vector3f(2.0f * trace.mRadius, 4.0f * trace.mRadius, 2.0f * trace.mRadius));
+		collCheckBox.mMin.sub(Vector3f(trace.mRadius * 2, trace.mRadius * 4, trace.mRadius * 2));
+		collCheckBox.mMax.add(Vector3f(trace.mRadius * 2, trace.mRadius * 4, trace.mRadius * 2));
 
 		trace.mObject = creature;
 
@@ -2302,7 +2310,10 @@ void MapMgr::traceMove(Creature* creature, MoveTrace& trace, f32 timeStep)
 			// (in reality, only pikmin sprouts ignore this)
 			FOREACH_NODE(DynCollShape, mCollShapeList->mChild, coll)
 			{
-				if ((!coll->mCreature || coll->mCreature != creature) && collCheckBox.intersects(coll->mBoundingBox)) {
+				if (coll->mCreature && coll->mCreature == creature) {
+					continue;
+				}
+				if (collCheckBox.intersects(coll->mBoundingBox)) {
 					for (int j = 0; j < coll->mCollGroupCount; j++) {
 						if (coll->mJointVisibility[coll->mCollGroupList[j]->mJointIndex]) {
 							coll->mCollGroupList[j]->mModel         = coll->mCollisionModel;

--- a/src/plugPikiColin/movSample.cpp
+++ b/src/plugPikiColin/movSample.cpp
@@ -222,13 +222,12 @@ struct MovSampleSetupSection : public Node {
 	}
 	virtual void draw(Graphics& gfx) // _14 (weak)
 	{
-		// NON-MATCHING
 		gfx.setViewport(AREA_FULL_SCREEN(gfx));
 		gfx.setScissor(AREA_FULL_SCREEN(gfx));
 		gfx.setClearColour(COLOUR_TRANSPARENT);
 		gfx.clearBuffer(3, false);
 		Matrix4f mtx;
-		STACK_PAD_VAR(63);
+		STACK_PAD_VAR(64);
 		gfx.setOrthogonal(mtx.mMtx, AREA_FULL_SCREEN(gfx));
 
 		GXSetNumTexGens(2);
@@ -291,9 +290,8 @@ struct MovSampleSetupSection : public Node {
 		gfx.setColour(COLOUR_WHITE, true);
 
 		// WHY WONT YOU USE DIFFERENT REGISTERS
-		int width = 640;
-		int height;
-		gfx.testRectangle(RectArea(0, 0, width, height = 480));
+		int width, height;
+		gfx.testRectangle(RectArea(0, 0, width = 640, height = 480));
 
 		GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
 		GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);

--- a/src/plugPikiColin/newPikiGame.cpp
+++ b/src/plugPikiColin/newPikiGame.cpp
@@ -2511,14 +2511,14 @@ public:
 void GameMovieInterface::parseMessages()
 {
 	// process all queued commands
-	for (int i = 0; i < mSimpleMessageCount; i++) {
-		parse(mSimpMesg[i]);
+	for (int simpleMesgIdx = 0; simpleMesgIdx < mSimpleMessageCount; simpleMesgIdx++) {
+		parse(mSimpMesg[simpleMesgIdx]);
 	}
 	mSimpleMessageCount = 0;
 
 	// process all queued movies
-	for (int i = 0; i < mComplexMesgCount; i++) {
-		parse(mCompMesg[i]);
+	for (int complexMesgIdx = 0; complexMesgIdx < mComplexMesgCount; complexMesgIdx++) {
+		parse(mCompMesg[complexMesgIdx]);
 	}
 
 	mComplexMesgCount = 0;

--- a/src/plugPikiKando/dynCreature.cpp
+++ b/src/plugPikiKando/dynCreature.cpp
@@ -208,8 +208,10 @@ void DynCreature::initialiseSystem()
 	mCenterOfMass.set(0.0f, 0.0f, 0.0f);
 	mMass = 0.0f;
 
+	DynParticle* ptcl;
+
 	// First pass: Calculate total mass and weighted center of mass
-	for (DynParticle* ptcl = mParticleList; ptcl; ptcl = ptcl->mNextParticle) {
+	for (ptcl = mParticleList; ptcl; ptcl = ptcl->mNextParticle) {
 		mCenterOfMass = mCenterOfMass + ptcl->mMass * ptcl->mInitialPosition;
 		mMass += ptcl->mMass;
 	}
@@ -218,7 +220,7 @@ void DynCreature::initialiseSystem()
 	mCenterOfMass = mCenterOfMass * (1.0f / mMass);
 
 	// Second pass: Adjust particle positions relative to center of mass
-	for (DynParticle* ptcl = mParticleList; ptcl; ptcl = ptcl->mNextParticle) {
+	for (ptcl = mParticleList; ptcl; ptcl = ptcl->mNextParticle) {
 		ptcl->mLocalPosition = ptcl->mInitialPosition - mCenterOfMass;
 	}
 

--- a/src/plugPikiKando/fastGrid.cpp
+++ b/src/plugPikiKando/fastGrid.cpp
@@ -287,7 +287,7 @@ void FastGrid::renderAIGrid2D(Graphics& gfx)
 	gfx.useTexture(nullptr, GX_TEXMAP0);
 	gfx.setColour(Colour(155, 155, 155, 255), true);
 
-	// Making the following named constants actually `const` affects matching.  Lovely `const` memes!
+	// Making the following named constants actually `const` affects matching.  Lovely const memes!
 	immut int dispAmount = 12; // Width and height (in cells) of the displayed square grid of cells.
 	immut int iOffs      = mWidth - (dispAmount >> 1);
 	immut int jOffs      = mHeight - (dispAmount >> 1);

--- a/src/plugPikiKando/fishItem.cpp
+++ b/src/plugPikiKando/fishItem.cpp
@@ -46,14 +46,16 @@ void FishGenerator::startAI(int /*unused*/)
  */
 void FishGenerator::update()
 {
+	int i;
+
 	mSchoolCentre.set(0.0f, 0.0f, 0.0f);
-	for (int i = 0; i < mFishCount; i++) {
+	for (i = 0; i < mFishCount; i++) {
 		mSchoolCentre = mSchoolCentre + mFish[i].mPosition;
 	}
 
 	mSchoolCentre.multiply(1.0f / mFishCount);
 
-	for (int i = 0; i < mFishCount; i++) {
+	for (i = 0; i < mFishCount; i++) {
 		moveFish(&mFish[i]);
 	}
 }

--- a/src/plugPikiKando/formationMgr.cpp
+++ b/src/plugPikiKando/formationMgr.cpp
@@ -165,11 +165,11 @@ void FormationMgr::slide(Creature* target, int idx)
 	int replaceIdx      = -1;
 	Creature* toReplace = nullptr;
 
-	for (int i = 0; i < mCount; i++) {
-		toReplace = mFormPoints[i].getOwner();
-		if (!mFormPoints[i].isFree()) {
+	for (int searchReplaceIdx = 0; searchReplaceIdx < mCount; searchReplaceIdx++) {
+		toReplace = mFormPoints[searchReplaceIdx].getOwner();
+		if (!mFormPoints[searchReplaceIdx].isFree()) {
 			if (toReplace->getFormationPri() > target->getFormationPri()) {
-				replaceIdx = i;
+				replaceIdx = searchReplaceIdx;
 				break;
 			}
 		}
@@ -177,9 +177,9 @@ void FormationMgr::slide(Creature* target, int idx)
 
 	if (replaceIdx != -1) {
 		mFormPoints[replaceIdx].setOwner(target);
-		for (int i = 0; i < mCount; i++) {
-			if (mFormMembers[i] == toReplace) {
-				mFormMembers[i] = target;
+		for (int memberIdx = 0; memberIdx < mCount; memberIdx++) {
+			if (mFormMembers[memberIdx] == toReplace) {
+				mFormMembers[memberIdx] = target;
 			}
 		}
 
@@ -190,9 +190,9 @@ void FormationMgr::slide(Creature* target, int idx)
 	}
 
 	int freeIdx = -1;
-	for (int i = 0; i < mFormPointCount; i++) {
-		if (mFormPoints[i].isFree()) {
-			freeIdx = i;
+	for (int searchFreeIdx = 0; searchFreeIdx < mFormPointCount; searchFreeIdx++) {
+		if (mFormPoints[searchFreeIdx].isFree()) {
+			freeIdx = searchFreeIdx;
 			break;
 		}
 	}

--- a/src/plugPikiKando/formationMgr.cpp
+++ b/src/plugPikiKando/formationMgr.cpp
@@ -275,7 +275,7 @@ void FormationMgr::exit(Creature* target)
 
 /**
  * @todo: Documentation
- * @note UNUSED Size: 00008C
+ * @note UNUSED Size: 00008C (Matching by size)
  */
 void FormationMgr::clear()
 {
@@ -284,6 +284,8 @@ void FormationMgr::clear()
 	for (i = 0; i < mMax; i++) {
 		mFormPoints[i].reset();
 	}
+
+	mFormPointCount = 0;
 
 	for (i = 0; i < mCount; i++) {
 		if (mFormMembers[i]) {

--- a/src/plugPikiKando/formationMgr.cpp
+++ b/src/plugPikiKando/formationMgr.cpp
@@ -279,11 +279,13 @@ void FormationMgr::exit(Creature* target)
  */
 void FormationMgr::clear()
 {
-	for (int i = 0; i < mMax; i++) {
+	int i;
+
+	for (i = 0; i < mMax; i++) {
 		mFormPoints[i].reset();
 	}
 
-	for (int i = 0; i < mCount; i++) {
+	for (i = 0; i < mCount; i++) {
 		if (mFormMembers[i]) {
 			mFormMembers[i]->mFormPoint = nullptr;
 			mFormMembers[i]             = nullptr;

--- a/src/plugPikiKando/gameCoreSection.cpp
+++ b/src/plugPikiKando/gameCoreSection.cpp
@@ -545,7 +545,8 @@ void GameCoreSection::cleanupDayEnd()
 
 	if (naviMgr->getNavi()) {
 		PRINT("********** KILL RIPPLE EFFECT****\n");
-		naviMgr->getNavi()->mRippleEffect->kill();
+		Navi* navi = naviMgr->getNavi();
+		navi->mRippleEffect->kill();
 	}
 	seSystem->resetSystem();
 
@@ -602,9 +603,10 @@ void GameCoreSection::cleanupDayEnd()
 		{
 			Piki* piki = (Piki*)*it;
 			int mode   = piki->mMode;
+
 			if (piki->isKinoko()) {
 				GameStat::victimPikis.inc(piki->mColor);
-#if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01_01)
+#if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01_01) || defined(WIN32)
 #else
 				GameStat::deadPikis.inc(piki->mColor);
 #endif
@@ -612,54 +614,65 @@ void GameCoreSection::cleanupDayEnd()
 				piki->kill(false);
 				it.dec();
 				killed++;
-			} else {
-				if (piki->isHolding()) {
-					InteractRelease act(piki, 1.0f);
-					Creature* obj = piki->getHoldCreature();
-					obj->stimulate(act);
-					BombItem* bomb = (BombItem*)obj;
-					C_SAI(bomb)->start(bomb, BombAI::BOMB_Mizu);
-					PRINT("BOMB KILL!\n");
+				continue;
+			}
+
+			if (piki->isHolding()) {
+				InteractRelease act(piki, 1.0f);
+				Creature* obj = piki->getHoldCreature();
+				obj->stimulate(act);
+				BombItem* bomb = (BombItem*)obj;
+				C_SAI(bomb)->start(bomb, BombAI::BOMB_Mizu);
+				PRINT("BOMB KILL!\n");
+			}
+
+			int state = piki->getState();
+			if (mode == PikiMode::FormationMode) {
+				if (state == PIKISTATE_Drown || state == PIKISTATE_Fired || state == PIKISTATE_Dead || state == PIKISTATE_Swallowed
+				    || state == PIKISTATE_Bubble || state == PIKISTATE_Dying || state == PIKISTATE_Flick || !piki->isAlive()) {
+					// do nothing
+				} else {
+					continue;
 				}
-				int state = piki->getState();
-				if ((mode != PikiMode::FormationMode || state == PIKISTATE_Drown || state == PIKISTATE_Fired || state == PIKISTATE_Dead
-				     || state == PIKISTATE_Swallowed || state == PIKISTATE_Bubble || state == PIKISTATE_Dying || state == PIKISTATE_Flick
-				     || !piki->isAlive())
-				    && !(mode == PikiMode::EnterMode || mode == PikiMode::ExitMode) && state != PIKISTATE_LookAt) {
-					bool isNearOnyonShip = false;
-					if (piki->mMode == PikiMode::FreeMode) {
-						for (int i = 0; i < PikiColorCount; i++) {
-							GoalItem* goal = itemMgr->getContainer(i);
-							if (goal) {
-								if (qdist2(goal->mSRT.t.x, goal->mSRT.t.z, piki->mSRT.t.x, piki->mSRT.t.z)
-								    <= pikiMgr->mPikiParms->mPikiParms.mSunsetSafetyRange()) {
-									isNearOnyonShip = true;
-									break;
-								}
-							}
-							UfoItem* ufo = itemMgr->getUfo();
-							if (ufo) {
-								Vector3f pos = ufo->getGoalPos();
-								if (qdist2(pos.x, pos.z, piki->mSRT.t.x, piki->mSRT.t.z)
-								    <= pikiMgr->mPikiParms->mPikiParms.mSunsetSafetyRange()) {
-									isNearOnyonShip = true;
-									break;
-								}
-							}
+			}
+			if (mode == PikiMode::ExitMode || mode == PikiMode::EnterMode) {
+				continue;
+			} else if (state == PIKISTATE_LookAt) {
+				continue;
+			}
+
+			bool isNearOnyonShip = false;
+			if (piki->mMode == PikiMode::FreeMode) {
+				for (int i = 0; i < PikiColorCount; i++) {
+					GoalItem* goal = itemMgr->getContainer(i);
+					if (goal) {
+						if (qdist2(goal->mSRT.t.x, goal->mSRT.t.z, piki->mSRT.t.x, piki->mSRT.t.z)
+						    <= pikiMgr->mPikiParms->mPikiParms.mSunsetSafetyRange()) {
+							isNearOnyonShip = true;
+							break;
 						}
 					}
-					if (!isNearOnyonShip) {
-						GameStat::victimPikis.inc(piki->mColor);
-#if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01_01)
-#else
-						GameStat::deadPikis.inc(piki->mColor);
-#endif
-						piki->setEraseKill();
-						piki->kill(false);
-						it.dec();
-						killed++;
+					UfoItem* ufo = itemMgr->getUfo();
+					if (ufo) {
+						Vector3f pos = ufo->getGoalPos();
+						if (qdist2(pos.x, pos.z, piki->mSRT.t.x, piki->mSRT.t.z) <= pikiMgr->mPikiParms->mPikiParms.mSunsetSafetyRange()) {
+							isNearOnyonShip = true;
+							break;
+						}
 					}
 				}
+			}
+
+			if (!isNearOnyonShip) {
+				GameStat::victimPikis.inc(piki->mColor);
+#if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01_01) || defined(WIN32)
+#else
+				GameStat::deadPikis.inc(piki->mColor);
+#endif
+				piki->setEraseKill();
+				piki->kill(false);
+				it.dec();
+				killed++;
 			}
 		}
 		if (GameStat::victimPikis > 0) {
@@ -757,8 +770,9 @@ void GameCoreSection::cleanupDayEnd()
 	}
 
 	playerState->mSproutedNum += GameStat::bornPikis;
-	int lost = GameStat::deadPikis - GameStat::victimPikis;
-	playerState->mLostBattlePikis += (lost < 0) ? 0 : lost;
+	int lostBattlePikis = GameStat::deadPikis - GameStat::victimPikis;
+	lostBattlePikis     = (lostBattlePikis < 0) ? 0 : lostBattlePikis;
+	playerState->mLostBattlePikis += lostBattlePikis;
 	playerState->mLeftBehindPikis += GameStat::victimPikis;
 }
 

--- a/src/plugPikiKando/gameCoreSection.cpp
+++ b/src/plugPikiKando/gameCoreSection.cpp
@@ -535,7 +535,7 @@ void GameCoreSection::cleanupDayEnd()
 	playerState->setDayPowerupCount(day, playerState->getNextPowerupNumber());
 
 	int i;
-	for (i = 0; i < 3; i++) {
+	for (i = 0; i < PikiColorCount; i++) {
 		GoalItem* goal = itemMgr->getContainer(i);
 		if (goal) {
 			goal->setSpotActive(false);
@@ -626,13 +626,14 @@ void GameCoreSection::cleanupDayEnd()
 				    && !(mode == PikiMode::EnterMode || mode == PikiMode::ExitMode) && state != PIKISTATE_LookAt) {
 					bool isNearOnyonShip = false;
 					if (piki->mMode == PikiMode::FreeMode) {
-						for (int i = 0; i < 3; i++) {
+						for (int i = 0; i < PikiColorCount; i++) {
 							GoalItem* goal = itemMgr->getContainer(i);
-							if (goal
-							    && qdist2(goal->mSRT.t.x, goal->mSRT.t.z, piki->mSRT.t.x, piki->mSRT.t.z)
-							           <= pikiMgr->mPikiParms->mPikiParms.mSunsetSafetyRange()) {
-								isNearOnyonShip = true;
-								break;
+							if (goal) {
+								if (qdist2(goal->mSRT.t.x, goal->mSRT.t.z, piki->mSRT.t.x, piki->mSRT.t.z)
+								    <= pikiMgr->mPikiParms->mPikiParms.mSunsetSafetyRange()) {
+									isNearOnyonShip = true;
+									break;
+								}
 							}
 							UfoItem* ufo = itemMgr->getUfo();
 							if (ufo) {
@@ -942,8 +943,7 @@ void GameCoreSection::initStage()
 	pikiMgr->mMapMgr    = mMapMgr;
 
 	memStat->start("pikiCreate");
-	// This has a capacity of 102 in the vanilla game for some reason.
-	pikiMgr->create(MAX_PIKI_ON_FIELD == 100 ? 102 : MAX_PIKI_ON_FIELD);
+	pikiMgr->create(MAX_PIKI_ON_FIELD + 2); // This has a capacity of 102 for some reason.
 	memStat->end("pikiCreate");
 
 	memStat->end("piki");

--- a/src/plugPikiKando/gameCoreSection.cpp
+++ b/src/plugPikiKando/gameCoreSection.cpp
@@ -534,9 +534,9 @@ void GameCoreSection::cleanupDayEnd()
 	playerState->setDayCollectCount(day, playerState->getCurrParts());
 	playerState->setDayPowerupCount(day, playerState->getNextPowerupNumber());
 
-	int i;
-	for (i = 0; i < PikiColorCount; i++) {
-		GoalItem* goal = itemMgr->getContainer(i);
+	int goalColor; // Gets reused way later in the function
+	for (goalColor = 0; goalColor < PikiColorCount; goalColor++) {
+		GoalItem* goal = itemMgr->getContainer(goalColor);
 		if (goal) {
 			goal->setSpotActive(false);
 		}
@@ -690,11 +690,11 @@ void GameCoreSection::cleanupDayEnd()
 
 	effectMgr->killAll();
 
-	for (i = 0; i < PikiColorCount; i++) {
-		GoalItem* goal = itemMgr->getContainer(i);
+	for (goalColor = 0; goalColor < PikiColorCount; goalColor++) {
+		GoalItem* goal = itemMgr->getContainer(goalColor);
 		if (goal && playerState->hasContainer(goal->mOnionColour)) {
-			goal->mSpotModelEff
-			    = effectMgr->create((EffectMgr::modelTypeTable)i, goal->mSRT.t, Vector3f(1.0f, 1.0f, 1.0f), Vector3f(0.0f, 0.0f, 0.0f));
+			goal->mSpotModelEff = effectMgr->create((EffectMgr::modelTypeTable)goalColor, goal->mSRT.t, Vector3f(1.0f, 1.0f, 1.0f),
+			                                        Vector3f(0.0f, 0.0f, 0.0f));
 		}
 	}
 

--- a/src/plugPikiKando/gameCoreSection.cpp
+++ b/src/plugPikiKando/gameCoreSection.cpp
@@ -560,14 +560,16 @@ void GameCoreSection::cleanupDayEnd()
 		int gens      = 0;
 		int creatures = 0;
 		int ufoParts  = 0;
-		FOREACH_NODE(Generator, generatorList->mGenListHead->mChild, gen)
+
+		Generator* gen;
+		FOREACH_NODE_REUSE(Generator, generatorList->mGenListHead->mChild, gen)
 		{
 			if (gen->mCarryOverFlags & GENCARRY_SaveGenerator) {
 				generatorCache->saveGenerator(gen);
 				gens++;
 			}
 		}
-		FOREACH_NODE(Generator, generatorList->mGenListHead->mChild, gen)
+		FOREACH_NODE_REUSE(Generator, generatorList->mGenListHead->mChild, gen)
 		{
 			if ((gen->mCarryOverFlags & GENCARRY_SaveGenerator) && (gen->mCarryOverFlags & GENCARRY_SaveCreature)) {
 				generatorCache->saveGeneratorCreature(gen);

--- a/src/plugPikiKando/gameDemo.cpp
+++ b/src/plugPikiKando/gameDemo.cpp
@@ -57,7 +57,7 @@ DemoFlags::DemoFlags()
 	mStoredFlags      = new u8[mFlagCount];
 	mFlagDataList     = new DemoFlag*[mFlagDataNum];
 
-	int i = 0;
+	int i;
 	for (i = 0; i < mFlagCount; i++) {
 		mStoredFlags[i] = 0;
 	}

--- a/src/plugPikiKando/gameDemo.cpp
+++ b/src/plugPikiKando/gameDemo.cpp
@@ -102,7 +102,7 @@ DemoFlags::DemoFlags()
 	registerDemoFlag(DEMOFLAG_Pluck15thPikmin, "15 NUKI", 12, 0, 0);
 	registerDemoFlag(DEMOFLAG_FirstNoon, "FIRST NOON", 12, 0, 0);
 
-	for (int i = 0; i < MAX_UFO_PARTS; i++) {
+	for (i = 0; i < MAX_UFO_PARTS; i++) {
 		registerDemoFlag(i + DEMOFLAG_UfoPartDiscoveryOffset, "UFO PARTS", 12, i, 0);
 	}
 

--- a/src/plugPikiKando/gameStat.cpp
+++ b/src/plugPikiKando/gameStat.cpp
@@ -64,14 +64,14 @@ void GameStat::init()
  */
 void GameStat::update()
 {
-	int i;
+	int color;
 
-	for (i = PikiMinColor; i < PikiColorCount; i++) {
-		mapPikis.set(formationPikis[i] + freePikis[i] + mePikis[i] + workPikis[i], i);
+	for (color = PikiMinColor; color < PikiColorCount; color++) {
+		mapPikis.set(formationPikis[color] + freePikis[color] + mePikis[color] + workPikis[color], color);
 	}
 
-	for (i = PikiMinColor; i < PikiColorCount; i++) {
-		allPikis.set(mapPikis[i] + containerPikis[i], i);
+	for (color = PikiMinColor; color < PikiColorCount; color++) {
+		allPikis.set(mapPikis[color] + containerPikis[color], color);
 	}
 
 	int total = allPikis;

--- a/src/plugPikiKando/gameStat.cpp
+++ b/src/plugPikiKando/gameStat.cpp
@@ -64,11 +64,13 @@ void GameStat::init()
  */
 void GameStat::update()
 {
-	for (int i = PikiMinColor; i < PikiColorCount; i++) {
+	int i;
+
+	for (i = PikiMinColor; i < PikiColorCount; i++) {
 		mapPikis.set(formationPikis[i] + freePikis[i] + mePikis[i] + workPikis[i], i);
 	}
 
-	for (int i = PikiMinColor; i < PikiColorCount; i++) {
+	for (i = PikiMinColor; i < PikiColorCount; i++) {
 		allPikis.set(mapPikis[i] + containerPikis[i], i);
 	}
 

--- a/src/plugPikiKando/gameStat.cpp
+++ b/src/plugPikiKando/gameStat.cpp
@@ -74,8 +74,7 @@ void GameStat::update()
 		allPikis.set(mapPikis[color] + containerPikis[color], color);
 	}
 
-	int total = allPikis;
-	if (total > maxPikis) {
+	if (allPikis > maxPikis) {
 		maxPikis = allPikis;
 	}
 }

--- a/src/plugPikiKando/genItem.cpp
+++ b/src/plugPikiKando/genItem.cpp
@@ -183,20 +183,20 @@ Creature* GenObjectItem::birth(BirthInfo& info)
 		switch (item->mObjType) {
 		case OBJTYPE_Goal:
 		{
-			GoalItem* goal = (GoalItem*)item;
+			GoalItem* goal = static_cast<GoalItem*>(item);
 			goal->setColorType(mParameterA());
 			break;
 		}
 		case OBJTYPE_Rope:
 		{
-			RopeItem* rope = (RopeItem*)item;
+			RopeItem* rope = static_cast<RopeItem*>(item);
 			rope->_2D0     = mParameterA();
 			rope->autoInit();
 			break;
 		}
 		case OBJTYPE_GemItem:
 		{
-			GemItem* gem = (GemItem*)item;
+			GemItem* gem = static_cast<GemItem*>(item);
 			gem->setColorType(mParameterA());
 			break;
 		}
@@ -205,13 +205,13 @@ Creature* GenObjectItem::birth(BirthInfo& info)
 		case OBJTYPE_SluiceBomb:
 		case OBJTYPE_SluiceBombHard:
 		{
-			BuildingItem* wall = (BuildingItem*)item;
+			BuildingItem* wall = static_cast<BuildingItem*>(item);
 			wall->mNumStages   = mParameterD();
 			break;
 		}
 		case OBJTYPE_RockGen:
 		{
-			RockGen* rock = (RockGen*)item;
+			RockGen* rock = static_cast<RockGen*>(item);
 			f32 size      = mParameterA();
 			if (size <= 0.0f) {
 				size = 30.0f;
@@ -221,7 +221,7 @@ Creature* GenObjectItem::birth(BirthInfo& info)
 		}
 		case OBJTYPE_GrassGen:
 		{
-			GrassGen* grass = (GrassGen*)item;
+			GrassGen* grass = static_cast<GrassGen*>(item);
 			f32 size        = mParameterA();
 			if (size <= 0.0f) {
 				size = 30.0f;
@@ -231,7 +231,7 @@ Creature* GenObjectItem::birth(BirthInfo& info)
 		}
 		case OBJTYPE_Weeds:
 		{
-			WeedsGen* weeds    = (WeedsGen*)item;
+			WeedsGen* weeds    = static_cast<WeedsGen*>(item);
 			weeds->mWeedsCount = mParameterD();
 			break;
 		}
@@ -253,13 +253,13 @@ Creature* GenObjectItem::birth(BirthInfo& info)
 		item->mGenerator->mGeneratorName.sprint(id);
 
 		if (mVersion != 'v0.0' && item->mObjType == OBJTYPE_Door) {
-			DoorItem* door              = (DoorItem*)item;
+			DoorItem* door              = static_cast<DoorItem*>(item);
 			door->mDestinationStagePath = mStageName;
 			door->mLabelText            = mPrintName;
 		}
 
 		if (item->mObjType == OBJTYPE_BombGen) {
-			BombGenItem* bombGen = (BombGenItem*)item;
+			BombGenItem* bombGen = static_cast<BombGenItem*>(item);
 			bombGen->mCapacity = bombGen->mRemaining = mParameterA();
 			bombGen->mGrid.updateGrid(item->mSRT.t);
 		}
@@ -275,11 +275,11 @@ Creature* GenObjectItem::birth(BirthInfo& info)
 					f32 dist = sphereDist(obj, item);
 					if (dist < maxDist) {
 						maxDist = dist;
-						goal    = (GoalItem*)obj;
+						goal    = static_cast<GoalItem*>(obj);
 					}
 				}
 			}
-			((PikiHeadItem*)item)->mParentOnion = goal;
+			static_cast<PikiHeadItem*>(item)->mParentOnion = goal;
 		}
 	}
 	return item;

--- a/src/plugPikiKando/genItem.cpp
+++ b/src/plugPikiKando/genItem.cpp
@@ -99,10 +99,11 @@ void GenObjectItem::doRead(RandomAccessStream& stream)
 	}
 
 	if (mVersion != 'v0.0') {
-		for (int i = 0; i < 32; i++) {
+		int i;
+		for (i = 0; i < 32; i++) {
 			mStageName[i] = stream.readByte();
 		}
-		for (int i = 0; i < 32; i++) {
+		for (i = 0; i < 32; i++) {
 			mPrintName[i] = stream.readByte();
 		}
 	} else {
@@ -123,10 +124,11 @@ void GenObjectItem::doWrite(RandomAccessStream& stream)
 
 	stream.writeString(ObjType::getName(mObjType));
 	if (getLatestVersion() != 'v0.0') {
-		for (int i = 0; i < 32; i++) {
+		int i;
+		for (i = 0; i < 32; i++) {
 			stream.writeByte(mStageName[i]);
 		}
-		for (int i = 0; i < 32; i++) {
+		for (i = 0; i < 32; i++) {
 			stream.writeByte(mPrintName[i]);
 		}
 	}

--- a/src/plugPikiKando/genItem.cpp
+++ b/src/plugPikiKando/genItem.cpp
@@ -102,7 +102,6 @@ void GenObjectItem::doRead(RandomAccessStream& stream)
 		for (int i = 0; i < 32; i++) {
 			mStageName[i] = stream.readByte();
 		}
-
 		for (int i = 0; i < 32; i++) {
 			mPrintName[i] = stream.readByte();
 		}
@@ -127,7 +126,6 @@ void GenObjectItem::doWrite(RandomAccessStream& stream)
 		for (int i = 0; i < 32; i++) {
 			stream.writeByte(mStageName[i]);
 		}
-
 		for (int i = 0; i < 32; i++) {
 			stream.writeByte(mPrintName[i]);
 		}

--- a/src/plugPikiKando/genMapParts.cpp
+++ b/src/plugPikiKando/genMapParts.cpp
@@ -199,17 +199,19 @@ Creature* GenObjectMapParts::birth(BirthInfo& info)
 #ifdef WIN32
 void GenObjectMapParts::doGenAge(AgeServer& server)
 {
+	int i;
+
 	server.StartOptionBox("マップパーツ", &mPartKind, 252); // Map Parts
-	for (int i = 0; i < numKinds; i++) {
+	for (i = 0; i < numKinds; i++) {
 		server.NewOption(kindNames[i], i);
 	}
 	server.EndOptionBox();
 
 	server.StartOptionBox("シェイプ", &mShapeIndex, 252); // Shape
-	for (int i = 0; i < numShapes; i++) {
+	for (i = 0; i < numShapes; i++) {
 		server.NewOption(shapeNames[i], i);
 	}
-	for (int i = 0; i < numParts; i++) {
+	for (i = 0; i < numParts; i++) {
 		server.NewOption(partNames[i], i + numShapes);
 	}
 	server.EndOptionBox();

--- a/src/plugPikiKando/generatorCache.cpp
+++ b/src/plugPikiKando/generatorCache.cpp
@@ -244,7 +244,7 @@ GeneratorCache::Cache* GeneratorCache::findCache(GeneratorCache::Cache& list, u3
  */
 void GeneratorCache::preload(u32 stageID)
 {
-	for (int i = 0; i < 10; i++) {
+	for (int printCount1 = 0; printCount1 < 10; printCount1++) {
 		PRINT("************** PRELOAD **************\n"); // lol
 	}
 
@@ -273,7 +273,7 @@ void GeneratorCache::preload(u32 stageID)
 		PRINT("no data for stage %d\n", stageID);
 	}
 
-	for (int i = 0; i < 10; i++) {
+	for (int printCount2 = 0; printCount2 < 10; printCount2++) {
 		PRINT("**************-----------************\n"); // lol
 	}
 
@@ -608,14 +608,14 @@ void GeneratorCache::dump()
 {
 	PRINT("************ Generator Cache ***********\n");
 	PRINT("--- alive caches ---\n");
-	FOREACH_NODE(Cache, mAliveCacheList.mChild, cache)
+	FOREACH_NODE(Cache, mAliveCacheList.mChild, aliveCache)
 	{
-		cache->dump();
+		aliveCache->dump();
 	}
 	PRINT("--- dead cache ---\n");
-	FOREACH_NODE(Cache, mDeadCacheList.mChild, cache)
+	FOREACH_NODE(Cache, mDeadCacheList.mChild, deadCache)
 	{
-		cache->dump();
+		deadCache->dump();
 	}
 	PRINT("*******************************\n");
 

--- a/src/plugPikiKando/generatorCache.cpp
+++ b/src/plugPikiKando/generatorCache.cpp
@@ -64,7 +64,7 @@ void GeneratorCache::initGame()
 	int idx = 0;
 	FOREACH_NODE_REUSE(Cache, mDeadCacheList.mChild, cache)
 	{
-		cache->mStageID           = idx;
+		cache->mStageID           = idx++;
 		cache->mCacheHeapOffset   = 0;
 		cache->mTotalCacheSize    = 0;
 		cache->mGenCacheSize      = 0;
@@ -73,7 +73,6 @@ void GeneratorCache::initGame()
 		cache->mGenCount          = 0;
 		cache->mCreatureCount     = 0;
 		cache->mUfoPartsCount     = 0;
-		idx++;
 	}
 
 	PRINT("*********** INIT GAME CALLED !!!!!!!!!!!!!!!!!\n");

--- a/src/plugPikiKando/generatorCache.cpp
+++ b/src/plugPikiKando/generatorCache.cpp
@@ -62,7 +62,7 @@ void GeneratorCache::initGame()
 	}
 
 	int idx = 0;
-	FOREACH_NODE(Cache, mDeadCacheList.mChild, cache)
+	FOREACH_NODE_REUSE(Cache, mDeadCacheList.mChild, cache)
 	{
 		cache->mStageID           = idx;
 		cache->mCacheHeapOffset   = 0;

--- a/src/plugPikiKando/kmath.cpp
+++ b/src/plugPikiKando/kmath.cpp
@@ -137,42 +137,44 @@ Vector3f getThrowVelocity(immut Vector3f& startPos, f32 horizSpeed, immut Vector
  */
 f32 getCameraSafeAngle(immut Vector3f& cameraPos, f32 checkDistance, f32 heightWeighting)
 {
-	f32 angleInc = QUARTER_PI;
-	int scores[8]; // visibility scores
+	immut f32 angleInc = TAU / 8; // const meme
+	int visibilityScores[8];
 	int scoreIdx, pointCount;
-	f32 numPointsToCheck = 20.0f;
+	immut int numPointsToCheck = 20; // const meme
+	const f32 distanceToCheck  = checkDistance;
+
 	for (scoreIdx = 0; scoreIdx < 8; scoreIdx++) {
-		scores[scoreIdx] = 0;
+		visibilityScores[scoreIdx] = 0;
 	}
 
 	for (scoreIdx = 0; scoreIdx < 8; scoreIdx++) {
-		f32 currentAngle = angleInc * f32(scoreIdx);
-		Vector3f dir(sinf(currentAngle), 0.0f, cosf(currentAngle));
-		f32 distanceInc = checkDistance / numPointsToCheck;
+		f32 theta = angleInc * scoreIdx;
+		Vector3f dir(sinf(theta), 0.0f, cosf(theta));
+		f32 distanceInc = distanceToCheck / numPointsToCheck;
 
-		// check 20 points along direction vector
-		for (pointCount = 0; pointCount < 20; pointCount++) {
-			f32 heightThreshold = heightWeighting * f32(pointCount) * distanceInc / checkDistance;
+		// check `numPointsToCheck` points along direction vector
+		for (pointCount = 0; pointCount < numPointsToCheck; pointCount++) {
+			f32 heightThreshold = heightWeighting * pointCount * distanceInc / distanceToCheck;
 			Vector3f checkPos;
-			checkPos        = cameraPos + dir * (distanceInc * f32(pointCount));
+			checkPos        = cameraPos + dir * (distanceInc * pointCount);
 			f32 checkHeight = mapMgr->getMinY(checkPos.x, checkPos.z, true);
 			if (checkHeight >= heightThreshold) {
-				scores[scoreIdx] += int(checkHeight - heightThreshold);
+				visibilityScores[scoreIdx] += int(checkHeight - heightThreshold);
 			}
 		}
-		PRINT("score[%d] = %d\n", scoreIdx, scores[scoreIdx]);
+		PRINT("score[%d] = %d\n", scoreIdx, visibilityScores[scoreIdx]);
 	}
 
 	// find angle with lowest score (best visibility):
-	int minScore     = 128000;
-	int bestAngleIdx = -1;
+	int minScore = 128000;
+	int minIndex = -1;
 	for (scoreIdx = 0; scoreIdx < 8; scoreIdx++) {
-		if (scores[scoreIdx] < minScore) {
-			bestAngleIdx = scoreIdx;
-			minScore     = scores[scoreIdx];
+		if (visibilityScores[scoreIdx] < minScore) {
+			minIndex = scoreIdx;
+			minScore = visibilityScores[scoreIdx];
 		}
 	}
 
-	PRINT("minIndex = %d ang = %.1f\n", bestAngleIdx, f32(bestAngleIdx) * angleInc / PI * 180.0f);
-	return f32(bestAngleIdx) * angleInc;
+	PRINT("minIndex = %d ang = %.1f\n", minIndex, minIndex * angleInc / PI * 180.0f);
+	return minIndex * angleInc;
 }

--- a/src/plugPikiKando/kmath.cpp
+++ b/src/plugPikiKando/kmath.cpp
@@ -139,36 +139,37 @@ f32 getCameraSafeAngle(immut Vector3f& cameraPos, f32 checkDistance, f32 heightW
 {
 	f32 angleInc = QUARTER_PI;
 	int scores[8]; // visibility scores
+	int scoreIdx, pointCount;
 	f32 numPointsToCheck = 20.0f;
-	for (int i = 0; i < 8; i++) {
-		scores[i] = 0;
+	for (scoreIdx = 0; scoreIdx < 8; scoreIdx++) {
+		scores[scoreIdx] = 0;
 	}
 
-	for (int i = 0; i < 8; i++) {
-		f32 currentAngle = angleInc * f32(i);
+	for (scoreIdx = 0; scoreIdx < 8; scoreIdx++) {
+		f32 currentAngle = angleInc * f32(scoreIdx);
 		Vector3f dir(sinf(currentAngle), 0.0f, cosf(currentAngle));
 		f32 distanceInc = checkDistance / numPointsToCheck;
 
 		// check 20 points along direction vector
-		for (int j = 0; j < 20; j++) {
-			f32 heightThreshold = heightWeighting * f32(j) * distanceInc / checkDistance;
+		for (pointCount = 0; pointCount < 20; pointCount++) {
+			f32 heightThreshold = heightWeighting * f32(pointCount) * distanceInc / checkDistance;
 			Vector3f checkPos;
-			checkPos        = cameraPos + dir * (distanceInc * f32(j));
+			checkPos        = cameraPos + dir * (distanceInc * f32(pointCount));
 			f32 checkHeight = mapMgr->getMinY(checkPos.x, checkPos.z, true);
 			if (checkHeight >= heightThreshold) {
-				scores[i] += int(checkHeight - heightThreshold);
+				scores[scoreIdx] += int(checkHeight - heightThreshold);
 			}
 		}
-		PRINT("score[%d] = %d\n", i, scores[i]);
+		PRINT("score[%d] = %d\n", scoreIdx, scores[scoreIdx]);
 	}
 
 	// find angle with lowest score (best visibility):
 	int minScore     = 128000;
 	int bestAngleIdx = -1;
-	for (int i = 0; i < 8; i++) {
-		if (scores[i] < minScore) {
-			bestAngleIdx = i;
-			minScore     = scores[i];
+	for (scoreIdx = 0; scoreIdx < 8; scoreIdx++) {
+		if (scores[scoreIdx] < minScore) {
+			bestAngleIdx = scoreIdx;
+			minScore     = scores[scoreIdx];
 		}
 	}
 

--- a/src/plugPikiKando/kmath.cpp
+++ b/src/plugPikiKando/kmath.cpp
@@ -71,7 +71,7 @@ f32 calcImpulse(immut Vector3f& relativePos, f32 mass, immut Vector3f& collision
 /**
  * @todo: Documentation
  */
-Vector3f CRSpline(f32 t, immut Vector3f* ctrlPts)
+Vector3f CRSpline(f32 t, immut Vector3f* const ctrlPts)
 {
 	f32 tSqr = t * t;
 	f32 tCub = tSqr * t;
@@ -87,7 +87,7 @@ Vector3f CRSpline(f32 t, immut Vector3f* ctrlPts)
 /**
  * @todo: Documentation
  */
-Vector3f CRSplineTangent(f32 t, immut Vector3f* ctrlPts)
+Vector3f CRSplineTangent(f32 t, immut Vector3f* const ctrlPts)
 {
 	f32 tSqr = t * t;
 	f32 tCub = tSqr * t; // unused but necessary?? CLEARLY copied from above and edited lol

--- a/src/plugPikiKando/navi.cpp
+++ b/src/plugPikiKando/navi.cpp
@@ -1161,6 +1161,8 @@ void Navi::releasePikis()
 	Iterator iter(mPlateMgr);
 	Piki* pikiList[MAX_PIKI_ON_FIELD * 2]; // This has a capacity of 200 for some reason.
 	int pikiCount = 0;
+	int pikiIdx;
+
 	CI_LOOP(iter)
 	{
 		Piki* piki = static_cast<Piki*>(*iter);
@@ -1177,10 +1179,12 @@ void Navi::releasePikis()
 		// no pikis to dismiss
 		return;
 	}
+
 	Vector3f colorCoMs[PikiColorCount + 1]; // each color + bomb-carriers
 	int colorCounts[PikiColorCount + 1];    // each color + bomb-carriers
 	f32 colorSizes[PikiColorCount + 1];     // each color + bomb-carriers
-	int pikiIdx, colorIdx1;
+	int colorIdx1;
+
 	for (colorIdx1 = 0; colorIdx1 < PikiColorCount + 1; colorIdx1++) {
 		colorCoMs[colorIdx1].set(0.0f, 0.0f, 0.0f);
 		colorCounts[colorIdx1] = 0;
@@ -1189,7 +1193,7 @@ void Navi::releasePikis()
 	for (colorIdx1 = 0; colorIdx1 < PikiColorCount + 1; colorIdx1++) {
 		for (pikiIdx = 0; pikiIdx < pikiCount; pikiIdx++) {
 			if (colorIdx1 == Blue || colorIdx1 == Red) {
-				if (colorIdx1 == pikiList[pikiIdx]->mColor) {
+				if (pikiList[pikiIdx]->mColor == colorIdx1) {
 					colorCounts[colorIdx1]++;
 					colorCoMs[colorIdx1].add(pikiList[pikiIdx]->mSRT.t);
 				}
@@ -1214,13 +1218,16 @@ void Navi::releasePikis()
 		}
 	}
 
-	// They made a new loop variable for some reason.
+	const f32 maxSepDist = 18.0f;  // 100% CONFIRMED CONST MEME!
+	
+	 // They made a new loop variable for some reason.
 	for (int colorIdx2 = 0; colorIdx2 < PikiColorCount + 1; colorIdx2++) {
 		if (colorCounts[colorIdx2] > 0) {
 			Vector3f sepNaviGroup = colorCoMs[colorIdx2] - mSRT.t;
-			f32 dist              = sepNaviGroup.normalise() - colorSizes[colorIdx2] - 15.0f;
-			if (dist < 18.0f) {
-				dist = 18.0f - dist;
+			f32 normaliseResult   = sepNaviGroup.normalise();
+			f32 dist              = normaliseResult - colorSizes[colorIdx2] - 15.0f;
+			if (dist < maxSepDist) {
+				dist = maxSepDist - dist;
 				Vector3f offsetFromNavi;
 				offsetFromNavi = dist * sepNaviGroup;
 				colorCoMs[colorIdx2].add(offsetFromNavi);
@@ -1230,9 +1237,11 @@ void Navi::releasePikis()
 		for (int nextColor = colorIdx2 + 1; nextColor < PikiColorCount + 1; nextColor++) {
 			if (colorCounts[colorIdx2] > 0 && colorCounts[nextColor] > 0) {
 				Vector3f colorColorSep = colorCoMs[colorIdx2] - colorCoMs[nextColor];
-				f32 colorDist          = colorColorSep.normalise() - colorSizes[colorIdx2] - colorSizes[nextColor];
-				if (colorDist < 18.0f) {
-					colorDist = (18.0f - colorDist);
+				f32 normaliseResult    = colorColorSep.normalise();
+				f32 colorDist          = normaliseResult - colorSizes[colorIdx2] - colorSizes[nextColor];
+				if (colorDist < maxSepDist) {
+					colorDist = (maxSepDist - colorDist);
+					colorDist *= 1.0f;
 					Vector3f interColorOffset;
 					interColorOffset = colorDist * colorColorSep;
 					colorCoMs[colorIdx2].add(interColorOffset);
@@ -1255,8 +1264,6 @@ void Navi::releasePikis()
 			pikiList[pikiIdx]->mNavi = nullptr;
 		}
 	}
-
-	STACK_PAD_VAR(2);
 }
 
 /**

--- a/src/plugPikiKando/navi.cpp
+++ b/src/plugPikiKando/navi.cpp
@@ -1180,78 +1180,79 @@ void Navi::releasePikis()
 	Vector3f colorCoMs[PikiColorCount + 1]; // each color + bomb-carriers
 	int colorCounts[PikiColorCount + 1];    // each color + bomb-carriers
 	f32 colorSizes[PikiColorCount + 1];     // each color + bomb-carriers
-	int j, i;
-	for (i = 0; i < PikiColorCount + 1; i++) {
-		colorCoMs[i].set(0.0f, 0.0f, 0.0f);
-		colorCounts[i] = 0;
+	int pikiIdx, colorIdx1;
+	for (colorIdx1 = 0; colorIdx1 < PikiColorCount + 1; colorIdx1++) {
+		colorCoMs[colorIdx1].set(0.0f, 0.0f, 0.0f);
+		colorCounts[colorIdx1] = 0;
 	}
 
-	for (i = 0; i < PikiColorCount + 1; i++) {
-		for (j = 0; j < pikiCount; j++) {
-			if (i == Blue || i == Red) {
-				if (i == pikiList[j]->mColor) {
-					colorCounts[i]++;
-					colorCoMs[i].add(pikiList[j]->mSRT.t);
+	for (colorIdx1 = 0; colorIdx1 < PikiColorCount + 1; colorIdx1++) {
+		for (pikiIdx = 0; pikiIdx < pikiCount; pikiIdx++) {
+			if (colorIdx1 == Blue || colorIdx1 == Red) {
+				if (colorIdx1 == pikiList[pikiIdx]->mColor) {
+					colorCounts[colorIdx1]++;
+					colorCoMs[colorIdx1].add(pikiList[pikiIdx]->mSRT.t);
 				}
 			} else {
-				if (pikiList[j]->mColor == Yellow) {
-					if (pikiList[j]->hasBomb()) {
+				if (pikiList[pikiIdx]->mColor == Yellow) {
+					if (pikiList[pikiIdx]->hasBomb()) {
 						colorCounts[3]++;
-						colorCoMs[3].add(pikiList[j]->mSRT.t);
+						colorCoMs[3].add(pikiList[pikiIdx]->mSRT.t);
 					} else {
 						colorCounts[Yellow]++;
-						colorCoMs[Yellow].add(pikiList[j]->mSRT.t);
+						colorCoMs[Yellow].add(pikiList[pikiIdx]->mSRT.t);
 					}
 				}
 			}
 		}
 	}
 
-	for (i = 0; i < PikiColorCount + 1; i++) {
-		if (colorCounts[i] > 0) {
-			colorCoMs[i].multiply(1.0f / colorCounts[i]);
-			colorSizes[i] = (2.5f * pikiList[0]->getSize()) * std::sqrtf(colorCounts[i]);
+	for (colorIdx1 = 0; colorIdx1 < PikiColorCount + 1; colorIdx1++) {
+		if (colorCounts[colorIdx1] > 0) {
+			colorCoMs[colorIdx1].multiply(1.0f / colorCounts[colorIdx1]);
+			colorSizes[colorIdx1] = (2.5f * pikiList[0]->getSize()) * std::sqrtf(colorCounts[colorIdx1]);
 		}
 	}
 
-	for (int k = 0; k < PikiColorCount + 1; k++) {
-		if (colorCounts[k] > 0) {
-			Vector3f sepNaviGroup = colorCoMs[k] - mSRT.t;
-			f32 dist              = sepNaviGroup.normalise() - colorSizes[k] - 15.0f;
+	// They made a new loop variable for some reason.
+	for (int colorIdx2 = 0; colorIdx2 < PikiColorCount + 1; colorIdx2++) {
+		if (colorCounts[colorIdx2] > 0) {
+			Vector3f sepNaviGroup = colorCoMs[colorIdx2] - mSRT.t;
+			f32 dist              = sepNaviGroup.normalise() - colorSizes[colorIdx2] - 15.0f;
 			if (dist < 18.0f) {
 				dist = 18.0f - dist;
 				Vector3f offsetFromNavi;
 				offsetFromNavi = dist * sepNaviGroup;
-				colorCoMs[k].add(offsetFromNavi);
+				colorCoMs[colorIdx2].add(offsetFromNavi);
 			}
 		}
 
-		for (int j = k + 1; j < PikiColorCount + 1; j++) {
-			if (colorCounts[k] > 0 && colorCounts[j] > 0) {
-				Vector3f colorColorSep = colorCoMs[k] - colorCoMs[j];
-				f32 colorDist          = colorColorSep.normalise() - colorSizes[k] - colorSizes[j];
+		for (int nextColor = colorIdx2 + 1; nextColor < PikiColorCount + 1; nextColor++) {
+			if (colorCounts[colorIdx2] > 0 && colorCounts[nextColor] > 0) {
+				Vector3f colorColorSep = colorCoMs[colorIdx2] - colorCoMs[nextColor];
+				f32 colorDist          = colorColorSep.normalise() - colorSizes[colorIdx2] - colorSizes[nextColor];
 				if (colorDist < 18.0f) {
 					colorDist = (18.0f - colorDist);
 					Vector3f interColorOffset;
 					interColorOffset = colorDist * colorColorSep;
-					colorCoMs[k].add(interColorOffset);
-					colorCoMs[j].sub(interColorOffset);
+					colorCoMs[colorIdx2].add(interColorOffset);
+					colorCoMs[nextColor].sub(interColorOffset);
 				}
 			}
 		}
 	}
 
-	for (j = 0; j < pikiCount; j++) {
-		pikiList[j]->changeMode(PikiMode::FreeMode, this);
-		int color = pikiList[j]->mColor;
-		if (pikiList[j]->hasBomb()) {
+	for (pikiIdx = 0; pikiIdx < pikiCount; pikiIdx++) {
+		pikiList[pikiIdx]->changeMode(PikiMode::FreeMode, this);
+		int color = pikiList[pikiIdx]->mColor;
+		if (pikiList[pikiIdx]->hasBomb()) {
 			color = PikiColorCount;
 		}
 
-		ActFree* action = static_cast<ActFree*>(pikiList[j]->mActiveAction->getCurrAction());
+		ActFree* action = static_cast<ActFree*>(pikiList[pikiIdx]->mActiveAction->getCurrAction());
 		action->initBoid(colorCoMs[color], colorSizes[color]);
-		if (flowCont.mIsVersusMode == TRUE && pikiList[j]->mPlayerId == -1) {
-			pikiList[j]->mNavi = nullptr;
+		if (flowCont.mIsVersusMode == TRUE && pikiList[pikiIdx]->mPlayerId == -1) {
+			pikiList[pikiIdx]->mNavi = nullptr;
 		}
 	}
 

--- a/src/plugPikiKando/navi.cpp
+++ b/src/plugPikiKando/navi.cpp
@@ -251,8 +251,7 @@ void Navi::updateDayEnd(immut Vector3f& pos)
  */
 void Navi::enterAllPikis()
 {
-	// This has a capacity of 200 in the vanilla game for some reason.
-	Piki* pikiList[MAX_PIKI_ON_FIELD == 100 ? 200 : MAX_PIKI_ON_FIELD];
+	Piki* pikiList[MAX_PIKI_ON_FIELD * 2]; // This has a capacity of 200 for some reason.
 	GoalItem* onyons[PikiColorCount];
 	int i;
 	for (i = 0; i < PikiColorCount; i++) {
@@ -1160,8 +1159,7 @@ void Navi::callDebugs(f32 radius)
 void Navi::releasePikis()
 {
 	Iterator iter(mPlateMgr);
-	// This has a capacity of 200 in the vanilla game for some reason.
-	Piki* pikiList[MAX_PIKI_ON_FIELD == 100 ? 200 : MAX_PIKI_ON_FIELD];
+	Piki* pikiList[MAX_PIKI_ON_FIELD * 2]; // This has a capacity of 200 for some reason.
 	int pikiCount = 0;
 	CI_LOOP(iter)
 	{
@@ -1181,7 +1179,7 @@ void Navi::releasePikis()
 	}
 	Vector3f colorCoMs[PikiColorCount + 1]; // each color + bomb-carriers
 	int colorCounts[PikiColorCount + 1];    // each color + bomb-carriers
-	f32 colorSizes[PikiColorCount + 1];
+	f32 colorSizes[PikiColorCount + 1];     // each color + bomb-carriers
 	int j, i;
 	for (i = 0; i < PikiColorCount + 1; i++) {
 		colorCoMs[i].set(0.0f, 0.0f, 0.0f);
@@ -1247,7 +1245,7 @@ void Navi::releasePikis()
 		pikiList[i]->changeMode(PikiMode::FreeMode, this);
 		int color = pikiList[i]->mColor;
 		if (pikiList[i]->hasBomb()) {
-			color = 3;
+			color = PikiColorCount;
 		}
 
 		ActFree* action = static_cast<ActFree*>(pikiList[i]->mActiveAction->getCurrAction());

--- a/src/plugPikiKando/navi.cpp
+++ b/src/plugPikiKando/navi.cpp
@@ -1214,44 +1214,44 @@ void Navi::releasePikis()
 		}
 	}
 
-	for (int i = 0; i < PikiColorCount + 1; i++) {
-		if (colorCounts[i] > 0) {
-			Vector3f sepNaviGroup = colorCoMs[i] - mSRT.t;
-			f32 dist              = sepNaviGroup.normalise() - colorSizes[i] - 15.0f;
+	for (int k = 0; k < PikiColorCount + 1; k++) {
+		if (colorCounts[k] > 0) {
+			Vector3f sepNaviGroup = colorCoMs[k] - mSRT.t;
+			f32 dist              = sepNaviGroup.normalise() - colorSizes[k] - 15.0f;
 			if (dist < 18.0f) {
 				dist = 18.0f - dist;
 				Vector3f offsetFromNavi;
 				offsetFromNavi = dist * sepNaviGroup;
-				colorCoMs[i].add(offsetFromNavi);
+				colorCoMs[k].add(offsetFromNavi);
 			}
 		}
 
-		for (int j = i + 1; j < PikiColorCount + 1; j++) {
-			if (colorCounts[i] > 0 && colorCounts[j] > 0) {
-				Vector3f colorColorSep = colorCoMs[i] - colorCoMs[j];
-				f32 colorDist          = colorColorSep.normalise() - colorSizes[i] - colorSizes[j];
+		for (int j = k + 1; j < PikiColorCount + 1; j++) {
+			if (colorCounts[k] > 0 && colorCounts[j] > 0) {
+				Vector3f colorColorSep = colorCoMs[k] - colorCoMs[j];
+				f32 colorDist          = colorColorSep.normalise() - colorSizes[k] - colorSizes[j];
 				if (colorDist < 18.0f) {
 					colorDist = (18.0f - colorDist);
 					Vector3f interColorOffset;
 					interColorOffset = colorDist * colorColorSep;
-					colorCoMs[i].add(interColorOffset);
+					colorCoMs[k].add(interColorOffset);
 					colorCoMs[j].sub(interColorOffset);
 				}
 			}
 		}
 	}
 
-	for (i = 0; i < pikiCount; i++) {
-		pikiList[i]->changeMode(PikiMode::FreeMode, this);
-		int color = pikiList[i]->mColor;
-		if (pikiList[i]->hasBomb()) {
+	for (j = 0; j < pikiCount; j++) {
+		pikiList[j]->changeMode(PikiMode::FreeMode, this);
+		int color = pikiList[j]->mColor;
+		if (pikiList[j]->hasBomb()) {
 			color = PikiColorCount;
 		}
 
-		ActFree* action = static_cast<ActFree*>(pikiList[i]->mActiveAction->getCurrAction());
+		ActFree* action = static_cast<ActFree*>(pikiList[j]->mActiveAction->getCurrAction());
 		action->initBoid(colorCoMs[color], colorSizes[color]);
-		if (flowCont.mIsVersusMode == TRUE && pikiList[i]->mPlayerId == -1) {
-			pikiList[i]->mNavi = nullptr;
+		if (flowCont.mIsVersusMode == TRUE && pikiList[j]->mPlayerId == -1) {
+			pikiList[j]->mNavi = nullptr;
 		}
 	}
 

--- a/src/plugPikiKando/naviDemoState.cpp
+++ b/src/plugPikiKando/naviDemoState.cpp
@@ -207,8 +207,7 @@ void NaviDemoSunsetState::WhistleState::procAnimMsg(NaviDemoSunsetState* state, 
  */
 void NaviDemoSunsetState::WhistleState::enterAllPikis(NaviDemoSunsetState* state)
 {
-	// This has a capacity of 200 in the vanilla game for some reason.
-	Piki* pikiList[MAX_PIKI_ON_FIELD == 100 ? 200 : MAX_PIKI_ON_FIELD];
+	Piki* pikiList[MAX_PIKI_ON_FIELD * 2]; // This has a capacity of 200 for some reason.
 	Navi* navi = state->mNavi;
 	Iterator it(itemMgr);
 	GoalItem* goals[3];

--- a/src/plugPikiKando/naviState.cpp
+++ b/src/plugPikiKando/naviState.cpp
@@ -1065,8 +1065,7 @@ void NaviContainerState::exec(Navi* navi)
 void NaviContainerState::enterPikis(Navi* navi, int countToEnter)
 {
 	PRINT("goal color = %d\n", navi->mGoalItem->mOnionColour);
-	// This has a capacity of 200 in the vanilla game for some reason.
-	Piki* pikiList[MAX_PIKI_ON_FIELD == 100 ? 200 : MAX_PIKI_ON_FIELD];
+	Piki* pikiList[MAX_PIKI_ON_FIELD * 2]; // This has a capacity of 200 for some reason.
 	int numPikis = 0;
 	Iterator it(navi->mPlateMgr);
 

--- a/src/plugPikiKando/pelletMgr.cpp
+++ b/src/plugPikiKando/pelletMgr.cpp
@@ -1890,6 +1890,7 @@ void PelletMgr::genAge(AgeServer& server)
 	server.NewButton("new animinfo", new Delegate1<PelletMgr, AgeServer&>(this, addAnimInfo), 221);
 	server.NewButton("Load", new Delegate1<PelletMgr, AgeServer&>(this, animInfoRead), 221);
 	server.NewButton("Save", new Delegate1<PelletMgr, AgeServer&>(this, animInfoWrite), 221);
+	server.EndGroup();
 	FOREACH_NODE_REUSE(CoreNode, mAnimInfoList.mChild, cnode)
 	{
 		PelletAnimInfo* info = static_cast<PelletAnimInfo*>(cnode);
@@ -1904,6 +1905,7 @@ void PelletMgr::genAge(AgeServer& server)
 	server.NewButton("new config", new Delegate1<PelletMgr, AgeServer&>(this, addConfig), 221);
 	server.NewButton("Load", new Delegate1<PelletMgr, AgeServer&>(this, configRead), 221);
 	server.NewButton("Save", new Delegate1<PelletMgr, AgeServer&>(this, configWrite), 221);
+	server.EndGroup();
 	FOREACH_NODE_REUSE(CoreNode, mConfigList.mChild, cnode)
 	{
 		PelletConfig* config = static_cast<PelletConfig*>(cnode);

--- a/src/plugPikiKando/pelletMgr.cpp
+++ b/src/plugPikiKando/pelletMgr.cpp
@@ -1883,13 +1883,16 @@ void PelletMgr::genAge(AgeServer& server)
 	server.NewButton("new config", new Delegate1<PelletMgr, AgeServer&>(this, addConfig), 221);
 	server.EndGroup();
 
+	CoreNode* cnode;
+
 	server.StartSection("シェイプ管理", true); // shape management
 	server.StartGroup("file");
 	server.NewButton("new animinfo", new Delegate1<PelletMgr, AgeServer&>(this, addAnimInfo), 221);
 	server.NewButton("Load", new Delegate1<PelletMgr, AgeServer&>(this, animInfoRead), 221);
 	server.NewButton("Save", new Delegate1<PelletMgr, AgeServer&>(this, animInfoWrite), 221);
-	FOREACH_NODE(PelletAnimInfo, mAnimInfoList.mChild, info)
+	FOREACH_NODE_REUSE(CoreNode, mAnimInfoList.mChild, cnode)
 	{
+		PelletAnimInfo* info = static_cast<PelletAnimInfo*>(cnode);
 		server.StartSection(info->mID.mStringID, true);
 		server.setSectionRefresh(new Delegate1<PelletAnimInfo, AgeServer&>(info, PelletAnimInfo::genAge));
 		server.EndSection();
@@ -1901,8 +1904,9 @@ void PelletMgr::genAge(AgeServer& server)
 	server.NewButton("new config", new Delegate1<PelletMgr, AgeServer&>(this, addConfig), 221);
 	server.NewButton("Load", new Delegate1<PelletMgr, AgeServer&>(this, configRead), 221);
 	server.NewButton("Save", new Delegate1<PelletMgr, AgeServer&>(this, configWrite), 221);
-	FOREACH_NODE(PelletConfig, mConfigList.mChild, config)
+	FOREACH_NODE_REUSE(CoreNode, mConfigList.mChild, cnode)
 	{
+		PelletConfig* config = static_cast<PelletConfig*>(cnode);
 		server.StartSection(config->mPelletName().mString, true);
 		server.setSectionRefresh(new Delegate1<PelletConfig, AgeServer&>(config, CoreNode::genAge));
 		server.EndSection();
@@ -1910,8 +1914,9 @@ void PelletMgr::genAge(AgeServer& server)
 	server.EndSection();
 
 	server.StartSection("animMgr", true);
-	FOREACH_NODE(PelletAnimInfo, mAnimInfoList.mChild, info)
+	FOREACH_NODE_REUSE(CoreNode, mAnimInfoList.mChild, cnode)
 	{
+		PelletAnimInfo* info = static_cast<PelletAnimInfo*>(cnode);
 		if (info->mPelletShapeObject) {
 			info->mPelletShapeObject->genAge(server);
 		}

--- a/src/plugPikiKando/resultFlag.cpp
+++ b/src/plugPikiKando/resultFlag.cpp
@@ -364,11 +364,11 @@ void ResultFlags::dump()
 		}
 #endif
 
-		if (prev != flagTable[i].type()) {
+		if (prev != info.type()) {
 			p    = 0;
-			prev = flagTable[i].type();
+			prev = info.type();
 		}
-		prev = flagTable[i].type();
+		prev = info.type();
 
 #if defined(DEVELOP) || defined(WIN32)
 		strs[0] = "OFF";
@@ -381,7 +381,7 @@ void ResultFlags::dump()
 #endif
 
 		// So as a result of all that, this PRINT contains brazen (but stripped) undefined behavior (`strs[3]`) in the retail game.
-		PRINT(" ENUM_RESULT_%s_G%02d_P00 = %s : %d pages\n", strs[3], p++, strs[getFlag(flagTable[i].mScreenId)],
+		PRINT(" ENUM_RESULT_%s_G%02d_P00 = %s : %d pages\n", strs[3], p++, strs[getFlag(info.mScreenId)],
 		      (flagTable[i + 1].mScreenId == -1) ? 1 : flagTable[i + 1].mScreenId - info.mScreenId);
 	}
 	PRINT("*************************************************\n");
@@ -394,7 +394,10 @@ u8 ResultFlags::getFlag(int index)
 {
 	int a = mScreenToTableList[index];
 	int b = a >> 2;
-	return mStates[b] >> ((a - b * 4) * 2) & 3;
+	int c = a - b * 4;
+	u8 d = mStates[b];
+	d = d >> (c * 2);
+	return d & 3;
 }
 
 /**

--- a/src/plugPikiKando/resultFlag.cpp
+++ b/src/plugPikiKando/resultFlag.cpp
@@ -375,7 +375,7 @@ void ResultFlags::dump()
 		STACK_PAD_INLINE(1);
 #endif
 
-		// So as a result of all that, the final game version this PRINT contains brazen (but stripped) undefined behavior (`strs[3]`).
+		// So as a result of all that, this PRINT contains brazen (but stripped) undefined behavior (`strs[3]`) in the retail game.
 		PRINT(" ENUM_RESULT_%s_G%02d_P00 = %s : %d pages\n", strs[3], p++, strs[getFlag(flagTable[i].mScreenId)],
 		      (flagTable[i + 1].mScreenId == -1) ? 1 : flagTable[i + 1].mScreenId - info.mScreenId);
 	}

--- a/src/plugPikiKando/resultFlag.cpp
+++ b/src/plugPikiKando/resultFlag.cpp
@@ -107,11 +107,14 @@ ResultFlags::ResultFlags()
 	mScreenToTableList = new u32[max + 110];
 	mActiveCount       = 0;
 	mStates            = new u8[mLength];
-	for (int i = 0; i < mLength; i++) {
+
+	int i;
+
+	for (i = 0; i < mLength; i++) {
 		mStates[i] = false;
 	}
 
-	for (int i = 0; i < mTableSize; i++) {
+	for (i = 0; i < mTableSize; i++) {
 		if (flagTable[i].mScreenId == -1) {
 			break;
 		}
@@ -125,7 +128,7 @@ ResultFlags::ResultFlags()
 		mActiveCount++;
 	}
 
-	for (int i = 0; i < MAX_DAYS; i++) {
+	for (i = 0; i < MAX_DAYS; i++) {
 		mDaysSeen[i] = -1;
 	}
 
@@ -141,11 +144,13 @@ ResultFlags::ResultFlags()
  */
 void ResultFlags::initGame()
 {
-	for (int i = 0; i < mLength; i++) {
+	int i;
+
+	for (i = 0; i < mLength; i++) {
 		mStates[i] = false;
 	}
 
-	for (int i = 0; i < mTableSize; i++) {
+	for (i = 0; i < mTableSize; i++) {
 		if (flagTable[i].mScreenId == -1) {
 			break;
 		}
@@ -156,7 +161,7 @@ void ResultFlags::initGame()
 		}
 	}
 
-	for (int i = 0; i < MAX_DAYS; i++) {
+	for (i = 0; i < MAX_DAYS; i++) {
 		mDaysSeen[i] = -1;
 	}
 

--- a/src/plugPikiKando/routeMgr.cpp
+++ b/src/plugPikiKando/routeMgr.cpp
@@ -382,11 +382,11 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 	// Current and destination positions (XZ plane)
 	Vector3f currPos = getWayPoint(buf.mWayPointIdx)->mPosition;
 	Vector3f destPos = getWayPoint(destWPIdx)->mPosition;
-	int dir;
+	int linkDir;
 
-	for (dir = 0; dir < 8; dir++) {
+	for (linkDir = 0; linkDir < 8; linkDir++) {
 		// Skip if this direction is not available
-		if (!buf.check(dir)) {
+		if (!buf.check(linkDir)) {
 			continue;
 		}
 
@@ -403,14 +403,14 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 		}
 
 		// Skip self-links
-		int neighborIdx = wp->mLinkIndices[dir];
+		int neighborIdx = wp->mLinkIndices[linkDir];
 		if (neighborIdx == buf.mWayPointIdx) {
 			continue;
 		}
 
 		// Invalid link index: clear flag and skip
 		if (neighborIdx == -1) {
-			buf.resetFlag(dir);
+			buf.resetFlag(linkDir);
 			continue;
 		}
 
@@ -422,7 +422,7 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 
 		// Exclude closed/blocked paths if not allowed
 		if (!includeBlockedPaths && !getWayPoint(neighborIdx)->mIsOpen) {
-			buf.resetFlag(dir);
+			buf.resetFlag(linkDir);
 			continue;
 		}
 
@@ -446,11 +446,11 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 		}
 
 		// Record this direction as a candidate
-		dirIndices[validLinkCount] = dir;
+		dirIndices[validLinkCount] = linkDir;
 
 		// If this neighbor is the destination, return immediately
 		if (neighborIdx == destWPIdx) {
-			return dir;
+			return linkDir;
 		}
 
 		// Squared horizontal distance to destination
@@ -462,10 +462,10 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 
 	// Choose the candidate with minimum squared distance to destination
 	f32 bestDist = 128000.0f;
-	for (dir = 0; dir < validLinkCount; dir++) {
-		if (distToDestSq[dir] < bestDist) {
-			bestDist  = distToDestSq[dir];
-			chosenDir = dirIndices[dir];
+	for (linkDir = 0; linkDir < validLinkCount; linkDir++) {
+		if (distToDestSq[linkDir] < bestDist) {
+			bestDist  = distToDestSq[linkDir];
+			chosenDir = dirIndices[linkDir];
 		}
 	}
 
@@ -1531,17 +1531,17 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 	Vector3f wpPos   = getWayPoint(buf.mWayPointIdx)->mPosition;
 	Vector3f destPos = getWayPoint(destWPIdx)->mPosition;
 	////////////////////////////////////////////////////////////
-	int dir;
+	int linkDir;
 
-	for (dir = 0; dir < 8; dir++) {
+	for (linkDir = 0; linkDir < 8; linkDir++) {
 		// Skip if this direction is not available
-		if (!buf.check(dir)) {
+		if (!buf.check(linkDir)) {
 			continue;
 		}
 
 		WayPoint* wp = getWayPoint(buf.mWayPointIdx);
 		if (!PathFinder::checkMode(PathFinderMode::AvoidWater) || !wp->inWater()) {
-			int neighborIdx = wp->mLinkIndices[dir];
+			int neighborIdx = wp->mLinkIndices[linkDir];
 
 			// Skip self-referencing links
 			if (neighborIdx == buf.mWayPointIdx) {
@@ -1550,13 +1550,13 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 
 			// Handle invalid links by resetting the flag
 			if (neighborIdx == -1) {
-				buf.resetFlag(dir);
+				buf.resetFlag(linkDir);
 				continue;
 			}
 
 			// Check if connected waypoint is closed (and we're not ignoring closed waypoints)
 			if (!ignoreClosedWaypoints && !getWayPoint(neighborIdx)->mIsOpen) {
-				buf.resetFlag(dir);
+				buf.resetFlag(linkDir);
 				continue;
 			}
 
@@ -1570,16 +1570,16 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 			}
 
 			// Add to valid links if it has valid pathfinding info and hasn't been visited
-			if (wp->mLinkInfos[dir].getInfo(goalType) != -2 && !isAlreadyVisited) {
-				validLinkIndices[validLinkCount] = dir;
+			if (wp->mLinkInfos[linkDir].getInfo(goalType) != -2 && !isAlreadyVisited) {
+				validLinkIndices[validLinkCount] = linkDir;
 
 				// If this link leads directly to destination, return immediately (optimal path found)
 				if (neighborIdx == destWPIdx) {
-					return dir;
+					return linkDir;
 				}
 
 				// Store the pathfinding cost for this link
-				pathCosts[validLinkCount] = wp->mLinkInfos[dir].getInfo(goalType);
+				pathCosts[validLinkCount] = wp->mLinkInfos[linkDir].getInfo(goalType);
 				validLinkCount++;
 			}
 		}
@@ -1587,10 +1587,10 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 
 	// Phase 2: Find the best (lowest cost) option among all valid links
 	int lowestCost = 128000;
-	for (dir = 0; dir < validLinkCount; dir++) {
-		if (pathCosts[dir] < lowestCost) {
-			lowestCost    = pathCosts[dir];
-			bestLinkIndex = validLinkIndices[dir];
+	for (linkDir = 0; linkDir < validLinkCount; linkDir++) {
+		if (pathCosts[linkDir] < lowestCost) {
+			lowestCost    = pathCosts[linkDir];
+			bestLinkIndex = validLinkIndices[linkDir];
 		}
 	}
 
@@ -1632,17 +1632,17 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 
 	Vector3f wpPos   = getWayPoint(buf.mWayPointIdx)->mPosition;
 	Vector3f destPos = getWayPoint(destWPIdx)->mPosition;
-	int dir;
+	int linkDir;
 
-	for (dir = 0; dir < 8; dir++) {
+	for (linkDir = 0; linkDir < 8; linkDir++) {
 		// Skip if this direction is not available
-		if (!buf.check(dir)) {
+		if (!buf.check(linkDir)) {
 			continue;
 		}
 
 		WayPoint* currWP = getWayPoint(buf.mWayPointIdx);
 		if (!PathFinder::checkMode(PathFinderMode::AvoidWater) || !currWP->inWater()) {
-			int neighborIdx = currWP->mLinkIndices[dir];
+			int neighborIdx = currWP->mLinkIndices[linkDir];
 
 			// Skip self-referencing links
 			if (neighborIdx == buf.mWayPointIdx) {
@@ -1651,36 +1651,36 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 
 			// Handle invalid links by resetting the flag
 			if (neighborIdx == -1) {
-				buf.resetFlag(dir);
+				buf.resetFlag(linkDir);
 				continue;
 			}
 
 			// Check if connected waypoint is closed (and we're not ignoring closed waypoints)
 			if (!ignoreClosedWaypoints && !getWayPoint(neighborIdx)->mIsOpen) {
-				buf.resetFlag(dir);
+				buf.resetFlag(linkDir);
 				continue;
 			}
 
 			// Check if this waypoint has already been visited to avoid cycles
 			bool isAlreadyVisited = false;
-			for (int j = 0; j < bufIdx; j++) {
-				if (bufferList[j].mWayPointIdx == neighborIdx) {
+			for (int bufIdx = 0; bufIdx < bufIdx; bufIdx++) {
+				if (bufferList[bufIdx].mWayPointIdx == neighborIdx) {
 					isAlreadyVisited = true;
 					break;
 				}
 			}
 
 			// Add to valid links if it has valid pathfinding info and hasn't been visited
-			if (currWP->mLinkInfos[dir].getInfo(goalType) != -2 && !isAlreadyVisited) {
-				validLinkIndices[validLinkCount] = dir;
+			if (currWP->mLinkInfos[linkDir].getInfo(goalType) != -2 && !isAlreadyVisited) {
+				validLinkIndices[validLinkCount] = linkDir;
 
 				// If this link leads directly to destination, return immediately
 				if (neighborIdx == destWPIdx) {
-					return dir;
+					return linkDir;
 				}
 
 				// Store the pathfinding cost for this link
-				pathCosts[validLinkCount] = currWP->mLinkInfos[dir].getInfo(goalType);
+				pathCosts[validLinkCount] = currWP->mLinkInfos[linkDir].getInfo(goalType);
 				validLinkCount++;
 			}
 		}
@@ -1688,10 +1688,10 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 
 	// Phase 2: Find the best (lowest cost) option
 	int lowestCost = 128000;
-	for (dir = 0; dir < validLinkCount; dir++) {
-		if (pathCosts[dir] < lowestCost) {
-			lowestCost    = pathCosts[dir];
-			bestLinkIndex = validLinkIndices[dir];
+	for (linkDir = 0; linkDir < validLinkCount; linkDir++) {
+		if (pathCosts[linkDir] < lowestCost) {
+			lowestCost    = pathCosts[linkDir];
+			bestLinkIndex = validLinkIndices[linkDir];
 		}
 	}
 
@@ -1699,11 +1699,11 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 	int secondBestLinkIndex = -1;
 	secondBestCost          = 128000;
 
-	for (dir = 0; dir < validLinkCount; dir++) {
+	for (linkDir = 0; linkDir < validLinkCount; linkDir++) {
 		// Skip the best option and only consider better costs than current second-best
-		if (dir != bestLinkIndex && pathCosts[dir] < secondBestCost) {
-			WayPoint* wp1 = getWayPoint(buf.mWayPointIdx);                         // Source waypoint
-			WayPoint* wp2 = getWayPoint(wp1->mLinkIndices[validLinkIndices[dir]]); // Destination waypoint
+		if (linkDir != bestLinkIndex && pathCosts[linkDir] < secondBestCost) {
+			WayPoint* wp1 = getWayPoint(buf.mWayPointIdx);                             // Source waypoint
+			WayPoint* wp2 = getWayPoint(wp1->mLinkIndices[validLinkIndices[linkDir]]); // Destination waypoint
 
 			bool geometricallyValid = true;
 
@@ -1745,8 +1745,8 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 
 			// Update second-best if this option passes geometric validation
 			if (geometricallyValid) {
-				secondBestLinkIndex = dir;
-				secondBestCost      = pathCosts[dir];
+				secondBestLinkIndex = linkDir;
+				secondBestCost      = pathCosts[linkDir];
 			}
 		}
 	}

--- a/src/plugPikiKando/routeMgr.cpp
+++ b/src/plugPikiKando/routeMgr.cpp
@@ -379,85 +379,87 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 	f32 distToDestSq[8];
 	int dirIndices[8];
 
-	// Current and destination positions (XZ plane)
+	// NEVER USED, FOR WHATEVER REASON /////////////////////////
 	Vector3f currPos = getWayPoint(buf.mWayPointIdx)->mPosition;
 	Vector3f destPos = getWayPoint(destWPIdx)->mPosition;
+	////////////////////////////////////////////////////////////
 	int linkDir;
 
 	for (linkDir = 0; linkDir < 8; linkDir++) {
-		// Skip if this direction is not available
-		if (!buf.check(linkDir)) {
-			continue;
-		}
+		// Try this direction if it is available
+		if (buf.check(linkDir)) {
+			WayPoint* wp = getWayPoint(buf.mWayPointIdx);
+			if (!wp) {
+				BUGPRINT("buffer.idx=%d", buf.mWayPointIdx);
+				ERROR("wp is null!");
+			}
 
-		WayPoint* wp = getWayPoint(buf.mWayPointIdx);
-		if (!wp) {
-			BUGPRINT("buffer.idx=%d", buf.mWayPointIdx);
-			ERROR("wp is null!");
-		}
+			// Exclude one's own waypoint index based on mode flags
+			if (checkMode(PathFinderMode::AvoidOwnIndex) && avoidWayPointIndex != -1 && wp->mIndex == avoidWayPointIndex) {
+				continue;
+			}
 
-		// Exclude waypoints based on mode flags (e.g., avoid a specific index or water)
-		if ((checkMode(PathFinderMode::AvoidOwnIndex) && avoidWayPointIndex != -1 && wp->mIndex == avoidWayPointIndex)
-		    || (checkMode(PathFinderMode::AvoidWater) && wp->inWater())) {
-			continue;
-		}
+			// Exclude waypoints in water based on mode flags
+			if (checkMode(PathFinderMode::AvoidWater) && wp->inWater()) {
+				continue;
+			}
 
-		// Skip self-links
-		int neighborIdx = wp->mLinkIndices[linkDir];
-		if (neighborIdx == buf.mWayPointIdx) {
-			continue;
-		}
+			// Skip self-links
+			int neighborIdx = wp->mLinkIndices[linkDir];
+			if (neighborIdx == buf.mWayPointIdx) {
+				continue;
+			}
 
-		// Invalid link index: clear flag and skip
-		if (neighborIdx == -1) {
-			buf.resetFlag(linkDir);
-			continue;
-		}
+			// Invalid link index: clear flag and skip
+			if (neighborIdx == -1) {
+				buf.resetFlag(linkDir);
+				continue;
+			}
 
-		// Ensure waypoint exists
-		if (!getWayPoint(neighborIdx)) {
-			BUGPRINT("idx=%d", neighborIdx);
-			ERROR("no getwaypoint!");
-		}
+			// Ensure waypoint exists
+			if (!getWayPoint(neighborIdx)) {
+				BUGPRINT("idx=%d", neighborIdx);
+				ERROR("no getwaypoint!");
+			}
 
-		// Exclude closed/blocked paths if not allowed
-		if (!includeBlockedPaths && !getWayPoint(neighborIdx)->mIsOpen) {
-			buf.resetFlag(linkDir);
-			continue;
-		}
+			// Exclude closed/blocked paths if not allowed
+			if (!includeBlockedPaths && !getWayPoint(neighborIdx)->mIsOpen) {
+				buf.resetFlag(linkDir);
+				continue;
+			}
 
-		// Avoid revisiting waypoints already in current path buffer
-		bool alreadyVisited = false;
-		for (int j = 0; j < wpCount; j++) {
-			if (bufferList[j].mWayPointIdx == neighborIdx) {
-				alreadyVisited = true;
-				break;
+			// Avoid revisiting waypoints already in current path buffer
+			bool alreadyVisited = false;
+			for (int j = 0; j < wpCount; j++) {
+				if (bufferList[j].mWayPointIdx == neighborIdx) {
+					alreadyVisited = true;
+					break;
+				}
+			}
+
+			if (!alreadyVisited) {
+				// Sanity check: no more than 8 candidates
+				if (validLinkCount >= 8) {
+					BUGPRINT("numWays=%d", validLinkCount);
+					ERROR("numWays>=8");
+				}
+
+				// Record this direction as a candidate
+				dirIndices[validLinkCount] = linkDir;
+
+				// If this neighbor is the destination, return immediately
+				if (neighborIdx == destWPIdx) {
+					return linkDir;
+				}
+
+				// Squared horizontal distance to destination
+				Vector3f linkPos             = getWayPoint(neighborIdx)->mPosition;
+				f32 dist                     = qdist2(linkPos.x, linkPos.z, destPos.x, destPos.z);
+				distToDestSq[validLinkCount] = dist;
+
+				validLinkCount++;
 			}
 		}
-
-		if (alreadyVisited) {
-			continue;
-		}
-
-		// Sanity check: no more than 8 candidates
-		if (validLinkCount >= 8) {
-			BUGPRINT("numWays=%d", validLinkCount);
-			ERROR("numWays>=8");
-		}
-
-		// Record this direction as a candidate
-		dirIndices[validLinkCount] = linkDir;
-
-		// If this neighbor is the destination, return immediately
-		if (neighborIdx == destWPIdx) {
-			return linkDir;
-		}
-
-		// Squared horizontal distance to destination
-		Vector3f linkPos             = getWayPoint(neighborIdx)->mPosition;
-		distToDestSq[validLinkCount] = qdist2(linkPos.x, linkPos.z, destPos.x, destPos.z);
-
-		validLinkCount++;
 	}
 
 	// Choose the candidate with minimum squared distance to destination
@@ -1018,9 +1020,11 @@ void RouteMgr::construct(MapMgr* map)
  */
 void RouteMgr::initLinks()
 {
-	// this gsys stuff isn't in the DLL
+#if defined(WIN32)
+#else
 	bool check           = gsys->mPrevAllocType;
 	gsys->mPrevAllocType = FALSE;
+#endif
 
 	int numWPs = getNumWayPoints('test');
 	PRINT("total %d links\n", numWPs);
@@ -1035,9 +1039,11 @@ void RouteMgr::initLinks()
 		wp->initLinkInfos();
 	}
 
-	// same with this stuff
+#if defined(WIN32)
+#else
 	gsys->mPrevAllocType = check;
 	gsys->mRetraceCount  = 0;
+#endif
 }
 
 /**
@@ -1521,11 +1527,14 @@ int PathFinder::findSyncOnyon(immut Vector3f& startPos, PathFinder::Buffer* buff
 int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buffer& buf, int destWPIdx, PathFinder::Buffer* bufferList,
                                int visitedBufferCount, bool ignoreClosedWaypoints)
 {
+	int bestLinkIndex;  // Index of the best (lowest cost) link direction
+	int validLinkCount; // Number of valid links found
+
 	int pathCosts[8];        // Cost values for each valid link
 	int validLinkIndices[8]; // Direction indices for valid links
 
-	int bestLinkIndex  = -1; // Index of the best (lowest cost) link direction
-	int validLinkCount = 0;  // Number of valid links found
+	bestLinkIndex  = -1;
+	validLinkCount = 0;
 
 	// NEVER USED, FOR WHATEVER REASON /////////////////////////
 	Vector3f wpPos   = getWayPoint(buf.mWayPointIdx)->mPosition;
@@ -1534,13 +1543,14 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 	int linkDir;
 
 	for (linkDir = 0; linkDir < 8; linkDir++) {
-		// Skip if this direction is not available
-		if (!buf.check(linkDir)) {
-			continue;
-		}
+		// Try this direction if it is available
+		if (buf.check(linkDir)) {
 
-		WayPoint* wp = getWayPoint(buf.mWayPointIdx);
-		if (!PathFinder::checkMode(PathFinderMode::AvoidWater) || !wp->inWater()) {
+			WayPoint* wp = getWayPoint(buf.mWayPointIdx);
+			if (PathFinder::checkMode(PathFinderMode::AvoidWater) && wp->inWater()) {
+				continue;
+			}
+
 			int neighborIdx = wp->mLinkIndices[linkDir];
 
 			// Skip self-referencing links
@@ -1569,8 +1579,13 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 				}
 			}
 
-			// Add to valid links if it has valid pathfinding info and hasn't been visited
-			if (wp->mLinkInfos[linkDir].getInfo(goalType) != -2 && !isAlreadyVisited) {
+			// Check if waypoint this waypoint link is valid
+			if (wp->mLinkInfos[linkDir].getInfo(goalType) == -2) {
+				continue;
+			}
+
+			// Add to valid links if it hasn't been visited
+			if (!isAlreadyVisited) {
 				validLinkIndices[validLinkCount] = linkDir;
 
 				// If this link leads directly to destination, return immediately (optimal path found)
@@ -1601,17 +1616,15 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 
 		// Calculate actual distance between waypoints
 		Vector3f directionVector = targetWaypoint->mPosition - sourceWaypoint->mPosition;
-		f32 actualDistance       = directionVector.length();
 
 		// Add any additional cost penalty/bonus to the distance
-		int totalDistanceCost = (int)actualDistance + additionalCost;
-		PRINT("\t way %d: next %d: sum is %d\n", bestLinkIndex, targetWaypoint->mIndex, totalDistanceCost);
+		additionalCost += static_cast<int>(directionVector.length());
 
-		STACK_PAD_TERNARY(totalDistanceCost, 1);
-		STACK_PAD_TERNARY(targetWaypoint, 1);
+		PRINT("\t way %d: next %d: sum is %d\n", bestLinkIndex, targetWaypoint->mIndex, additionalCost);
 	}
 
-	STACK_PAD_VAR(4);
+	STACK_PAD_VAR(6);
+	STACK_PAD_TERNARY(this, 2);
 
 	return bestLinkIndex;
 }
@@ -1620,28 +1633,32 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
  * @todo: Documentation
  */
 int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBestCost, int goalType, PathFinder::Buffer& buf, int destWPIdx,
-                                         PathFinder::Buffer* bufferList, int bufIdx, bool ignoreClosedWaypoints)
+                                         PathFinder::Buffer* bufferList, int visitedBufferCount, bool ignoreClosedWaypoints)
 {
+	int bestLinkIndex;  // Index of the best (lowest cost) link direction
+	int validLinkCount; // Number of valid links found
+
 	int pathCosts[8];        // Cost values for each valid link
-	int validLinkIndices[8]; // Direction indices forvalid links
+	int validLinkIndices[8]; // Direction indices for valid links
 
-	STACK_PAD_VAR(1);
+	bestLinkIndex  = -1;
+	validLinkCount = 0;
 
-	int bestLinkIndex  = -1; // Index of the best (lowest cost) link
-	int validLinkCount = 0;  // Number of valid links found
-
+	// NEVER USED, FOR WHATEVER REASON /////////////////////////
 	Vector3f wpPos   = getWayPoint(buf.mWayPointIdx)->mPosition;
 	Vector3f destPos = getWayPoint(destWPIdx)->mPosition;
+	////////////////////////////////////////////////////////////
 	int linkDir;
 
 	for (linkDir = 0; linkDir < 8; linkDir++) {
-		// Skip if this direction is not available
-		if (!buf.check(linkDir)) {
-			continue;
-		}
+		if (buf.check(linkDir)) {
 
-		WayPoint* currWP = getWayPoint(buf.mWayPointIdx);
-		if (!PathFinder::checkMode(PathFinderMode::AvoidWater) || !currWP->inWater()) {
+			WayPoint* currWP = getWayPoint(buf.mWayPointIdx);
+
+			if (PathFinder::checkMode(PathFinderMode::AvoidWater) && currWP->inWater()) {
+				continue;
+			}
+
 			int neighborIdx = currWP->mLinkIndices[linkDir];
 
 			// Skip self-referencing links
@@ -1663,15 +1680,20 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 
 			// Check if this waypoint has already been visited to avoid cycles
 			bool isAlreadyVisited = false;
-			for (int bufIdx = 0; bufIdx < bufIdx; bufIdx++) {
+			for (int bufIdx = 0; bufIdx < visitedBufferCount; bufIdx++) {
 				if (bufferList[bufIdx].mWayPointIdx == neighborIdx) {
 					isAlreadyVisited = true;
 					break;
 				}
 			}
 
-			// Add to valid links if it has valid pathfinding info and hasn't been visited
-			if (currWP->mLinkInfos[linkDir].getInfo(goalType) != -2 && !isAlreadyVisited) {
+			// Check if waypoint this waypoint link is valid
+			if (currWP->mLinkInfos[linkDir].getInfo(goalType) == -2) {
+				continue;
+			}
+
+			// Add to valid links if it hasn't been visited
+			if (!isAlreadyVisited) {
 				validLinkIndices[validLinkCount] = linkDir;
 
 				// If this link leads directly to destination, return immediately
@@ -1702,40 +1724,41 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 	for (linkDir = 0; linkDir < validLinkCount; linkDir++) {
 		// Skip the best option and only consider better costs than current second-best
 		if (linkDir != bestLinkIndex && pathCosts[linkDir] < secondBestCost) {
-			WayPoint* wp1 = getWayPoint(buf.mWayPointIdx);                             // Source waypoint
-			WayPoint* wp2 = getWayPoint(wp1->mLinkIndices[validLinkIndices[linkDir]]); // Destination waypoint
+			WayPoint* srcWp = getWayPoint(buf.mWayPointIdx);
+			int dstWpIdx    = srcWp->mLinkIndices[validLinkIndices[linkDir]];
+			WayPoint* dstWp = getWayPoint(dstWpIdx);
 
 			bool geometricallyValid = true;
 
-			PRINT("wp(%d) = %s wp2(%d) = %s\n", wp1->mIndex, wp1->mIsOpen ? "on" : "off", wp2->mIndex, wp2->mIsOpen ? "on" : "off");
+			PRINT("wp(%d) = %s wp2(%d) = %s\n", srcWp->mIndex, srcWp->mIsOpen ? "on" : "off", dstWp->mIndex, dstWp->mIsOpen ? "on" : "off");
 
-			if (!wp1->mIsOpen) {
+			if (!srcWp->mIsOpen) {
 				// If source waypoint is closed, create plane at source facing target
 				Plane seperatingPlane;
-				Vector3f directionToTarget = wp2->mPosition - wp1->mPosition;
+				Vector3f directionToTarget = dstWp->mPosition - srcWp->mPosition;
 				directionToTarget.normalise();
 				seperatingPlane.mNormal = directionToTarget;
-				seperatingPlane.mOffset = directionToTarget.DP(wp1->mPosition);
+				seperatingPlane.mOffset = directionToTarget.DP(srcWp->mPosition);
 
 				// Check if current position and target are on same side of plane
 				bool isAbove     = seperatingPlane.dist(curPos);
-				bool isLinkAbove = seperatingPlane.dist(wp2->mPosition);
+				bool isLinkAbove = seperatingPlane.dist(dstWp->mPosition);
 
 				if (isAbove != isLinkAbove) {
 					geometricallyValid = false;
 					PRINT("another side !\n");
 				}
-			} else if (!wp2->mIsOpen) {
+			} else if (!dstWp->mIsOpen) {
 				// If target waypoint is closed, create plane at target facing source
 				Plane separatingPlane;
-				Vector3f directionToTarget = wp2->mPosition - wp1->mPosition;
+				Vector3f directionToTarget = dstWp->mPosition - srcWp->mPosition;
 				directionToTarget.normalise();
 				separatingPlane.mNormal = directionToTarget;
-				separatingPlane.mOffset = directionToTarget.DP(wp2->mPosition);
+				separatingPlane.mOffset = directionToTarget.DP(dstWp->mPosition);
 
 				// Check if current position and source are on same side of plane
 				bool isAbove   = separatingPlane.dist(curPos);
-				bool isWPAbove = separatingPlane.dist(wp1->mPosition);
+				bool isWPAbove = separatingPlane.dist(srcWp->mPosition);
 
 				if (isAbove != isWPAbove) {
 					geometricallyValid = false;
@@ -1751,7 +1774,7 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 		}
 	}
 
-	STACK_PAD_VAR(6);
+	STACK_PAD_VAR(8);
 
 	PRINT("BEST IS %d : SECOND BEST IS %d\n", bestLinkIndex, secondBestLinkIndex);
 	return secondBestLinkIndex;

--- a/src/plugPikiKando/routeMgr.cpp
+++ b/src/plugPikiKando/routeMgr.cpp
@@ -396,7 +396,7 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 		}
 
 		// Exclude waypoints based on mode flags (e.g., avoid a specific index or water)
-		if ((checkMode(PathFinderMode::Unk2) && avoidWayPointIndex != -1 && wp->mIndex == avoidWayPointIndex)
+		if ((checkMode(PathFinderMode::AvoidOwnIndex) && avoidWayPointIndex != -1 && wp->mIndex == avoidWayPointIndex)
 		    || (checkMode(PathFinderMode::AvoidWater) && wp->inWater())) {
 			continue;
 		}
@@ -1208,7 +1208,7 @@ void WayPoint::resetLinkInfos()
  */
 void WayPoint::initLinkInfos()
 {
-	PathFinder::setMode(PathFinderMode::Unk2);
+	PathFinder::setMode(PathFinderMode::AvoidOwnIndex);
 	PathFinder::avoidWayPointIndex = mIndex;
 
 	for (int i = 0; i < 8; i++) {
@@ -1229,9 +1229,9 @@ void WayPoint::initLinkInfos()
 			int wpIdx = -1;
 
 			switch (goalIdx) {
-			case 0: // Red onion
-			case 1: // Blue onion
-			case 2: // Yellow onion
+			case Blue:
+			case Red:
+			case Yellow:
 			{
 				GoalItem* container = itemMgr->getContainer(goalIdx);
 				if (container) {
@@ -1312,9 +1312,9 @@ int PathFinder::findFirstStepOnyon(int startWPIdx, int goalType, PathFinder::Buf
 
 	// Determine the destination waypoint index based on goalType
 	switch (goalType) {
-	case 0: // Red onion
-	case 1: // Blue onion
-	case 2: // Yellow onion
+	case Blue:
+	case Red:
+	case Yellow:
 	{
 		GoalItem* goal = itemMgr->getContainer(goalType);
 		if (goal) {
@@ -1351,9 +1351,9 @@ int PathFinder::findSyncOnyon(immut Vector3f& startPos, PathFinder::Buffer* buff
 
 	// Determine the destination waypoint index based on goalType
 	switch (goalType) {
-	case 0: // Red onion
-	case 1: // Blue onion
-	case 2: // Yellow onion
+	case Blue:
+	case Red:
+	case Yellow:
 	{
 		GoalItem* container = itemMgr->getContainer(goalType);
 		if (container) {

--- a/src/plugPikiKando/routeMgr.cpp
+++ b/src/plugPikiKando/routeMgr.cpp
@@ -382,8 +382,9 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 	// Current and destination positions (XZ plane)
 	Vector3f currPos = getWayPoint(buf.mWayPointIdx)->mPosition;
 	Vector3f destPos = getWayPoint(destWPIdx)->mPosition;
+	int dir;
 
-	for (int dir = 0; dir < 8; dir++) {
+	for (dir = 0; dir < 8; dir++) {
 		// Skip if this direction is not available
 		if (!buf.check(dir)) {
 			continue;
@@ -461,10 +462,10 @@ int PathFinder::selectWay(PathFinder::Buffer& buf, int destWPIdx, PathFinder::Bu
 
 	// Choose the candidate with minimum squared distance to destination
 	f32 bestDist = 128000.0f;
-	for (int i = 0; i < validLinkCount; i++) {
-		if (distToDestSq[i] < bestDist) {
-			bestDist  = distToDestSq[i];
-			chosenDir = dirIndices[i];
+	for (dir = 0; dir < validLinkCount; dir++) {
+		if (distToDestSq[dir] < bestDist) {
+			bestDist  = distToDestSq[dir];
+			chosenDir = dirIndices[dir];
 		}
 	}
 
@@ -1530,8 +1531,9 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 	Vector3f wpPos   = getWayPoint(buf.mWayPointIdx)->mPosition;
 	Vector3f destPos = getWayPoint(destWPIdx)->mPosition;
 	////////////////////////////////////////////////////////////
+	int dir;
 
-	for (int dir = 0; dir < 8; dir++) {
+	for (dir = 0; dir < 8; dir++) {
 		// Skip if this direction is not available
 		if (!buf.check(dir)) {
 			continue;
@@ -1585,10 +1587,10 @@ int PathFinder::selectWayOnyon(int additionalCost, int goalType, PathFinder::Buf
 
 	// Phase 2: Find the best (lowest cost) option among all valid links
 	int lowestCost = 128000;
-	for (int i = 0; i < validLinkCount; i++) {
-		if (pathCosts[i] < lowestCost) {
-			lowestCost    = pathCosts[i];
-			bestLinkIndex = validLinkIndices[i];
+	for (dir = 0; dir < validLinkCount; dir++) {
+		if (pathCosts[dir] < lowestCost) {
+			lowestCost    = pathCosts[dir];
+			bestLinkIndex = validLinkIndices[dir];
 		}
 	}
 
@@ -1630,8 +1632,9 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 
 	Vector3f wpPos   = getWayPoint(buf.mWayPointIdx)->mPosition;
 	Vector3f destPos = getWayPoint(destWPIdx)->mPosition;
+	int dir;
 
-	for (int dir = 0; dir < 8; dir++) {
+	for (dir = 0; dir < 8; dir++) {
 		// Skip if this direction is not available
 		if (!buf.check(dir)) {
 			continue;
@@ -1685,23 +1688,22 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 
 	// Phase 2: Find the best (lowest cost) option
 	int lowestCost = 128000;
-	for (int i = 0; i < validLinkCount; i++) {
-		if (pathCosts[i] < lowestCost) {
-			lowestCost    = pathCosts[i];
-			bestLinkIndex = validLinkIndices[i];
+	for (dir = 0; dir < validLinkCount; dir++) {
+		if (pathCosts[dir] < lowestCost) {
+			lowestCost    = pathCosts[dir];
+			bestLinkIndex = validLinkIndices[dir];
 		}
 	}
 
 	// Phase 3: Find the second-best option with geometric validation
-	int i;
 	int secondBestLinkIndex = -1;
 	secondBestCost          = 128000;
 
-	for (i = 0; i < validLinkCount; i++) {
+	for (dir = 0; dir < validLinkCount; dir++) {
 		// Skip the best option and only consider better costs than current second-best
-		if (i != bestLinkIndex && pathCosts[i] < secondBestCost) {
-			WayPoint* wp1 = getWayPoint(buf.mWayPointIdx);                       // Source waypoint
-			WayPoint* wp2 = getWayPoint(wp1->mLinkIndices[validLinkIndices[i]]); // Destination waypoint
+		if (dir != bestLinkIndex && pathCosts[dir] < secondBestCost) {
+			WayPoint* wp1 = getWayPoint(buf.mWayPointIdx);                         // Source waypoint
+			WayPoint* wp2 = getWayPoint(wp1->mLinkIndices[validLinkIndices[dir]]); // Destination waypoint
 
 			bool geometricallyValid = true;
 
@@ -1743,8 +1745,8 @@ int PathFinder::selectSecondBestWayOnyon(immut Vector3f& curPos, int& secondBest
 
 			// Update second-best if this option passes geometric validation
 			if (geometricallyValid) {
-				secondBestLinkIndex = i;
-				secondBestCost      = pathCosts[i];
+				secondBestLinkIndex = dir;
+				secondBestCost      = pathCosts[dir];
 			}
 		}
 	}

--- a/src/plugPikiKando/soundMgr.cpp
+++ b/src/plugPikiKando/soundMgr.cpp
@@ -871,6 +871,7 @@ void SeSystem::dumpEvents()
 		}
 	}
 
+#if PIKI_USE_JAUDIO
 	u32 test[0x20];
 	u32 max = Jac_GetActiveEvents(test);
 	Jac_CheckFreeEvents();
@@ -879,6 +880,7 @@ void SeSystem::dumpEvents()
 		// probably something like this
 		PRINT("%d\n", test[i]);
 	}
+#endif
 }
 
 /**

--- a/src/plugPikiKando/ufoItem.cpp
+++ b/src/plugPikiKando/ufoItem.cpp
@@ -989,7 +989,9 @@ void UfoItem::refresh(Graphics& gfx)
  */
 void UfoItem::demoDraw(Graphics& gfx, immut Matrix4f* mtx)
 {
-	for (int i = 0; i < 4; i++) {
+	int i;
+
+	for (i = 0; i < 4; i++) {
 		mLightAnims[i].update();
 	}
 
@@ -1033,7 +1035,7 @@ void UfoItem::demoDraw(Graphics& gfx, immut Matrix4f* mtx)
 	}
 
 	mCollInfo->updateInfo(gfx, false);
-	for (int i = 0; i < 3; i++) {
+	for (i = 0; i < 3; i++) {
 		CollPart* part = mCollInfo->getSphere('gol1');
 		if (part) {
 			f32 anglePosition = mFaceDirection + mSpots[i].mAngleOffset;

--- a/src/plugPikiKando/ufoItem.cpp
+++ b/src/plugPikiKando/ufoItem.cpp
@@ -1004,33 +1004,34 @@ void UfoItem::demoDraw(Graphics& gfx, immut Matrix4f* mtx)
 	}
 
 	Vector3f pos;
-	STACK_PAD_VAR(1);
+	f32 cjwpret; // `BaseShape::calcJointWorldPos` return value is stored but never used.
+
 	pos.set(0.0f, 14.0f, 0.0f);
-	mShipModel->mShape->calcJointWorldPos(gfx, 48, pos);
+	cjwpret         = mShipModel->mShape->calcJointWorldPos(gfx, 48, pos);
 	mPca2FxPosition = pos;
 
 	pos.set(0.0f, 14.0f, 0.0f);
-	mShipModel->mShape->calcJointWorldPos(gfx, 49, pos);
+	cjwpret         = mShipModel->mShape->calcJointWorldPos(gfx, 49, pos);
 	mPca1FxPosition = pos;
 
 	if (playerState->isTutorial()) {
 
 		pos.set(13.1f, -98.4f, -2.0f);
-		mShipModel->mShape->calcJointWorldPos(gfx, 2, pos);
+		cjwpret                   = mShipModel->mShape->calcJointWorldPos(gfx, 2, pos);
 		mTroubleFxPositionList[0] = pos;
 
 		pos.set(-9.2f, -68.1f, 28.6f);
-		mShipModel->mShape->calcJointWorldPos(gfx, 2, pos);
+		cjwpret                   = mShipModel->mShape->calcJointWorldPos(gfx, 2, pos);
 		mTroubleFxPositionList[1] = pos;
 		mTroubleFxPositionList[2] = mTroubleFxPositionList[0];
 		mTroubleFxPositionList[3] = mTroubleFxPositionList[1];
 
 		pos.set(-22.2f, 4.9f, -25.0f);
-		mShipModel->mShape->calcJointWorldPos(gfx, 41, pos);
+		cjwpret                   = mShipModel->mShape->calcJointWorldPos(gfx, 41, pos);
 		mTroubleFxPositionList[4] = pos;
 
 		pos.set(0.0f, -93.0f, 0.0f);
-		mShipModel->mShape->calcJointWorldPos(gfx, 2, pos);
+		cjwpret                   = mShipModel->mShape->calcJointWorldPos(gfx, 2, pos);
 		mTroubleFxPositionList[5] = pos;
 	}
 

--- a/src/plugPikiKando/ufoItem.cpp
+++ b/src/plugPikiKando/ufoItem.cpp
@@ -1020,7 +1020,6 @@ void UfoItem::demoDraw(Graphics& gfx, immut Matrix4f* mtx)
 		pos.set(-9.2f, -68.1f, 28.6f);
 		mShipModel->mShape->calcJointWorldPos(gfx, 2, pos);
 		mTroubleFxPositionList[1] = pos;
-
 		mTroubleFxPositionList[2] = mTroubleFxPositionList[0];
 		mTroubleFxPositionList[3] = mTroubleFxPositionList[1];
 

--- a/src/plugPikiKando/utkando.cpp
+++ b/src/plugPikiKando/utkando.cpp
@@ -221,7 +221,7 @@ void drawArrow(Graphics& gfx, immut Vector3f& from, immut Vector3f& to, f32 size
 /**
  * @todo: Documentation
  */
-void CRSplineDraw(Graphics& gfx, int numSides, immut Vector3f* origin)
+void CRSplineDraw(Graphics& gfx, int numSides, immut Vector3f* const origin)
 {
 	gfx.useMatrix(gfx.mCamera->mLookAtMtx, 0);
 	gfx.setColour(Colour(255, 10, 100, 255), true);

--- a/src/plugPikiKando/workObject.cpp
+++ b/src/plugPikiKando/workObject.cpp
@@ -906,7 +906,7 @@ void HinderRock::startAI(int)
 	mPushMoveTimer     = 0.0f;
 	mWayPoint          = routeMgr->findNearestWayPointAll('test', mSRT.t);
 	mWayPoint->setFlag(false);
-	PRINT("********* ROCK WAYPOINT(%d) OFF\n", mWayPoint->mIsOpen);
+	PRINT("********* ROCK WAYPOINT(%d) OFF\n", mWayPoint->mIndex);
 	mIsSoundPlaying = false;
 	mSRT.t.y        = mapMgr->getMinY(mSRT.t.x, mSRT.t.z, false);
 }

--- a/src/plugPikiKando/workObject.cpp
+++ b/src/plugPikiKando/workObject.cpp
@@ -1076,10 +1076,11 @@ void Bridge::startAI(int)
 	mapMgr->mCollShapeList->add(mBuildShape);
 
 	if (mDoUseJointSegments) {
-		for (int i = 0; i < mStageCount; i++) {
+		int i;
+		for (i = 0; i < mStageCount; i++) {
 			mStageProgressList[i] = 0.0f;
 		}
-		for (int i = 0; i < mStageCount * 2; i++) {
+		for (i = 0; i < mStageCount * 2; i++) {
 			mBuildShape->jointVisible(mStageJoints[i]->mIndex, Joint::NotVisible);
 		}
 		mBuildShape->jointVisible(mStageJoints[0]->mIndex, Joint::Visible);
@@ -1529,14 +1530,16 @@ void GenObjectWorkObject::setNaviPos()
 
 void GenObjectWorkObject::doGenAge(AgeServer& server)
 {
+	int i;
+
 	server.StartOptionBox("仕事オブジェクト", (int*)&mObjectType, 252);
-	for (int i = 0; i < 2; i++) {
+	for (i = 0; i < 2; i++) {
 		server.NewOption(workObjectMgr->getName(i), i);
 	}
 	server.EndOptionBox();
 
 	server.StartOptionBox("シェイプ", &mShapeType, 252);
-	for (int i = 0; i < 5; i++) {
+	for (i = 0; i < 5; i++) {
 		server.NewOption(workObjectMgr->getShapeName(i), i);
 	}
 	server.EndOptionBox();

--- a/src/plugPikiNakata/nlibgeometry.cpp
+++ b/src/plugPikiNakata/nlibgeometry.cpp
@@ -1101,10 +1101,11 @@ void NUpperMatrix::solve(immut NVector& inVec, NVector& outVec)
  */
 void NUpperMatrix::println() immut
 {
-	for (int i = 0; i < mDimension; i++) {
+	int i;
+	for (i = 0; i < mDimension; i++) {
 		PRINT_NAKATA("e[%d]:%f\n", i, mCentre[i]);
 	}
-	for (int i = 0; i < mDimension - 1; i++) {
+	for (i = 0; i < mDimension - 1; i++) {
 		PRINT_NAKATA("u[%d]:%f\n", i, mUpper[i]);
 	}
 }
@@ -1161,13 +1162,14 @@ void LUMatrix::solve(immut NVector& inVec, NVector& outVec)
  */
 void LUMatrix::decompose()
 {
+	int i;
 	mUpper.setCenter(0, mCentreVals[0]);
-	for (int i = 1; i < mDimension; i++) {
+	for (i = 1; i < mDimension; i++) {
 		mLower.setLower(i, mLowerVals[i - 1] / mUpper.getCenter(i - 1));
 
 		mUpper.setCenter(i, mCentreVals[i] - mLower.getLower(i) * mUpperVals[i - 1]);
 	}
-	for (int i = 0; i < mDimension - 1; i++) {
+	for (i = 0; i < mDimension - 1; i++) {
 		mUpper.setUpper(i, mUpperVals[i]);
 	}
 }
@@ -1178,13 +1180,14 @@ void LUMatrix::decompose()
  */
 void LUMatrix::println() immut
 {
-	for (int i = 0; i < mDimension; i++) {
+	int i;
+	for (i = 0; i < mDimension; i++) {
 		PRINT_NAKATA("e[%d]:%f\n", i, mCentreVals[i]);
 	}
-	for (int i = 0; i < mDimension - 1; i++) {
+	for (i = 0; i < mDimension - 1; i++) {
 		PRINT_NAKATA("l[%d]:%f\n", i, mLowerVals[i]);
 	}
-	for (int i = 0; i < mDimension - 1; i++) {
+	for (i = 0; i < mDimension - 1; i++) {
 		PRINT_NAKATA("u[%d]:%f\n", i, mUpperVals[i]);
 	}
 }

--- a/src/plugPikiNakata/nlibspline.cpp
+++ b/src/plugPikiNakata/nlibspline.cpp
@@ -41,23 +41,25 @@ void SplineInterpolator::reset()
  */
 void SplineInterpolator::makeSpline()
 {
-	f32 fVals[16];
 	NVector3f* vecVals[16];
+	f32 fVals[16];
+	int i;
+
 	if (mFrameArray->getSize() < 2) {
 		return;
 	}
 
-	for (int i = 0; i < mFrameArray->getSize(); i++) {
+	for (i = 0; i < mFrameArray->getSize(); i++) {
 		fVals[i] = mFrameArray->get(i)->getParameter();
 	}
 
-	for (int i = 0; i < mFrameArray->getSize(); i++) {
+	for (i = 0; i < mFrameArray->getSize(); i++) {
 		vecVals[i] = &mFrameArray->get(i)->getPosture().getViewpoint();
 	}
 
 	mViewpointCurve->makeCurve(fVals, vecVals, mFrameArray->getSize());
 
-	for (int i = 0; i < mFrameArray->getSize(); i++) {
+	for (i = 0; i < mFrameArray->getSize(); i++) {
 		vecVals[i] = &mFrameArray->get(i)->getPosture().getWatchpoint();
 	}
 

--- a/src/plugPikiNishimura/KingBody.cpp
+++ b/src/plugPikiNishimura/KingBody.cpp
@@ -409,15 +409,17 @@ void KingBody::checkBlendingParm(Matrix4f* animMatrices)
 void KingBody::makeBlending(Matrix4f* animMatrices)
 {
 	if (mBlendingRatio > 0.0f) {
+		int i;
 		f32 tComp = 1.0f - mBlendingRatio;
 		Vector3f blendPositions[66];
-		for (int i = 0; i < 66; i++) {
+
+		for (i = 0; i < 66; i++) {
 			blendPositions[i].x = mBlendingRatio * animMatrices[i].mMtx[0][3] + tComp * mBlendStartMatrices[i].mMtx[0][3];
 			blendPositions[i].y = mBlendingRatio * animMatrices[i].mMtx[1][3] + tComp * mBlendStartMatrices[i].mMtx[1][3];
 			blendPositions[i].z = mBlendingRatio * animMatrices[i].mMtx[2][3] + tComp * mBlendStartMatrices[i].mMtx[2][3];
 		}
 
-		for (int i = 0; i < 66; i++) {
+		for (i = 0; i < 66; i++) {
 			Vector3f colX;
 			Vector3f colY;
 			Vector3f colZ;

--- a/src/plugPikiNishimura/SlimeBody.cpp
+++ b/src/plugPikiNishimura/SlimeBody.cpp
@@ -171,7 +171,9 @@ void SlimeBody::sortPosition(Vector3f* outVertex, Vector3f* outNormal, immut Vec
 	Vector3f targetNormal(vertical->x, vertical->y, vertical->z);
 	f32 totalScore; // fun fact: declaring this here is load bearing for stack placement.
 	f32 creatureScores[4];
-	for (int i = 0; i < C_SLIME_PROP(mSlime).mMaxSortCount(); i++) {
+	int i;
+
+	for (i = 0; i < C_SLIME_PROP(mSlime).mMaxSortCount(); i++) {
 		outVertex->x = (minNormal.x + targetNormal.x) / 2.0f;
 		outVertex->y = (minNormal.y + targetNormal.y) / 2.0f;
 		outVertex->z = (minNormal.z + targetNormal.z) / 2.0f;
@@ -188,7 +190,7 @@ void SlimeBody::sortPosition(Vector3f* outVertex, Vector3f* outNormal, immut Vec
 	outNormal->y = 0.0f;
 	outNormal->z = 0.0f;
 
-	for (int i = 0; i < bossMgr->mSlimeCreatureCount; i++) {
+	for (i = 0; i < bossMgr->mSlimeCreatureCount; i++) {
 		outNormal->x += creatureScores[i] * creatureNormals[i].x;
 		outNormal->y += creatureScores[i] * creatureNormals[i].y;
 		outNormal->z += creatureScores[i] * creatureNormals[i].z;

--- a/src/plugPikiNishimura/SlimeBody.cpp
+++ b/src/plugPikiNishimura/SlimeBody.cpp
@@ -169,7 +169,7 @@ void SlimeBody::sortPosition(Vector3f* outVertex, Vector3f* outNormal, immut Vec
 	Vector3f creatureNormals[4];
 	Vector3f minNormal(outVertex->x, outVertex->y, outVertex->z);
 	Vector3f targetNormal(vertical->x, vertical->y, vertical->z);
-	f32 totalScore; // fun fact: declaring this here is load bearing for stack placement.
+	f32 totalScore = 0.0f;
 	f32 creatureScores[4];
 	int i;
 
@@ -180,9 +180,13 @@ void SlimeBody::sortPosition(Vector3f* outVertex, Vector3f* outNormal, immut Vec
 
 		totalScore = calcVertexScore(outVertex, creatureNormals, creatureScores);
 		if (totalScore > C_SLIME_PROP(mSlime).mVertexPositionScore()) {
-			targetNormal.set(*outVertex);
+			targetNormal.x = outVertex->x;
+			targetNormal.y = outVertex->y;
+			targetNormal.z = outVertex->z;
 		} else {
-			minNormal.set(*outVertex);
+			minNormal.x = outVertex->x;
+			minNormal.y = outVertex->y;
+			minNormal.z = outVertex->z;
 		}
 	}
 

--- a/src/plugPikiNishimura/SnakeBody.cpp
+++ b/src/plugPikiNishimura/SnakeBody.cpp
@@ -96,12 +96,14 @@ void SnakeBody::init(immut Vector3f&, Snake* snake)
 	mUseBlend      = false;
 	mBlendingRatio = 0.0f;
 
-	for (int i = 0; i < 7; i++) {
+	int i;
+
+	for (i = 0; i < 7; i++) {
 		mSegmentLengthList[i] = 0.0f;
 		mDeadPtclGens[i]      = nullptr;
 	}
 
-	for (int i = 0; i < 8; i++) {
+	for (i = 0; i < 8; i++) {
 		mSegmentScaleList[i] = 1.0f;
 	}
 

--- a/src/plugPikiNishimura/SpiderLeg.cpp
+++ b/src/plugPikiNishimura/SpiderLeg.cpp
@@ -336,7 +336,9 @@ void SpiderLeg::init(Spider* spider)
 	mCentreVelocity.set(0.0f, 0.0f, 0.0f);
 	mCurrentCentre = mSpider->mSRT.t;
 
-	for (int i = 0; i < 4; i++) {
+	int i;
+
+	for (i = 0; i < 4; i++) {
 		mStuckPikiCount[i]      = 0;
 		mPrevOnGround[i]        = false;
 		mIsOnGround[i]          = false;
@@ -346,7 +348,7 @@ void SpiderLeg::init(Spider* spider)
 		mBezierPoints[i][0]   = mJointPositions[i][0];
 	}
 
-	for (int i = 0; i < 16; i++) {
+	for (i = 0; i < 16; i++) {
 		mSegmentScale[i] = 1.0f;
 	}
 }

--- a/src/plugPikiNishimura/SpiderLeg.cpp
+++ b/src/plugPikiNishimura/SpiderLeg.cpp
@@ -122,7 +122,7 @@ void SpiderLeg::setDeadBombEffect(u32 legCollPartID)
  * @todo: Documentation
  * @note UNUSED Size: 000094
  */
-void SpiderLeg::setSmallSparkEffect(u32 legCollPartID, int* p2)
+void SpiderLeg::setSmallSparkEffect(u32 legCollPartID, int* const p2)
 {
 	CollPart* legPart = mSpider->mCollInfo->getSphere(legCollPartID);
 	for (int i = 0; i < 3; i++) {

--- a/src/plugPikiNishimura/genBoss.cpp
+++ b/src/plugPikiNishimura/genBoss.cpp
@@ -258,8 +258,10 @@ void GenObjectBoss::doGenAge(AgeServer& server)
 	server.NewOption("ランダム", 3);
 	server.EndOptionBox();
 
+	int i;
+
 	server.StartOptionBox("ペレットの数", &mItemCount, 252);
-	for (int i = 0; i < 16; i++) {
+	for (i = 0; i < 16; i++) {
 		char id[4];
 		if (i / 10 < 1) {
 			id[0] = i % 10 + '0';
@@ -275,7 +277,7 @@ void GenObjectBoss::doGenAge(AgeServer& server)
 
 	server.StartOptionBox("ＵＦＯパーツ", &mPelletConfigIdx, 252);
 	server.NewOption("none", -1);
-	for (int i = 0; i < pelletMgr->getNumConfigs(); i++) {
+	for (i = 0; i < pelletMgr->getNumConfigs(); i++) {
 		PelletConfig* config = pelletMgr->getConfigFromIdx(i);
 		server.NewOption(config->mPelletName().mString, config->mPelletId.mId);
 	}

--- a/src/plugPikiNishimura/genBoss.cpp
+++ b/src/plugPikiNishimura/genBoss.cpp
@@ -262,16 +262,17 @@ void GenObjectBoss::doGenAge(AgeServer& server)
 
 	server.StartOptionBox("ペレットの数", &mItemCount, 252);
 	for (i = 0; i < 16; i++) {
-		char id[4];
-		if (i / 10 < 1) {
-			id[0] = i % 10 + '0';
-			id[1] = 0;
+		char str[4];
+		int tens = i / 10;
+		if (tens > 0) {
+			str[0] = tens + '0';
+			str[1] = i % 10 + '0';
+			str[2] = '\0';
 		} else {
-			id[0] = i / 10 + '0';
-			id[1] = i % 10 + '0';
-			id[2] = 0;
+			str[0] = i % 10 + '0';
+			str[1] = '\0';
 		}
-		server.NewOption(id, i);
+		server.NewOption(str, i);
 	}
 	server.EndOptionBox();
 
@@ -279,7 +280,7 @@ void GenObjectBoss::doGenAge(AgeServer& server)
 	server.NewOption("none", -1);
 	for (i = 0; i < pelletMgr->getNumConfigs(); i++) {
 		PelletConfig* config = pelletMgr->getConfigFromIdx(i);
-		server.NewOption(config->mPelletName().mString, config->mPelletId.mId);
+		server.NewOption(config->mPelletName().mString, i);
 	}
 	server.EndOptionBox();
 }

--- a/src/plugPikiNishimura/nscalculation.cpp
+++ b/src/plugPikiNishimura/nscalculation.cpp
@@ -21,7 +21,7 @@ DEFINE_PRINT("TODO: Replace")
 /*
  * Aside from arg order and defines, identical to Pikmin 2's NsMathExp::calcLagrange
  */
-void NsCalculation::calcLagrange(f32 t, const Vector3f* controlPts, Vector3f& outPoint)
+void NsCalculation::calcLagrange(f32 t, const Vector3f* const controlPts, Vector3f& outPoint)
 {
 	outPoint.x = (t - 2.0f) * (controlPts[0].x * 0.5f * (t - 1.0f)) - ((t - 2.0f) * (controlPts[1].x * t))
 	           + (t - 1.0f) * (controlPts[2].x * 0.5f * t);

--- a/src/plugPikiOgawa/ogCallBack.cpp
+++ b/src/plugPikiOgawa/ogCallBack.cpp
@@ -19,7 +19,7 @@ DEFINE_PRINT("OgCallBackSection")
 zen::TextColorCallBack::TextColorCallBack(P2DPane* pane)
     : P2DPaneCallBack(pane, PANETYPE_TextBox)
 {
-	mTextBox            = (P2DTextBox*)pane;
+	mTextBox            = static_cast<P2DTextBox*>(pane);
 	mIsTransitionActive = false;
 	mTransitionDuration = 1.0f;
 	mElapsedTime        = 0.0f;

--- a/src/plugPikiOgawa/ogDiary.cpp
+++ b/src/plugPikiOgawa/ogDiary.cpp
@@ -598,21 +598,21 @@ zen::ogDrawSelectDiary::SelectDiaryStatus zen::ogDrawSelectDiary::update(Control
 	mScreen->update();
 	mDiaryStatus = mDiaryInstance->update(input);
 	mBlackFadeScreen->update();
-	for (int i = mCurrentDay + 1; i < MAX_DAYS; i++) {
-		P2DPicture* obj = static_cast<P2DPicture*>(_248[i]->getPaneTree()->getParent()->getObject());
+	for (int futureDay = mCurrentDay + 1; futureDay < MAX_DAYS; futureDay++) {
+		P2DPicture* obj = static_cast<P2DPicture*>(_248[futureDay]->getPaneTree()->getParent()->getObject());
 		obj->setAlpha(0);
 	}
 
-	for (int i = 0; i <= mCurrentDay; i++) {
+	for (int day = 0; day <= mCurrentDay; day++) {
 		f32 phase = mTransitionTimer;
 		if (phase >= 1.0f) {
 			phase -= 1.0f;
 		}
 
-		phase -= f32(i) * 0.1f;
+		phase -= f32(day) * 0.1f;
 		f32 scale = 0.05f * sinf(TAU * phase) + 1.0f;
-		mDayDisplayPanes[i]->setOffset(mDayDisplayPanes[i]->getWidth() / 2, mDayDisplayPanes[i]->getHeight() / 2);
-		mDayDisplayPanes[i]->setScale(scale);
+		mDayDisplayPanes[day]->setOffset(mDayDisplayPanes[day]->getWidth() / 2, mDayDisplayPanes[day]->getHeight() / 2);
+		mDayDisplayPanes[day]->setScale(scale);
 	}
 
 	if (mStatus == ViewingSingleDiary && mDiaryStatus == ogDrawDiary::Closed) {

--- a/src/plugPikiOgawa/ogDiary.cpp
+++ b/src/plugPikiOgawa/ogDiary.cpp
@@ -532,7 +532,8 @@ zen::ogDrawSelectDiary::SelectDiaryStatus zen::ogDrawSelectDiary::update(Control
 			return mStatus;
 		}
 
-		mBlackFadePicture->setAlpha((1.0f - mTransitionTimer / 0.5f) * 255.0f);
+		f32 alphaRatio = mTransitionTimer / 0.5f;
+		mBlackFadePicture->setAlpha(255.0f * (1.0f - alphaRatio));
 	}
 
 	if (mStatus == FadingOut) {
@@ -541,15 +542,16 @@ zen::ogDrawSelectDiary::SelectDiaryStatus zen::ogDrawSelectDiary::update(Control
 			return mStatus;
 		}
 
-		mBlackFadePicture->setAlpha((mTransitionTimer / 0.5f) * 255.0f);
+		f32 alphaRatio = mTransitionTimer / 0.5f;
+		mBlackFadePicture->setAlpha(255.0f * alphaRatio);
 	}
 
 	if (mStatus == Active) {
 		if (input->keyClick(KBBTN_A | KBBTN_START)) {
 			P2DPane* pane = mDayDisplayPanes[mSelectionIndex];
-			f32 x         = pane->getPosH() + pane->getWidth() / 2;
-			f32 y         = pane->getPosV() + pane->getHeight() / 2;
-			mDiaryInstance->open(x, y, mSelectionIndex + 1);
+			int centerX   = pane->getPosH() + pane->getWidth() / 2;
+			int centerY   = pane->getPosV() + pane->getHeight() / 2;
+			mDiaryInstance->open(centerX, centerY, mSelectionIndex + 1);
 			seSystem->playSysSe(ogEnumFix(SYSSE_DECIDE1, JACSYS_Decide1));
 			mStatus = ViewingSingleDiary;
 			return mStatus;
@@ -598,6 +600,7 @@ zen::ogDrawSelectDiary::SelectDiaryStatus zen::ogDrawSelectDiary::update(Control
 	mScreen->update();
 	mDiaryStatus = mDiaryInstance->update(input);
 	mBlackFadeScreen->update();
+	
 	for (int futureDay = mCurrentDay + 1; futureDay < MAX_DAYS; futureDay++) {
 		P2DPicture* obj = static_cast<P2DPicture*>(_248[futureDay]->getPaneTree()->getParent()->getObject());
 		obj->setAlpha(0);
@@ -609,9 +612,11 @@ zen::ogDrawSelectDiary::SelectDiaryStatus zen::ogDrawSelectDiary::update(Control
 			phase -= 1.0f;
 		}
 
-		phase -= f32(day) * 0.1f;
+		phase -= day * 0.1f;
 		f32 scale = 0.05f * sinf(TAU * phase) + 1.0f;
-		mDayDisplayPanes[day]->setOffset(mDayDisplayPanes[day]->getWidth() / 2, mDayDisplayPanes[day]->getHeight() / 2);
+		int offsetX = mDayDisplayPanes[day]->getWidth() / 2;
+		int offsetY = mDayDisplayPanes[day]->getHeight() / 2;
+		mDayDisplayPanes[day]->setOffset(offsetX, offsetY);
 		mDayDisplayPanes[day]->setScale(scale);
 	}
 

--- a/src/plugPikiOgawa/ogDiary.cpp
+++ b/src/plugPikiOgawa/ogDiary.cpp
@@ -394,11 +394,11 @@ zen::ogDrawSelectDiary::ogDrawSelectDiary()
 	mScreen->set("screen/blo/m_menu_r.blo", true, true, true);
 	mBlackFadeScreen = new P2DScreen;
 	mBlackFadeScreen->set("screen/blo/black.blo", false, false, true);
-	mBlackFadePicture = (P2DPicture*)mBlackFadeScreen->search('blck', true);
+	mBlackFadePicture = static_cast<P2DPicture*>(mBlackFadeScreen->search('blck', true));
 	mBlackFadePicture->setAlpha(255);
 	mController = new ZenController(nullptr);
 	mController->setRepeatTime(0.2f);
-	mAButtonIcon          = (P2DPicture*)mScreen->search('abtn', true);
+	mAButtonIcon          = static_cast<P2DPicture*>(mScreen->search('abtn', true));
 	mAButtonAlphaAnimator = new setTenmetuAlpha(mAButtonIcon, 1.0f);
 	mDiaryInstance        = new ogDrawDiary;
 	mCurrentDay           = 0;
@@ -417,7 +417,7 @@ zen::ogDrawSelectDiary::ogDrawSelectDiary()
 		mDayDisplayPanes[i] = mScreen->search(P2DPaneLibrary::makeTag(name), true);
 
 		sprintf(name, "pk%02d", i + 14);
-		_248[i] = (P2DPicture*)mScreen->search(P2DPaneLibrary::makeTag(name), true);
+		_248[i] = static_cast<P2DPicture*>(mScreen->search(P2DPaneLibrary::makeTag(name), true));
 	}
 
 	mSelectedColumnIndex = 0;
@@ -462,7 +462,7 @@ void zen::ogDrawSelectDiary::start()
 	}
 
 	for (int i = mCurrentDay + 1; i < MAX_DAYS; i++) {
-		P2DPicture* obj = (P2DPicture*)_248[i]->getPaneTree()->getParent()->getObject();
+		P2DPicture* obj = static_cast<P2DPicture*>(_248[i]->getPaneTree()->getParent()->getObject());
 		obj->setAlpha(0);
 	}
 
@@ -597,7 +597,7 @@ zen::ogDrawSelectDiary::SelectDiaryStatus zen::ogDrawSelectDiary::update(Control
 	mDiaryStatus = mDiaryInstance->update(input);
 	mBlackFadeScreen->update();
 	for (int i = mCurrentDay + 1; i < MAX_DAYS; i++) {
-		P2DPicture* obj = (P2DPicture*)_248[i]->getPaneTree()->getParent()->getObject();
+		P2DPicture* obj = static_cast<P2DPicture*>(_248[i]->getPaneTree()->getParent()->getObject());
 		obj->setAlpha(0);
 	}
 

--- a/src/plugPikiOgawa/ogDiary.cpp
+++ b/src/plugPikiOgawa/ogDiary.cpp
@@ -453,7 +453,9 @@ void zen::ogDrawSelectDiary::start()
 	_UNUSED2E6           = 0;
 	mBlackFadePicture->setAlpha(255);
 
-	for (int i = 0; i < MAX_DAYS; i++) {
+	int i;
+
+	for (i = 0; i < MAX_DAYS; i++) {
 		if (i > mCurrentDay) {
 			P2DPaneLibrary::setFamilyAlpha(mDayDisplayPanes[i], 80);
 		} else {
@@ -461,7 +463,7 @@ void zen::ogDrawSelectDiary::start()
 		}
 	}
 
-	for (int i = mCurrentDay + 1; i < MAX_DAYS; i++) {
+	for (i = mCurrentDay + 1; i < MAX_DAYS; i++) {
 		P2DPicture* obj = static_cast<P2DPicture*>(_248[i]->getPaneTree()->getParent()->getObject());
 		obj->setAlpha(0);
 	}

--- a/src/plugPikiOgawa/ogFileSelect.cpp
+++ b/src/plugPikiOgawa/ogFileSelect.cpp
@@ -225,27 +225,27 @@ void zen::ogScrFileSelectMgr::getPane_FileTop1()
 
 	mTitleTextBasePane       = mMainUIScreen->search('p_ma', true);
 	mYesNoDialogPane         = mMainUIScreen->search('yn_w', true);
-	mCardAccessIcon          = (P2DPicture*)mMainUIScreen->search('chui', true);
-	mYesNoDialogImage        = (P2DPicture*)mMainUIScreen->search('back', true);
-	mYesNoDialogPromptText   = (P2DTextBox*)mMainUIScreen->search('se_c', true);
-	mNitakuYesText           = (P2DTextBox*)mMainUIScreen->search('hai', true);
-	mNitakuNoText            = (P2DTextBox*)mMainUIScreen->search('iie', true);
+	mCardAccessIcon          = static_cast<P2DPicture*>(mMainUIScreen->search('chui', true));
+	mYesNoDialogImage        = static_cast<P2DPicture*>(mMainUIScreen->search('back', true));
+	mYesNoDialogPromptText   = static_cast<P2DTextBox*>(mMainUIScreen->search('se_c', true));
+	mNitakuYesText           = static_cast<P2DTextBox*>(mMainUIScreen->search('hai', true));
+	mNitakuNoText            = static_cast<P2DTextBox*>(mMainUIScreen->search('iie', true));
 	mPromptSelectSavePane    = mMainUIScreen->search('dono', true);
-	mCorruptText             = (P2DTextBox*)mMainUIScreen->search('hsho', true);
+	mCorruptText             = static_cast<P2DTextBox*>(mMainUIScreen->search('hsho', true));
 	mPromptNoCardPane        = mMainUIScreen->search('sho', true);
 	mPromptCardErrPane       = mMainUIScreen->search('dsho', true);
 	mPromptSelectCopySrcPane = mMainUIScreen->search('doko', true);
-	mConfirmCopyText         = (P2DTextBox*)mMainUIScreen->search('d1co', true);
+	mConfirmCopyText         = static_cast<P2DTextBox*>(mMainUIScreen->search('d1co', true));
 	mOpInProgressPane        = mMainUIScreen->search('copc', true);
 	mPromptConfirmDelPane    = mMainUIScreen->search('dcxx', true);
 	mOpCompletePane          = mMainUIScreen->search('dcop', true);
-	mFormatDoneText          = (P2DTextBox*)mMainUIScreen->search('dasa', true);
+	mFormatDoneText          = static_cast<P2DTextBox*>(mMainUIScreen->search('dasa', true));
 	mPromptSaveFailPane      = mMainUIScreen->search('dosa', true);
 	mPromptSaveOKPane        = mMainUIScreen->search('savc', true);
 	mPromptCardFullPane      = mMainUIScreen->search('ddxx', true);
-	mAltMsgText1             = (P2DTextBox*)mMainUIScreen->search('uasa', true);
-	mAltMsgText2             = (P2DTextBox*)mMainUIScreen->search('u1co', true);
-	mAltMsgText3             = (P2DTextBox*)mMainUIScreen->search('usho', true);
+	mAltMsgText1             = static_cast<P2DTextBox*>(mMainUIScreen->search('uasa', true));
+	mAltMsgText2             = static_cast<P2DTextBox*>(mMainUIScreen->search('u1co', true));
+	mAltMsgText3             = static_cast<P2DTextBox*>(mMainUIScreen->search('usho', true));
 
 	Colour colour;
 	colour.set(255, 255, 255, 255);
@@ -409,12 +409,12 @@ void zen::ogScrFileSelectMgr::getPane_FileIcon()
 		mSlotScreensNoData[i]->setScale(scale);
 
 		mDayCount1DigitPane[i]  = screen->search('dc_c', true);
-		mDayCount1DigitPic[i]   = (P2DPicture*)screen->search('dcmc', true);
+		mDayCount1DigitPic[i]   = static_cast<P2DPicture*>(screen->search('dcmc', true));
 		mDayCount2DigitLPane[i] = screen->search('dc_l', true);
 		mDayCount2DigitRPane[i] = screen->search('dc_r', true);
-		mDayCount2DigitLPic[i]  = (P2DPicture*)screen->search('dcml', true);
-		mDayCount2DigitRPic[i]  = (P2DPicture*)screen->search('dcmr', true);
-		mDayCountColorSrcPic[i] = (P2DPicture*)screen->search('sm_c', true);
+		mDayCount2DigitLPic[i]  = static_cast<P2DPicture*>(screen->search('dcml', true));
+		mDayCount2DigitRPic[i]  = static_cast<P2DPicture*>(screen->search('dcmr', true));
+		mDayCountColorSrcPic[i] = static_cast<P2DPicture*>(screen->search('sm_c', true));
 
 		Colour white = mDayCountColorSrcPic[i]->getWhite();
 		u8 alpha     = mDayCountColorSrcPic[i]->getAlpha();
@@ -767,7 +767,7 @@ zen::ogScrFileSelectMgr::ogScrFileSelectMgr()
 	mBlackOverlayScreen = new P2DScreen();
 	mBlackOverlayScreen->set("screen/blo/black.blo", false, false, true);
 
-	mDeleteCursorPicture = (P2DPicture*)mBlackOverlayScreen->search('blck', true);
+	mDeleteCursorPicture = static_cast<P2DPicture*>(mBlackOverlayScreen->search('blck', true));
 	mDeleteCursorPicture->setAlpha(255);
 
 	getPane_FileTop1();

--- a/src/plugPikiOgawa/ogGraph.cpp
+++ b/src/plugPikiOgawa/ogGraph.cpp
@@ -53,7 +53,9 @@ ogGraphMgr::ogGraphMgr(P2DScreen* screen)
  */
 void ogGraphMgr::SetDummyLineData()
 {
-	for (int i = 0; i < 32; i++) {
+	int i;
+
+	for (i = 0; i < 32; i++) {
 		LinePointB[i] = 0;
 		LinePointR[i] = 0;
 		LinePointY[i] = 0;
@@ -68,7 +70,7 @@ void ogGraphMgr::SetDummyLineData()
 	// The way this was originally written, it describes a line containing 14 points.
 	// That is UB because `ogawa_per_line` only contains 13 elements, but luckily the
 	// erroneous final point is never rendered by `zen::setGraphGX` anyway.
-	for (int i = 0; i TERNARY_BUGFIX(<, <=) 13; i++) {
+	for (i = 0; i TERNARY_BUGFIX(<, <=) 13; i++) {
 		int yPercentFromTop = 100 - ogawa_per_line[i];
 		s16 pointY          = y + yPercentFromTop * paneFullHeight / 100;
 		pointArray[0]       = x + i * paneSegmentWidth;

--- a/src/plugPikiOgawa/ogGraph.cpp
+++ b/src/plugPikiOgawa/ogGraph.cpp
@@ -64,10 +64,10 @@ void ogGraphMgr::SetDummyLineData()
 	s16 y                = mParent->getPosV();
 	s16 paneFullHeight   = mParent->getHeight();
 
+	s16* pointArray = LinePointR;
 	// The way this was originally written, it describes a line containing 14 points.
 	// That is UB because `ogawa_per_line` only contains 13 elements, but luckily the
 	// erroneous final point is never rendered by `zen::setGraphGX` anyway.
-	s16* pointArray = LinePointR;
 	for (int i = 0; i TERNARY_BUGFIX(<, <=) 13; i++) {
 		int yPercentFromTop = 100 - ogawa_per_line[i];
 		s16 pointY          = y + yPercentFromTop * paneFullHeight / 100;

--- a/src/plugPikiOgawa/ogGraph.cpp
+++ b/src/plugPikiOgawa/ogGraph.cpp
@@ -71,11 +71,13 @@ void ogGraphMgr::SetDummyLineData()
 	// That is UB because `ogawa_per_line` only contains 13 elements, but luckily the
 	// erroneous final point is never rendered by `zen::setGraphGX` anyway.
 	for (i = 0; i TERNARY_BUGFIX(<, <=) 13; i++) {
-		int yPercentFromTop = 100 - ogawa_per_line[i];
-		s16 pointY          = y + yPercentFromTop * paneFullHeight / 100;
-		pointArray[0]       = x + i * paneSegmentWidth;
-		pointArray[1]       = pointY;
-		pointArray += 2;
+		s16 percent   = ogawa_per_line[i];
+		s16 pointX    = i * paneSegmentWidth + x;
+		s16 pointY    = (100 - percent) * paneFullHeight / 100 + y;
+		*pointArray = pointX;
+		pointArray++;
+		*pointArray = pointY;
+		pointArray++;
 	}
 }
 

--- a/src/plugPikiOgawa/ogMakeDefault.cpp
+++ b/src/plugPikiOgawa/ogMakeDefault.cpp
@@ -30,14 +30,14 @@ zen::ogScrMakeDefaultMgr::ogScrMakeDefaultMgr()
 
 	mBlackScreen = new P2DScreen;
 	mBlackScreen->set("screen/blo/black.blo", false, false, true);
-	mBlackScreenOverlay = (P2DPicture*)mBlackScreen->search('blck', true);
+	mBlackScreenOverlay = static_cast<P2DPicture*>(mBlackScreen->search('blck', true));
 	mBlackScreenOverlay->setAlpha(255);
 
-	mAButtonPromptPicture       = (P2DPicture*)mScreen->search('abtn', true);
+	mAButtonPromptPicture       = static_cast<P2DPicture*>(mScreen->search('abtn', true));
 	mAButtonPromptAlphaAnimator = new setTenmetuAlpha(mAButtonPromptPicture, 1.0f);
 	mAButtonPromptPicture->hide();
 
-	mDefaultMessageTextBox   = (P2DTextBox*)mScreen->search('tx00', true);
+	mDefaultMessageTextBox   = static_cast<P2DTextBox*>(mScreen->search('tx00', true));
 	mDefaultMessageTypingMgr = new TypingTextMgr(mDefaultMessageTextBox);
 	mActiveTypingTextMgr     = mDefaultMessageTypingMgr;
 
@@ -45,13 +45,13 @@ zen::ogScrMakeDefaultMgr::ogScrMakeDefaultMgr()
 	mTwoSecondDelayPane   = mScreen->search('tx02', true);
 	mThreeSecondDelayPane = mScreen->search('tx03', true);
 
-	mCursorPicture       = (P2DPicture*)mScreen->search('curs', true);
+	mCursorPicture       = static_cast<P2DPicture*>(mScreen->search('curs', true));
 	mCursorAlphaAnimator = new setTenmetuAlpha(mCursorPicture, 0.5f);
 
-	mOkMessageTextBox   = (P2DTextBox*)mScreen->search('pfok', true);
+	mOkMessageTextBox   = static_cast<P2DTextBox*>(mScreen->search('pfok', true));
 	mOkMessageTypingMgr = new TypingTextMgr(mOkMessageTextBox);
 
-	mFailMessageTextBox   = (P2DTextBox*)mScreen->search('pfxx', true);
+	mFailMessageTextBox   = static_cast<P2DTextBox*>(mScreen->search('pfxx', true));
 	mFailMessageTypingMgr = new TypingTextMgr(mFailMessageTextBox);
 
 	mStateTimer = 0.0f;

--- a/src/plugPikiOgawa/ogMap.cpp
+++ b/src/plugPikiOgawa/ogMap.cpp
@@ -56,7 +56,7 @@ zen::ogScrMapMgr::ogScrMapMgr()
 	P2DTextBox* textBox = static_cast<P2DTextBox*>(mTest2Screen->search('tx00', true));
 	mTypingTextMgr      = new TypingTextMgr(textBox);
 
-	mCursorPane = (P2DPicture*)mTest2Screen->search('curs', true);
+	mCursorPane = static_cast<P2DPicture*>(mTest2Screen->search('curs', true));
 	mFrameTimer = 0.0f;
 	mState      = Inactive;
 }

--- a/src/plugPikiOgawa/ogMemChk.cpp
+++ b/src/plugPikiOgawa/ogMemChk.cpp
@@ -33,7 +33,7 @@ zen::ogScrMemChkMgr::ogScrMemChkMgr()
 
 	mBlackScreen = new P2DScreen;
 	mBlackScreen->set("screen/blo/black.blo", false, false, true);
-	mBlackPane = (P2DPicture*)mBlackScreen->search('blck', true);
+	mBlackPane = static_cast<P2DPicture*>(mBlackScreen->search('blck', true));
 	mBlackPane->setAlpha(255);
 
 	mEfxMgr = new EffectMgr2D(0x20, 0x80, 0x80);
@@ -46,72 +46,72 @@ zen::ogScrMemChkMgr::ogScrMemChkMgr()
 	P2DScreen* screen = mMainScreen;
 
 	// "If you format this Memory Card, all saved files will be erased. Is this OK?"
-	mFormatConfirmTextBox = (P2DTextBox*)screen->search('shom', true);
+	mFormatConfirmTextBox = static_cast<P2DTextBox*>(screen->search('shom', true));
 
 	// "The Memory Card has been formatted."
-	mFormattedTextBox = (P2DTextBox*)screen->search('shot', true);
+	mFormattedTextBox = static_cast<P2DTextBox*>(screen->search('shot', true));
 
 	// "Formatting the Memory Card... Do not touch the Memory Card or POWER Button."
-	mFormattingTextBox = (P2DTextBox*)screen->search('shch', true);
+	mFormattingTextBox = static_cast<P2DTextBox*>(screen->search('shch', true));
 
 	// The Memory Card in Slot A is corrupted and needs to be formatted."
-	mNeedFormatTextBox = (P2DTextBox*)screen->search('shoi', true);
+	mNeedFormatTextBox = static_cast<P2DTextBox*>(screen->search('shoi', true));
 
 	// "The Memory Card in Slot A is not formatted for use in this market. It must be formatted. Is this OK?"
-	mDoFixUnformattedTextBox = (P2DTextBox*)screen->search('shok', true);
+	mDoFixUnformattedTextBox = static_cast<P2DTextBox*>(screen->search('shok', true));
 
 	// "The Memory Card could not be formatted."
-	mCantFormatTextBox = (P2DTextBox*)screen->search('shos', true);
+	mCantFormatTextBox = static_cast<P2DTextBox*>(screen->search('shos', true));
 
-	mYesPane = (P2DTextBox*)screen->search('hai', true); // "Yes"
-	mNoPane  = (P2DTextBox*)screen->search('iie', true); // "No"
+	mYesPane = static_cast<P2DTextBox*>(screen->search('hai', true)); // "Yes"
+	mNoPane  = static_cast<P2DTextBox*>(screen->search('iie', true)); // "No"
 
 #if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01)
 #else
-	mYesPane2 = (P2DTextBox*)screen->search('haic', true); // "Yes"
-	mNoPane2  = (P2DTextBox*)screen->search('iiec', true); // "No"
+	mYesPane2 = static_cast<P2DTextBox*>(screen->search('haic', true)); // "Yes"
+	mNoPane2  = static_cast<P2DTextBox*>(screen->search('iiec', true)); // "No"
 #endif
 
 	// "Some Pikmin save data is corrupted. The Pikmin file will now be repaired. Do not touch the Memory Card or POWER Button."
-	mRepairFileTextBox = (P2DTextBox*)screen->search('shuf', true);
+	mRepairFileTextBox = static_cast<P2DTextBox*>(screen->search('shuf', true));
 
 	// "The Pikmin file has been repaired."
-	mRepairSuccessTextBox = (P2DTextBox*)screen->search('shsi', true);
+	mRepairSuccessTextBox = static_cast<P2DTextBox*>(screen->search('shsi', true));
 
 	// "Some Pikmin save data could not be repaired."
-	mRepairFailTextBox = (P2DTextBox*)screen->search('shxx', true);
+	mRepairFailTextBox = static_cast<P2DTextBox*>(screen->search('shxx', true));
 
 	// There is no Memory Card in Slot A, so you won't be able to save your game. Continue without saving?"
-	mNoCardTextBox = (P2DTextBox*)screen->search('sari', true);
+	mNoCardTextBox = static_cast<P2DTextBox*>(screen->search('sari', true));
 
 	// The Memory Card in Slot A does not have enough space available. Pikmin needs 1 file and 19 blocks of memory to save. Continue
 	// without saving?"
-	mCardFullTextBox = (P2DTextBox*)screen->search('memo', true);
+	mCardFullTextBox = static_cast<P2DTextBox*>(screen->search('memo', true));
 
 	// "The Memory Card in Slot A is not compatible with Pikmin. You can't save.  Continue without saving?"
-	mUnusableCardTextBox = (P2DTextBox*)screen->search('brom', true);
+	mUnusableCardTextBox = static_cast<P2DTextBox*>(screen->search('brom', true));
 
 	// "The Memory Card inserted in Slot A is not formatted for use in this market. It must be formatted. Is this OK?"
-	mUnformattedCardTextBox = (P2DTextBox*)screen->search('kaim', true);
+	mUnformattedCardTextBox = static_cast<P2DTextBox*>(screen->search('kaim', true));
 
 	// "The Memory Card inserted  in Slot A is damaged or corrupted. You can't save. Do you still want to continue?"
-	mBrokenCardTextBox = (P2DTextBox*)screen->search('ijom', true);
+	mBrokenCardTextBox = static_cast<P2DTextBox*>(screen->search('ijom', true));
 
 	// "The device in Slot A cannot be used. You can't save. Is this OK?"
-	mNotACardTextBox = (P2DTextBox*)screen->search('naim', true);
+	mNotACardTextBox = static_cast<P2DTextBox*>(screen->search('naim', true));
 
 	// The Memory Card in Slot A does not have enough space available. Pikmin needs 1 file and 19 blocks of memory to save. Continue
 	// without saving?"
-	mFileNotMadeTextBox = (P2DTextBox*)screen->search('file', true);
+	mFileNotMadeTextBox = static_cast<P2DTextBox*>(screen->search('file', true));
 
 	mYesNoWindow = screen->search('yn_w', true);
 	mCapsulePane = screen->search('cpsl', true);
 
-	mAButtonPane     = (P2DPicture*)mMainScreen->search('abtn', true);
+	mAButtonPane     = static_cast<P2DPicture*>(mMainScreen->search('abtn', true));
 	mAButtonAlphaMgr = new setTenmetuAlpha(mAButtonPane, 1.0f);
 	mAButtonPane->hide();
 
-	mFormatEffPane = (P2DPicture*)mMainScreen->search('main', true);
+	mFormatEffPane = static_cast<P2DPicture*>(mMainScreen->search('main', true));
 
 	mFormatConfirmTextBox->hide();
 	mFormattedTextBox->hide();
@@ -133,7 +133,7 @@ zen::ogScrMemChkMgr::ogScrMemChkMgr()
 
 	mFileNotMadeTextBox->hide();
 
-	mCursorPane     = (P2DPicture*)mMainScreen->search('curs', true);
+	mCursorPane     = static_cast<P2DPicture*>(mMainScreen->search('curs', true));
 	mCursorAlphaMgr = new setTenmetuAlpha(mCursorPane, 0.5f);
 
 	mFormatConfirmTextMgr    = new TypingTextMgr(mFormatConfirmTextBox);
@@ -158,15 +158,15 @@ zen::ogScrMemChkMgr::ogScrMemChkMgr()
 	mPrevStatusCheck = Inactive;
 
 #if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01)
-	P2DTextBox* yes = (P2DTextBox*)mMainScreen->search('hai', true); // "yes"
-	P2DTextBox* no  = (P2DTextBox*)mMainScreen->search('iie', true); // "no"
-	P2DTextBox* a4  = (P2DTextBox*)mMainScreen->search('se_c', true);
+	P2DTextBox* yes = static_cast<P2DTextBox*>(mMainScreen->search('hai', true)); // "yes"
+	P2DTextBox* no  = static_cast<P2DTextBox*>(mMainScreen->search('iie', true)); // "no"
+	P2DTextBox* a4  = static_cast<P2DTextBox*>(mMainScreen->search('se_c', true));
 	mNitakuMgr      = new ogNitakuMgr(mMainScreen, yes, no, a4, false, false);
 #else
-	P2DTextBox* a1 = (P2DTextBox*)mMainScreen->search('fomt', true); // "Format"
-	P2DTextBox* a2 = (P2DTextBox*)mMainScreen->search('cws', true);  // "Continue without saving"
-	P2DTextBox* a3 = (P2DTextBox*)mMainScreen->search('rtry', true); // "Retry"
-	P2DTextBox* a4 = (P2DTextBox*)mMainScreen->search('se_c', true);
+	P2DTextBox* a1 = static_cast<P2DTextBox*>(mMainScreen->search('fomt', true)); // "Format"
+	P2DTextBox* a2 = static_cast<P2DTextBox*>(mMainScreen->search('cws', true));  // "Continue without saving"
+	P2DTextBox* a3 = static_cast<P2DTextBox*>(mMainScreen->search('rtry', true)); // "Retry"
+	P2DTextBox* a4 = static_cast<P2DTextBox*>(mMainScreen->search('se_c', true));
 	mNitakuMgr     = new ogNitakuMgr(mMainScreen, mYesPane2, mNoPane2, a4, false, false);
 	a1->hide();
 	a2->hide();

--- a/src/plugPikiOgawa/ogMenu.cpp
+++ b/src/plugPikiOgawa/ogMenu.cpp
@@ -162,10 +162,10 @@ zen::ogDrawScrController::ogDrawScrController()
 {
 	mControllerScreenMenu.setScreen("screen/blo/cont_00.blo");
 	P2DScreen* screen = mControllerScreenMenu.getPsc();
-	setTextColor((P2DTextBox*)screen->search('st_c', false), (P2DPicture*)screen->search('st', false));
+	setTextColor(static_cast<P2DTextBox*>(screen->search('st_c', false)), static_cast<P2DPicture*>(screen->search('st', false)));
 	mHighlightWhiteColor.set(255, 255, 255, 255);
 	mHighlightBlackColor.set(0, 0, 0, 0);
-	mMasterBackgroundWindowPane = (P2DPicture*)screen->search('3d_w', true);
+	mMasterBackgroundWindowPane = static_cast<P2DPicture*>(screen->search('3d_w', true));
 
 	static u32 pane_name[9]  = { 'l_m', 'r_m', 'z_m', 'y_m', 'x_m', 'a_m', 'b_m', 'c_m', '3d_m' };
 	static u32 pane_name2[9] = { 'l', 'r', 'z', 'y', 'x', 'a', 'b', 'c', '3d' };
@@ -173,10 +173,10 @@ zen::ogDrawScrController::ogDrawScrController()
 	static u32 pane_name4[9] = { 'l_w', 'r_w', 'z_w', 'y_w', 'x_w', 'a_w', 'b_w', 'c_w', '3d_w' };
 
 	for (int i = 0; i < 9; i++) {
-		mButtonMaskPanes[i]             = (P2DPicture*)screen->search(pane_name[i], true);
-		mButtonBasePanes[i]             = (P2DPicture*)screen->search(pane_name2[i], true);
-		mButtonTextBoxes[i]             = (P2DTextBox*)screen->search(pane_name3[i], true);
-		mButtonBackgroundWindowPanes[i] = (P2DPicture*)screen->search(pane_name4[i], true);
+		mButtonMaskPanes[i]             = static_cast<P2DPicture*>(screen->search(pane_name[i], true));
+		mButtonBasePanes[i]             = static_cast<P2DPicture*>(screen->search(pane_name2[i], true));
+		mButtonTextBoxes[i]             = static_cast<P2DTextBox*>(screen->search(pane_name3[i], true));
+		mButtonBackgroundWindowPanes[i] = static_cast<P2DPicture*>(screen->search(pane_name4[i], true));
 		setTextColor(mButtonTextBoxes[i], mButtonMaskPanes[i]);
 		setTextColor(mButtonTextBoxes[i], mButtonBasePanes[i]);
 	}
@@ -473,9 +473,9 @@ zen::ogScrMenuMgr::ogScrMenuMgr()
 
 	mBlackScreen = new P2DScreen;
 	mBlackScreen->set("screen/blo/black.blo", false, false, true);
-	mFadeOverlayPane = (P2DPicture*)mBlackScreen->search('blck', true);
+	mFadeOverlayPane = static_cast<P2DPicture*>(mBlackScreen->search('blck', true));
 
-	P2DTextBox* txt = (P2DTextBox*)mInfoScreen->mInfoScreenMenu.getPsc()->search('se_c', true);
+	P2DTextBox* txt = static_cast<P2DTextBox*>(mInfoScreen->mInfoScreenMenu.getPsc()->search('se_c', true));
 	mAlpha          = txt->getAlphaChar();
 	PRINT("se_c = %d\n", mAlpha);
 	mFadeOverlayPane->setAlpha(0);

--- a/src/plugPikiOgawa/ogMessage.cpp
+++ b/src/plugPikiOgawa/ogMessage.cpp
@@ -218,7 +218,7 @@ void zen::ogScrMessageMgr::backPage()
 /**
  * @todo: Documentation
  */
-s16 zen::ogScrMessageMgr::makePageInfo(immut char*** data)
+s16 zen::ogScrMessageMgr::makePageInfo(immut char*** const data)
 {
 	int idx = 0;
 	for (int i = 0; i < 0x99; i++) {
@@ -459,7 +459,7 @@ void zen::ogScrMessageMgr::ReadAllScreen()
 /**
  * @todo: Documentation
  */
-void zen::ogScrMessageMgr::MakeAndSetPageInfo(immut char*** data)
+void zen::ogScrMessageMgr::MakeAndSetPageInfo(immut char*** const data)
 {
 	mPageInfoEntryCount = makePageInfo(data);
 	setMessagePage(0);

--- a/src/plugPikiOgawa/ogMessage.cpp
+++ b/src/plugPikiOgawa/ogMessage.cpp
@@ -148,7 +148,7 @@ void zen::ogScrMessageMgr::resetPage()
 		switch (mPagePaneList[i]->getTypeID()) {
 		case PANETYPE_TextBox:
 		{
-			((P2DTextBox*)mPagePaneList[i])->setString("");
+			static_cast<P2DTextBox*>(mPagePaneList[i])->setString("");
 			break;
 		}
 		case PANETYPE_Picture:
@@ -417,14 +417,14 @@ void zen::ogScrMessageMgr::setPageInfoSub()
 			case PANETYPE_TextBox:
 			{
 #if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01)
-				mProcessedTextBoxStrings[id] = ((P2DTextBox*)mPagePaneList[id])->getString();
+				mProcessedTextBoxStrings[id] = static_cast<P2DTextBox*>(mPagePaneList[id])->getString();
 #else
-				sprintf(mRawPageTextBoxStrings[id], "%s", ((P2DTextBox*)mPagePaneList[id])->getString());
+				sprintf(mRawPageTextBoxStrings[id], "%s", static_cast<P2DTextBox*>(mPagePaneList[id])->getString());
 				mProcessedTextBoxStrings[id] = mRawPageTextBoxStrings[id];
 				cnvSingleMulti(mProcessedTextBoxStrings[id]);
 				cnvButtonIcon(mProcessedTextBoxStrings[id]);
 #endif
-				((P2DTextBox*)mPagePaneList[id])->setString("");
+				static_cast<P2DTextBox*>(mPagePaneList[id])->setString("");
 				id++;
 				break;
 			}
@@ -485,8 +485,8 @@ zen::ogScrMessageMgr::ogScrMessageMgr(immut char* path)
 	mHasDrawOccurredThisFrame = false;
 	mCurrPageNum              = 0;
 	mCurrentMessageId         = 0;
-	mCursorPane               = (P2DPicture*)mBaseScreen->search('curs', true);
-	mButtonPromptPane         = (P2DPicture*)mBaseScreen->search('a_bt', true);
+	mCursorPane               = static_cast<P2DPicture*>(mBaseScreen->search('curs', true));
+	mButtonPromptPane         = static_cast<P2DPicture*>(mBaseScreen->search('a_bt', true));
 	mCursorBlinker            = new setTenmetuAlpha(mCursorPane, 0.5f);
 	mButtonPromptBlinker      = new setTenmetuAlpha(mButtonPromptPane, 1.0f);
 	mCursorBlinker->start();
@@ -536,7 +536,7 @@ void zen::ogScrMessageMgr::dispAll()
 		switch (mPagePaneList[i]->getTypeID()) {
 		case PANETYPE_Picture:
 		{
-			P2DPicture* pic = (P2DPicture*)mPagePaneList[i];
+			P2DPicture* pic = static_cast<P2DPicture*>(mPagePaneList[i]);
 			pic->show();
 			P2DPaneLibrary::setFamilyAlpha(pic, 255);
 			pic->initWhite();
@@ -547,7 +547,7 @@ void zen::ogScrMessageMgr::dispAll()
 		{
 			strcpy(mFormattedDisplayStrings[i], mProcessedTextBoxStrings[i]);
 			cnvSpecialNumber(mFormattedDisplayStrings[i]);
-			((P2DTextBox*)mPagePaneList[i])->setString(mFormattedDisplayStrings[i]);
+			static_cast<P2DTextBox*>(mPagePaneList[i])->setString(mFormattedDisplayStrings[i]);
 			mActivePaneId = i;
 			break;
 		}
@@ -562,7 +562,7 @@ void zen::ogScrMessageMgr::dispAll()
 		mCursorPane->hide();
 	}
 	if (mActivePaneId >= 0) {
-		setCursorXY((P2DTextBox*)mPagePaneList[mActivePaneId]);
+		setCursorXY(static_cast<P2DTextBox*>(mPagePaneList[mActivePaneId]));
 	}
 }
 
@@ -644,7 +644,7 @@ zen::ogScrMessageMgr::MessageStatus zen::ogScrMessageMgr::update(Controller* inp
 	}
 
 	if (mActivePaneId >= 0) {
-		setCursorXY((P2DTextBox*)mPagePaneList[mActivePaneId]);
+		setCursorXY(static_cast<P2DTextBox*>(mPagePaneList[mActivePaneId]));
 		mCursorPane->move(mCursorTargetX, mCursorTargetY);
 	}
 
@@ -684,7 +684,7 @@ zen::ogScrMessageMgr::MessageStatus zen::ogScrMessageMgr::update(Controller* inp
 		switch (mPagePaneList[mNextPaneId]->getTypeID()) {
 		case PANETYPE_Picture:
 		{
-			P2DPicture* pic = (P2DPicture*)mPagePaneList[mNextPaneId];
+			P2DPicture* pic = static_cast<P2DPicture*>(mPagePaneList[mNextPaneId]);
 			pic->show();
 			if (mTextAnimationProgress < 1.0f) {
 				u8 alpha = 0;

--- a/src/plugPikiOgawa/ogRader.cpp
+++ b/src/plugPikiOgawa/ogRader.cpp
@@ -330,15 +330,15 @@ void zen::ogRaderMgr::getPartsPos()
 		_84[i]->hide();
 	}
 
-	int i = 0;
+	int partIdx = 0;
 	for (RadarInfo::PartsInfo* info = radarInfo->getFirst(); info; info = info->getNext()) {
 
 		Vector3f inPos = info->getPos();
 		Vector3f pos   = ogCalcDispXZ(inPos);
-		_84[i]->show();
-		_84[i]->move(pos.x, pos.z);
-		_84[i]->setScale(7.5f / _428);
-		i++;
+		_84[partIdx]->show();
+		_84[partIdx]->move(pos.x, pos.z);
+		_84[partIdx]->setScale(7.5f / _428);
+		partIdx++;
 	}
 }
 

--- a/src/plugPikiOgawa/ogRader.cpp
+++ b/src/plugPikiOgawa/ogRader.cpp
@@ -85,35 +85,35 @@ zen::ogRaderMgr::ogRaderMgr()
 	{
 		_54 = STAGE_Practice;
 		screen->set("screen/blo/p_map00.blo", true);
-		_4C = (P2DPicture*)screen->search('map0', true);
+		_4C = static_cast<P2DPicture*>(screen->search('map0', true));
 		break;
 	}
 	case STAGE_Forest:
 	{
 		_54 = STAGE_Forest;
 		screen->set("screen/blo/p_map01.blo", true);
-		_4C = (P2DPicture*)screen->search('map1', true);
+		_4C = static_cast<P2DPicture*>(screen->search('map1', true));
 		break;
 	}
 	case STAGE_Cave:
 	{
 		_54 = STAGE_Cave;
 		screen->set("screen/blo/p_map02.blo", true);
-		_4C = (P2DPicture*)screen->search('map2', true);
+		_4C = static_cast<P2DPicture*>(screen->search('map2', true));
 		break;
 	}
 	case STAGE_Yakushima:
 	{
 		_54 = STAGE_Yakushima;
 		screen->set("screen/blo/p_map03.blo", true);
-		_4C = (P2DPicture*)screen->search('map3', true);
+		_4C = static_cast<P2DPicture*>(screen->search('map3', true));
 		break;
 	}
 	case STAGE_Last:
 	{
 		_54 = STAGE_Last;
 		screen->set("screen/blo/p_map04.blo", true);
-		_4C = (P2DPicture*)screen->search('map4', true);
+		_4C = static_cast<P2DPicture*>(screen->search('map4', true));
 		break;
 	}
 	default:
@@ -121,7 +121,7 @@ zen::ogRaderMgr::ogRaderMgr()
 		PRINT("----- UNKNOWN MAP !!! -----\n");
 		_54 = 0;
 		screen->set("screen/blo/p_map00.blo", true);
-		_4C = (P2DPicture*)screen->search('map0', true);
+		_4C = static_cast<P2DPicture*>(screen->search('map0', true));
 		break;
 	}
 	}
@@ -130,16 +130,16 @@ zen::ogRaderMgr::ogRaderMgr()
 	_450        = 0.0f;
 	mMainScreen = screen;
 	_58         = screen->search('root', true);
-	_5C         = (P2DPicture*)screen->search('mbpi', true);
-	_60         = (P2DPicture*)screen->search('mrpi', true);
-	_64         = (P2DPicture*)screen->search('mypi', true);
-	_68         = (P2DPicture*)screen->search('mmpi', true);
-	_80         = (P2DPicture*)screen->search('part', true);
-	_6C         = (P2DPicture*)screen->search('orim', true);
-	_70         = (P2DPicture*)screen->search('mbci', true);
-	_74         = (P2DPicture*)screen->search('mrci', true);
-	_78         = (P2DPicture*)screen->search('myci', true);
-	_7C         = (P2DPicture*)screen->search('mroi', true);
+	_5C         = static_cast<P2DPicture*>(screen->search('mbpi', true));
+	_60         = static_cast<P2DPicture*>(screen->search('mrpi', true));
+	_64         = static_cast<P2DPicture*>(screen->search('mypi', true));
+	_68         = static_cast<P2DPicture*>(screen->search('mmpi', true));
+	_80         = static_cast<P2DPicture*>(screen->search('part', true));
+	_6C         = static_cast<P2DPicture*>(screen->search('orim', true));
+	_70         = static_cast<P2DPicture*>(screen->search('mbci', true));
+	_74         = static_cast<P2DPicture*>(screen->search('mrci', true));
+	_78         = static_cast<P2DPicture*>(screen->search('myci', true));
+	_7C         = static_cast<P2DPicture*>(screen->search('mroi', true));
 
 	setOffsetSub(_6C);
 	setOffsetSub(_70);
@@ -358,7 +358,7 @@ void zen::ogRaderMgr::getAllPikiPos()
 	Iterator iterator(pikiMgr);
 	CI_LOOP(iterator)
 	{
-		Piki* piki = (Piki*)*iterator;
+		Piki* piki = static_cast<Piki*>(*iterator);
 		if (piki->isAlive()) {
 			Vector3f pos = ogCalcDispXZ(piki->mSRT.t);
 			data->mColor = piki->mColor;
@@ -373,7 +373,7 @@ void zen::ogRaderMgr::getAllPikiPos()
 	Iterator iterator2(itemMgr->getPikiHeadMgr());
 	CI_LOOP(iterator2)
 	{
-		PikiHeadItem* piki = (PikiHeadItem*)*iterator2;
+		PikiHeadItem* piki = static_cast<PikiHeadItem*>(*iterator2);
 
 		Vector3f pos = ogCalcDispXZ(piki->mSRT.t);
 		data->mColor = -1;

--- a/src/plugPikiOgawa/ogResult.cpp
+++ b/src/plugPikiOgawa/ogResult.cpp
@@ -190,7 +190,7 @@ void zen::ogScrResultMgr::ogScrResultMgrSub()
 {
 	mBlackScreen = new P2DScreen;
 	mBlackScreen->set("screen/blo/black.blo", false, false, true);
-	mBlackPane = (P2DPicture*)mBlackScreen->search('blck', true);
+	mBlackPane = static_cast<P2DPicture*>(mBlackScreen->search('blck', true));
 	mBlackPane->setAlpha(0);
 
 	mMainScreen = new P2DScreen;
@@ -238,7 +238,7 @@ void zen::ogScrResultMgr::ogScrResultMgrSub()
 	}
 	}
 
-	_94 = (P2DTextBox*)mMainScreen->search('getp', true);
+	_94 = static_cast<P2DTextBox*>(mMainScreen->search('getp', true));
 	mPaneRedPikis->hide();
 	mPaneBluePikis->hide();
 	mPaneYellowPikis->hide();

--- a/src/plugPikiOgawa/ogSave.cpp
+++ b/src/plugPikiOgawa/ogSave.cpp
@@ -39,14 +39,14 @@ zen::ogSaveMgr::ogSaveMgr()
 	mScreen->set("screen/blo/ac_save.blo", true, true, true);
 	mStatus = Inactive;
 
-	mHeader0TextBox          = (P2DTextBox*)mScreen->search('he00', true);
-	mHeader1TextBox          = (P2DTextBox*)mScreen->search('he01', true);
+	mHeader0TextBox          = static_cast<P2DTextBox*>(mScreen->search('he00', true));
+	mHeader1TextBox          = static_cast<P2DTextBox*>(mScreen->search('he01', true));
 	mHeaderSub0              = mScreen->search('hs00', true);
 	mHeaderSub1              = mScreen->search('hs01', true);
-	mSaveCenterTextBox       = (P2DTextBox*)mScreen->search('se_c', true);
-	mBackPicture             = (P2DPicture*)mScreen->search('back', true);
-	mSaveActionCenterTextBox = (P2DTextBox*)mScreen->search('sa_c', true);
-	mSaveActionSideTextBox   = (P2DTextBox*)mScreen->search('sa_s', true);
+	mSaveCenterTextBox       = static_cast<P2DTextBox*>(mScreen->search('se_c', true));
+	mBackPicture             = static_cast<P2DPicture*>(mScreen->search('back', true));
+	mSaveActionCenterTextBox = static_cast<P2DTextBox*>(mScreen->search('sa_c', true));
+	mSaveActionSideTextBox   = static_cast<P2DTextBox*>(mScreen->search('sa_s', true));
 	mSaveActionKC            = mScreen->search('sakc', true);
 	mSaveActionKS            = mScreen->search('saks', true);
 
@@ -74,20 +74,20 @@ zen::ogSaveMgr::ogSaveMgr()
 
 	mBlackScreen = new P2DScreen;
 	mBlackScreen->set("screen/blo/black.blo", false, false, true);
-	mBlackPicture = (P2DPicture*)mBlackScreen->search('blck', true);
+	mBlackPicture = static_cast<P2DPicture*>(mBlackScreen->search('blck', true));
 	mBlackPicture->setAlpha(255);
 
 	mSecondaryScreen = new P2DScreen;
 	mSecondaryScreen->set("screen/blo/ac_save2.blo", true, true, true);
-	mSecondaryHeader0TextBox = (P2DTextBox*)mSecondaryScreen->search('he00', true);
-	mSecondaryHeader1TextBox = (P2DTextBox*)mSecondaryScreen->search('he01', true);
+	mSecondaryHeader0TextBox = static_cast<P2DTextBox*>(mSecondaryScreen->search('he00', true));
+	mSecondaryHeader1TextBox = static_cast<P2DTextBox*>(mSecondaryScreen->search('he01', true));
 
 	mWindow2 = mSecondaryScreen->search('2win', true);
 	mWindow2->show();
 	mWindow2->setOffset(mWindow2->getWidth() / 2, mWindow2->getHeight() / 2);
 	mWindow2->setScale(0.0f);
 
-	mSecondaryBackPicture = (P2DPicture*)mSecondaryScreen->search('back', true);
+	mSecondaryBackPicture = static_cast<P2DPicture*>(mSecondaryScreen->search('back', true));
 	mSecondaryBackPicture->setAlpha(0);
 
 	mSecondaryNikatuMgr

--- a/src/plugPikiOgawa/ogSub.cpp
+++ b/src/plugPikiOgawa/ogSub.cpp
@@ -131,8 +131,8 @@ PikaAlphaMgr::PikaAlphaMgr(P2DScreen* screen)
 			continue;
 		}
 
-		P2DPicture* pic  = (P2DPicture*)parent;
-		P2DTextBox* tbox = (P2DTextBox*)pane;
+		P2DPicture* pic  = static_cast<P2DPicture*>(parent);
+		P2DTextBox* tbox = static_cast<P2DTextBox*>(pane);
 		immut char* text = tbox->getString();
 		tbox->hide();
 		getStringCVS(str, text, 0);
@@ -516,13 +516,13 @@ void ogFadeMgr::setAlpha()
 	switch (mPaneType) {
 	case PANETYPE_Picture:
 	{
-		P2DPicture* pic = (P2DPicture*)mPane;
+		P2DPicture* pic = static_cast<P2DPicture*>(mPane);
 		pic->setAlpha(mCurrentAlpha);
 		break;
 	}
 	case PANETYPE_TextBox:
 	{
-		P2DTextBox* tbox = (P2DTextBox*)mPane;
+		P2DTextBox* tbox = static_cast<P2DTextBox*>(mPane);
 		tbox->setAlpha(mCurrentAlpha);
 		break;
 	}
@@ -602,7 +602,7 @@ ogTexAnimSubMgr::ogTexAnimSubMgr(P2DScreen* screen, P2DPicture* pic, P2DTextBox*
 			break;
 		}
 
-		P2DPicture* pane = (P2DPicture*)screen->search(P2DPaneLibrary::makeTag(tmpStr), true);
+		P2DPicture* pane = static_cast<P2DPicture*>(screen->search(P2DPaneLibrary::makeTag(tmpStr), true));
 		if (!pane) {
 			break;
 		}
@@ -664,8 +664,8 @@ ogTexAnimMgr::ogTexAnimMgr(P2DScreen* screen)
 
 		P2DPane* parent = pane->getPaneTree()->getParent()->getObject();
 		if (parent->getTypeID() == PANETYPE_Picture) {
-			P2DPicture* pic  = (P2DPicture*)parent;
-			P2DTextBox* tbox = (P2DTextBox*)pane;
+			P2DPicture* pic  = static_cast<P2DPicture*>(parent);
+			P2DTextBox* tbox = static_cast<P2DTextBox*>(pane);
 			mSubMgrs[i]      = new ogTexAnimSubMgr(screen, pic, tbox);
 			mSubMgrCount++;
 		}
@@ -837,11 +837,11 @@ ogMsgCtrlTagMgr::ogMsgCtrlTagMgr()
 	P2DScreen* screen = new P2DScreen();
 	screen->set("screen/blo/wait_char.blo", false, false, true);
 
-	P2DTextBox* onesBox = (P2DTextBox*)screen->search('maru', true);
-	P2DTextBox* tensBox = (P2DTextBox*)screen->search('ten', true);
+	P2DTextBox* onesBox = static_cast<P2DTextBox*>(screen->search('maru', true));
+	P2DTextBox* tensBox = static_cast<P2DTextBox*>(screen->search('ten', true));
 #if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01)
 #else
-	P2DTextBox* hundredsBox = (P2DTextBox*)screen->search('han', true);
+	P2DTextBox* hundredsBox = static_cast<P2DTextBox*>(screen->search('han', true));
 #endif
 
 	strcpy(mOnesWaitChar, onesBox->getString());

--- a/src/plugPikiOgawa/ogTitle.cpp
+++ b/src/plugPikiOgawa/ogTitle.cpp
@@ -88,12 +88,12 @@ zen::ogScrTitleMgr::ogScrTitleMgr()
 	for (int i = 0; i < 10; i++) {
 		sprintf(path, "on%02d", i + 1);
 		u32 test          = RGBA_TO_U32(path[0], path[1], path[2], path[3]);
-		mBgmVolButtons[i] = (P2DPicture*)mSoundScreen->search(test, true);
+		mBgmVolButtons[i] = static_cast<P2DPicture*>(mSoundScreen->search(test, true));
 	}
 	for (int i = 0; i < 10; i++) {
 		sprintf(path, "on%02d", i + 11);
 		u32 test          = RGBA_TO_U32(path[0], path[1], path[2], path[3]);
-		mSfxVolButtons[i] = (P2DPicture*)mSoundScreen->search(test, true);
+		mSfxVolButtons[i] = static_cast<P2DPicture*>(mSoundScreen->search(test, true));
 	}
 
 	mStatus            = STATUS_Null;

--- a/src/plugPikiOgawa/ogTitle.cpp
+++ b/src/plugPikiOgawa/ogTitle.cpp
@@ -65,12 +65,19 @@ zen::ogScrTitleMgr::ogScrTitleMgr()
 	mInput = new ZenController(nullptr);
 	mInput->setRepeatTime(0.2f);
 
-	static_cast<P2DPicture*>(mMenuNoChallenge->getScreenPtr()->search('back', true))->setAlpha(0);
-	static_cast<P2DPicture*>(mMenuWithChallenge->getScreenPtr()->search('back', true))->setAlpha(0);
-	static_cast<P2DPicture*>(mOptionsMenu->getScreenPtr()->search('back', true))->setAlpha(0);
-	static_cast<P2DPicture*>(mSoundMenu->getScreenPtr()->search('back', true))->setAlpha(0);
-	static_cast<P2DPicture*>(mRumbleMenu->getScreenPtr()->search('back', true))->setAlpha(0);
-	static_cast<P2DPicture*>(mLanguageMenu->getScreenPtr()->search('back', true))->setAlpha(0);
+	P2DPicture* pic;
+	pic = static_cast<P2DPicture*>(mMenuNoChallenge->getScreenPtr()->search('back', true));
+	pic->setAlpha(0);
+	pic = static_cast<P2DPicture*>(mMenuWithChallenge->getScreenPtr()->search('back', true));
+	pic->setAlpha(0);
+	pic = static_cast<P2DPicture*>(mOptionsMenu->getScreenPtr()->search('back', true));
+	pic->setAlpha(0);
+	pic = static_cast<P2DPicture*>(mSoundMenu->getScreenPtr()->search('back', true));
+	pic->setAlpha(0);
+	pic = static_cast<P2DPicture*>(mRumbleMenu->getScreenPtr()->search('back', true));
+	pic->setAlpha(0);
+	pic = static_cast<P2DPicture*>(mLanguageMenu->getScreenPtr()->search('back', true));
+	pic->setAlpha(0);
 
 	mSoundScreen      = mSoundMenu->getScreenPtr();
 	mStereoButton     = static_cast<P2DPicture*>(mSoundScreen->search('on21', true));
@@ -81,20 +88,18 @@ zen::ogScrTitleMgr::ogScrTitleMgr()
 	mAlphaMgr = new setTenmetuAlpha(mStereoButton, 0.5f, 0.0f, 0, 255);
 
 	int i;
-#if !defined(BUGFIX) && defined(VERSION_GPIP01)
-	char path[4]; // You made it undefined behavior?!
+#if defined(VERSION_GPIP01)
+	char path[TERNARY_BUGFIX(8, 4)]; // You made it undefined behavior?!
 #else
-	char path[12];
+	char path[8];
 #endif
 	for (i = 0; i < 10; i++) {
 		sprintf(path, "on%02d", i + 1);
-		u32 test          = RGBA_TO_U32(path[0], path[1], path[2], path[3]);
-		mBgmVolButtons[i] = static_cast<P2DPicture*>(mSoundScreen->search(test, true));
+		mBgmVolButtons[i] = static_cast<P2DPicture*>(mSoundScreen->search(P2DPaneLibrary::makeTag(path), true));
 	}
 	for (i = 0; i < 10; i++) {
 		sprintf(path, "on%02d", i + 11);
-		u32 test          = RGBA_TO_U32(path[0], path[1], path[2], path[3]);
-		mSfxVolButtons[i] = static_cast<P2DPicture*>(mSoundScreen->search(test, true));
+		mSfxVolButtons[i] = static_cast<P2DPicture*>(mSoundScreen->search(P2DPaneLibrary::makeTag(path), true));
 	}
 
 	mStatus            = STATUS_Null;

--- a/src/plugPikiOgawa/ogTitle.cpp
+++ b/src/plugPikiOgawa/ogTitle.cpp
@@ -80,17 +80,18 @@ zen::ogScrTitleMgr::ogScrTitleMgr()
 
 	mAlphaMgr = new setTenmetuAlpha(mStereoButton, 0.5f, 0.0f, 0, 255);
 
+	int i;
 #if !defined(BUGFIX) && defined(VERSION_GPIP01)
 	char path[4]; // You made it undefined behavior?!
 #else
 	char path[12];
 #endif
-	for (int i = 0; i < 10; i++) {
+	for (i = 0; i < 10; i++) {
 		sprintf(path, "on%02d", i + 1);
 		u32 test          = RGBA_TO_U32(path[0], path[1], path[2], path[3]);
 		mBgmVolButtons[i] = static_cast<P2DPicture*>(mSoundScreen->search(test, true));
 	}
-	for (int i = 0; i < 10; i++) {
+	for (i = 0; i < 10; i++) {
 		sprintf(path, "on%02d", i + 11);
 		u32 test          = RGBA_TO_U32(path[0], path[1], path[2], path[3]);
 		mSfxVolButtons[i] = static_cast<P2DPicture*>(mSoundScreen->search(test, true));

--- a/src/plugPikiOgawa/ogTotalScore.cpp
+++ b/src/plugPikiOgawa/ogTotalScore.cpp
@@ -93,7 +93,8 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 
 	for (i = 0; i < 5; i++) {
 		sprintf(buf, "pd%02d", i + 1);
-		mPartDayRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
+		int tag                = P2DPaneLibrary::makeTag(buf);
+		mPartDayRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(tag, true));
 		char* str              = mPartsDaysRecordStrings[i];
 		strcpy(str, mPartDayRecordTexts[i]->getString());
 		cnvSpecialNumber(str);
@@ -102,7 +103,8 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 
 	for (i = 0; i < 5; i++) {
 		sprintf(buf, "lp%02d", i + 1);
-		mBornRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
+		int tag             = P2DPaneLibrary::makeTag(buf);
+		mBornRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(tag, true));
 		char* str           = mBornRecordStrings[i];
 		strcpy(str, mBornRecordTexts[i]->getString());
 		cnvSpecialNumber(str);
@@ -111,7 +113,8 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 
 	for (i = 0; i < 5; i++) {
 		sprintf(buf, "dp%02d", i + 1);
-		mDeadRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
+		int tag             = P2DPaneLibrary::makeTag(buf);
+		mDeadRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(tag, true));
 		char* str           = mDeadRecordStrings[i];
 		strcpy(str, mDeadRecordTexts[i]->getString());
 		cnvSpecialNumber(str);
@@ -141,8 +144,6 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 
 	mFrameTimer = 0.0f;
 	mState      = TOTALSCORE_Sleep;
-
-	STACK_PAD_TERNARY(mDeadRecordTexts, 3);
 }
 
 /**

--- a/src/plugPikiOgawa/ogTotalScore.cpp
+++ b/src/plugPikiOgawa/ogTotalScore.cpp
@@ -88,8 +88,10 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 
 	mNewRecordDefaultPane = static_cast<P2DPicture*>(screen->search('newd', true));
 
+	int i;
 	char buf[8];
-	for (int i = 0; i < 5; i++) {
+
+	for (i = 0; i < 5; i++) {
 		sprintf(buf, "pd%02d", i + 1);
 		mPartDayRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str              = mPartsDaysRecordStrings[i];
@@ -98,7 +100,7 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 		mPartDayRecordTexts[i]->setString(str);
 	}
 
-	for (int i = 0; i < 5; i++) {
+	for (i = 0; i < 5; i++) {
 		sprintf(buf, "lp%02d", i + 1);
 		mBornRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str           = mBornRecordStrings[i];
@@ -107,7 +109,7 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 		mBornRecordTexts[i]->setString(str);
 	}
 
-	for (int i = 0; i < 5; i++) {
+	for (i = 0; i < 5; i++) {
 		sprintf(buf, "dp%02d", i + 1);
 		mDeadRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str           = mDeadRecordStrings[i];

--- a/src/plugPikiOgawa/ogTotalScore.cpp
+++ b/src/plugPikiOgawa/ogTotalScore.cpp
@@ -47,23 +47,23 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 	mDaysEffectPane      = screen->search('win2', true);
 	mBornEffectPane      = screen->search('win3', true);
 	mDeadEffectPane      = screen->search('win4', true);
-	mPartsDigitsTens     = (P2DPicture*)screen->search('pa_l', true);
-	mPartsDigitsOnes     = (P2DPicture*)screen->search('pa_r', true);
-	mDaysDigitsTens      = (P2DPicture*)screen->search('da_l', true);
-	mDaysDigitsOnes      = (P2DPicture*)screen->search('da_r', true);
-	mBornDigitsThousands = (P2DPicture*)screen->search('lp_4', true);
-	mBornDigitsHundreds  = (P2DPicture*)screen->search('lp_3', true);
-	mBornDigitsTens      = (P2DPicture*)screen->search('lp_2', true);
-	mBornDigitsOnes      = (P2DPicture*)screen->search('lp_1', true);
-	mDeadDigitsThousands = (P2DPicture*)screen->search('dp_4', true);
-	mDeadDigitsHundreds  = (P2DPicture*)screen->search('dp_3', true);
-	mDeadDigitsTens      = (P2DPicture*)screen->search('dp_2', true);
-	mDeadDigitsOnes      = (P2DPicture*)screen->search('dp_1', true);
-	mPartsDaysSlash      = (P2DPicture*)screen->search('pd_s', true);
-	mPartsHeading        = (P2DTextBox*)screen->search('pa_k', true);
-	mDaysHeading         = (P2DTextBox*)screen->search('pa_d', true);
-	mBornHeading         = (P2DTextBox*)screen->search('lp_h', true);
-	mDeadHeading         = (P2DTextBox*)screen->search('dp_h', true);
+	mPartsDigitsTens     = static_cast<P2DPicture*>(screen->search('pa_l', true));
+	mPartsDigitsOnes     = static_cast<P2DPicture*>(screen->search('pa_r', true));
+	mDaysDigitsTens      = static_cast<P2DPicture*>(screen->search('da_l', true));
+	mDaysDigitsOnes      = static_cast<P2DPicture*>(screen->search('da_r', true));
+	mBornDigitsThousands = static_cast<P2DPicture*>(screen->search('lp_4', true));
+	mBornDigitsHundreds  = static_cast<P2DPicture*>(screen->search('lp_3', true));
+	mBornDigitsTens      = static_cast<P2DPicture*>(screen->search('lp_2', true));
+	mBornDigitsOnes      = static_cast<P2DPicture*>(screen->search('lp_1', true));
+	mDeadDigitsThousands = static_cast<P2DPicture*>(screen->search('dp_4', true));
+	mDeadDigitsHundreds  = static_cast<P2DPicture*>(screen->search('dp_3', true));
+	mDeadDigitsTens      = static_cast<P2DPicture*>(screen->search('dp_2', true));
+	mDeadDigitsOnes      = static_cast<P2DPicture*>(screen->search('dp_1', true));
+	mPartsDaysSlash      = static_cast<P2DPicture*>(screen->search('pd_s', true));
+	mPartsHeading        = static_cast<P2DTextBox*>(screen->search('pa_k', true));
+	mDaysHeading         = static_cast<P2DTextBox*>(screen->search('pa_d', true));
+	mBornHeading         = static_cast<P2DTextBox*>(screen->search('lp_h', true));
+	mDeadHeading         = static_cast<P2DTextBox*>(screen->search('dp_h', true));
 
 	setSpecialNumber(1, mScores->mRecordNumParts[0]);
 	setSpecialNumber(2, mScores->mRecordNumDays[0]);
@@ -86,12 +86,12 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 	setSpecialNumber(19, mScores->mRecordNumDead[3]);
 	setSpecialNumber(20, mScores->mRecordNumDead[4]);
 
-	mNewRecordDefaultPane = (P2DPicture*)screen->search('newd', true);
+	mNewRecordDefaultPane = static_cast<P2DPicture*>(screen->search('newd', true));
 
 	char buf[8];
 	for (int i = 0; i < 5; i++) {
 		sprintf(buf, "pd%02d", i + 1);
-		mPartDayRecordTexts[i] = (P2DTextBox*)screen->search(P2DPaneLibrary::makeTag(buf), true);
+		mPartDayRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str              = mPartsDaysRecordStrings[i];
 		strcpy(str, mPartDayRecordTexts[i]->getString());
 		cnvSpecialNumber(str);
@@ -100,7 +100,7 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 
 	for (int i = 0; i < 5; i++) {
 		sprintf(buf, "lp%02d", i + 1);
-		mBornRecordTexts[i] = (P2DTextBox*)screen->search(P2DPaneLibrary::makeTag(buf), true);
+		mBornRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str           = mBornRecordStrings[i];
 		strcpy(str, mBornRecordTexts[i]->getString());
 		cnvSpecialNumber(str);
@@ -109,7 +109,7 @@ zen::ogScrTotalScoreMgr::ogScrTotalScoreMgr(zen::TotalScoreType* scores)
 
 	for (int i = 0; i < 5; i++) {
 		sprintf(buf, "dp%02d", i + 1);
-		mDeadRecordTexts[i] = (P2DTextBox*)screen->search(P2DPaneLibrary::makeTag(buf), true);
+		mDeadRecordTexts[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str           = mDeadRecordStrings[i];
 		strcpy(str, mDeadRecordTexts[i]->getString());
 		cnvSpecialNumber(str);

--- a/src/plugPikiYamashita/P2DPicture.cpp
+++ b/src/plugPikiYamashita/P2DPicture.cpp
@@ -444,8 +444,8 @@ void P2DPicture::setTevMode()
 
 	if (!((COLOUR_TO_U32(mBlack) == 0) ? true : false) || !((COLOUR_TO_U32(mWhite) == 0xFFFFFFFF) ? true : false)) {
 		GXSetTevOrder((GXTevStageID)i, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR_NULL);
-		GXSetTevColor(GX_TEVREG0, *(GXColor*)&mBlack);
-		GXSetTevColor(GX_TEVREG1, *(GXColor*)&mWhite);
+		GXSetTevColor(GX_TEVREG0, reinterpret_cast<GXColor&>(mBlack));
+		GXSetTevColor(GX_TEVREG1, reinterpret_cast<GXColor&>(mWhite));
 		GXSetTevColorIn((GXTevStageID)i, GX_CC_C0, GX_CC_C2, GX_CC_CPREV, GX_CC_ZERO);
 		GXSetTevAlphaIn((GXTevStageID)i, GX_CA_A0, GX_CA_A1, GX_CA_APREV, GX_CA_ZERO);
 		GXSetTevColorOp((GXTevStageID)i, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);

--- a/src/plugPikiYamashita/P2DPicture.cpp
+++ b/src/plugPikiYamashita/P2DPicture.cpp
@@ -354,6 +354,7 @@ void P2DPicture::drawTexCoord(int x, int y, int width, int height, f32 uBL, f32 
 	int xEnd = x + width;
 	int yEnd = y + height;
 
+#if PIKI_USE_DGX
 	GXClearVtxDesc();
 	GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
 	GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
@@ -395,6 +396,7 @@ void P2DPicture::drawTexCoord(int x, int y, int width, int height, f32 uBL, f32 
 	GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_POS_XYZ, GX_U16, 15);
 
 	GXEnd();
+#endif
 }
 
 /**
@@ -402,6 +404,7 @@ void P2DPicture::drawTexCoord(int x, int y, int width, int height, f32 uBL, f32 
  */
 void P2DPicture::setTevMode()
 {
+#if PIKI_USE_DGX
 	GXColor color;
 	for (int i = 0; i < mTextureCount; i++) {
 		GXSetTexCoordGen2((GXTexCoordID)i, GX_TG_MTX3X4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
@@ -464,6 +467,7 @@ void P2DPicture::setTevMode()
 
 	GXSetNumTevStages(i);
 	GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_SET);
+#endif
 }
 
 /**

--- a/src/plugPikiYamashita/drawCMscore.cpp
+++ b/src/plugPikiYamashita/drawCMscore.cpp
@@ -57,21 +57,21 @@ public:
 		P2DPane* pane = screen->search(P2DPaneLibrary::makeTag(buf), true);
 		pane->setCallBack(new NumberPicCallBack<int>(pane, &mScore, 100, false));
 		if (pane->getTypeID() == PANETYPE_Picture) {
-			mScoreDigitHundreds = (P2DPicture*)pane;
+			mScoreDigitHundreds = static_cast<P2DPicture*>(pane);
 		}
 
 		sprintf(buf, "%di_c", p2);
 		pane = screen->search(P2DPaneLibrary::makeTag(buf), true);
 		pane->setCallBack(new NumberPicCallBack<int>(pane, &mScore, 10, false));
 		if (pane->getTypeID() == PANETYPE_Picture) {
-			mScoreDigitTens = (P2DPicture*)pane;
+			mScoreDigitTens = static_cast<P2DPicture*>(pane);
 		}
 
 		sprintf(buf, "%di_r", p2);
 		pane = screen->search(P2DPaneLibrary::makeTag(buf), true);
 		pane->setCallBack(new NumberPicCallBack<int>(pane, &mScore, 1, false));
 		if (pane->getTypeID() == PANETYPE_Picture) {
-			mScoreDigitOnes = (P2DPicture*)pane;
+			mScoreDigitOnes = static_cast<P2DPicture*>(pane);
 		}
 		mMode         = MODE_Wait;
 		mModeFunction = &DrawCMscoreObj::modeWait;

--- a/src/plugPikiYamashita/drawCommon.cpp
+++ b/src/plugPikiYamashita/drawCommon.cpp
@@ -145,7 +145,7 @@ void zen::P2DPaneLibrary::setMirror(P2DPane* pane, P2DMirror mirror)
 	}
 	case PANETYPE_Picture:
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		pic->setMirror(mirror);
 		break;
 	}
@@ -273,9 +273,9 @@ void zen::P2DPaneLibrary::printUseTexName(P2DPane* pane, IDelegate1<immut char*>
 	while (iter != pane->getPaneTree()->getEndChild()) {
 		u16 type = iter->getTypeID();
 		if (type == PANETYPE_Window) {
-			P2DWindow* window = (P2DWindow*)iter.getObject();
+			P2DWindow* window = static_cast<P2DWindow*>(iter.getObject());
 		} else if (type == PANETYPE_Picture) {
-			P2DPicture* pic = (P2DPicture*)iter.getObject();
+			P2DPicture* pic = static_cast<P2DPicture*>(iter.getObject());
 			delegate->invoke(pic->getTexName());
 		}
 		printUseTexName(iter.getObject(), delegate);

--- a/src/plugPikiYamashita/drawContainer.cpp
+++ b/src/plugPikiYamashita/drawContainer.cpp
@@ -58,7 +58,7 @@ zen::DrawContainer::DrawContainer()
 #endif
 	mMessageMgr    = new MessageMgr(mScreen);
 	mWindowPaneMgr = new WindowPaneMgr(mScreen.search('pall', true));
-	mMarkerPicture = (P2DPicture*)mScreen.search('maru', true);
+	mMarkerPicture = static_cast<P2DPicture*>(mScreen.search('maru', true));
 	mMarkerPicture->show();
 	mMarkerPicture->setAlpha(0);
 	mMarkerPicture->setScale(3.0f);
@@ -170,15 +170,15 @@ void zen::DrawContainer::start(zen::DrawContainer::containerType color, int p2, 
 		mWindowPaneMgr->init();
 		mMessageMgr->init(mColor);
 
-		P2DWindow* pane = (P2DWindow*)mScreen.search('p264', true);
+		P2DWindow* pane = static_cast<P2DWindow*>(mScreen.search('p264', true));
 		pane->setTexture(mPikminTextures[mColor]);
-		P2DPicture* pic = (P2DPicture*)mScreen.search('ws8c', true);
+		P2DPicture* pic = static_cast<P2DPicture*>(mScreen.search('ws8c', true));
 		pic->setTexture(mWindowTextures[mColor], 0);
-		pic = (P2DPicture*)mScreen.search('p2c4', true);
+		pic = static_cast<P2DPicture*>(mScreen.search('p2c4', true));
 		pic->setTexture(mContainerTextures[mColor], 0);
-		pic = (P2DPicture*)mScreen.search('ws8u', true);
+		pic = static_cast<P2DPicture*>(mScreen.search('ws8u', true));
 		pic->setTexture(mWindowTextures[mColor], 0);
-		pic = (P2DPicture*)mScreen.search('ws8l', true);
+		pic = static_cast<P2DPicture*>(mScreen.search('ws8l', true));
 		pic->setTexture(mWindowTextures[mColor], 0);
 		SeSystem::playSysSe(SYSSE_CMENU_ON);
 	}

--- a/src/plugPikiYamashita/drawCountDown.cpp
+++ b/src/plugPikiYamashita/drawCountDown.cpp
@@ -38,7 +38,7 @@ zen::DrawCountDown::DrawCountDown()
 			PRINT("not picture pane.\n");
 			ERROR("not picture pane.\n");
 		} else {
-			mNumberPics[i] = (P2DPicture*)pane;
+			mNumberPics[i] = static_cast<P2DPicture*>(pane);
 			mNumberPics[i]->setAlpha(0);
 			mNumberPics[i]->hide();
 			mNumberPics[i]->setOffset(mNumberPics[i]->getWidth() >> 1, mNumberPics[i]->getHeight() >> 1);
@@ -50,7 +50,7 @@ zen::DrawCountDown::DrawCountDown()
 		PRINT("not picture pane.\n");
 		ERROR("not picture pane.\n");
 	} else {
-		mGatherYourPikminPane = (P2DPicture*)pane;
+		mGatherYourPikminPane = static_cast<P2DPicture*>(pane);
 		mGatherYourPikminPane->hide();
 	}
 

--- a/src/plugPikiYamashita/drawFinalResult.cpp
+++ b/src/plugPikiYamashita/drawFinalResult.cpp
@@ -40,23 +40,23 @@ zen::DrawTotalScore::DrawTotalScore(zen::TotalScoreRecord* record)
 		_14[i] = screen->search(P2DPaneLibrary::makeTag(buf), true);
 	}
 
-	mPartsNumLeft         = (P2DPicture*)screen->search('pa_l', true);
-	mPartsNumRight        = (P2DPicture*)screen->search('pa_r', true);
-	mDaysNumLeft          = (P2DPicture*)screen->search('da_l', true);
-	mDaysNumRight         = (P2DPicture*)screen->search('da_r', true);
-	mLivingPikisThousands = (P2DPicture*)screen->search('lp_4', true);
-	mLivingPikisHundreds  = (P2DPicture*)screen->search('lp_3', true);
-	mLivingPikisTens      = (P2DPicture*)screen->search('lp_2', true);
-	mLivingPikisOnes      = (P2DPicture*)screen->search('lp_1', true);
-	mDeadPikisThousands   = (P2DPicture*)screen->search('dp_4', true);
-	mDeadPikisHundreds    = (P2DPicture*)screen->search('dp_3', true);
-	mDeadPikisTens        = (P2DPicture*)screen->search('dp_2', true);
-	mDeadPikisOnes        = (P2DPicture*)screen->search('dp_1', true);
-	_B0                   = (P2DPicture*)screen->search('pd_s', true);
-	_B4                   = (P2DTextBox*)screen->search('pa_k', true);
-	_B8                   = (P2DTextBox*)screen->search('pa_d', true);
-	_BC                   = (P2DTextBox*)screen->search('lp_h', true);
-	_C0                   = (P2DTextBox*)screen->search('dp_h', true);
+	mPartsNumLeft         = static_cast<P2DPicture*>(screen->search('pa_l', true));
+	mPartsNumRight        = static_cast<P2DPicture*>(screen->search('pa_r', true));
+	mDaysNumLeft          = static_cast<P2DPicture*>(screen->search('da_l', true));
+	mDaysNumRight         = static_cast<P2DPicture*>(screen->search('da_r', true));
+	mLivingPikisThousands = static_cast<P2DPicture*>(screen->search('lp_4', true));
+	mLivingPikisHundreds  = static_cast<P2DPicture*>(screen->search('lp_3', true));
+	mLivingPikisTens      = static_cast<P2DPicture*>(screen->search('lp_2', true));
+	mLivingPikisOnes      = static_cast<P2DPicture*>(screen->search('lp_1', true));
+	mDeadPikisThousands   = static_cast<P2DPicture*>(screen->search('dp_4', true));
+	mDeadPikisHundreds    = static_cast<P2DPicture*>(screen->search('dp_3', true));
+	mDeadPikisTens        = static_cast<P2DPicture*>(screen->search('dp_2', true));
+	mDeadPikisOnes        = static_cast<P2DPicture*>(screen->search('dp_1', true));
+	_B0                   = static_cast<P2DPicture*>(screen->search('pd_s', true));
+	_B4                   = static_cast<P2DTextBox*>(screen->search('pa_k', true));
+	_B8                   = static_cast<P2DTextBox*>(screen->search('pa_d', true));
+	_BC                   = static_cast<P2DTextBox*>(screen->search('lp_h', true));
+	_C0                   = static_cast<P2DTextBox*>(screen->search('dp_h', true));
 
 	setSpecialNumber(1, mTotalScoreRecord->mRecordNumParts[0]);
 	setSpecialNumber(2, mTotalScoreRecord->mRecordNumDays[0]);
@@ -81,7 +81,7 @@ zen::DrawTotalScore::DrawTotalScore(zen::TotalScoreRecord* record)
 
 	for (i = 0; i < 5; i++) {
 		sprintf(buf, "pd%02d", i + 1);
-		mPartsDaysRecordPanes[i] = (P2DTextBox*)screen->search(P2DPaneLibrary::makeTag(buf), true);
+		mPartsDaysRecordPanes[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str                = mPartsDaysRecordTexts[i];
 		strcpy(str, mPartsDaysRecordPanes[i]->getString());
 		cnvSpecialNumberHyphen(str);
@@ -89,7 +89,7 @@ zen::DrawTotalScore::DrawTotalScore(zen::TotalScoreRecord* record)
 	}
 	for (i = 0; i < 5; i++) {
 		sprintf(buf, "lp%02d", i + 1);
-		mLivingPikiRecordPanes[i] = (P2DTextBox*)screen->search(P2DPaneLibrary::makeTag(buf), true);
+		mLivingPikiRecordPanes[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str                 = mLivingPikiRecordTexts[i];
 		strcpy(str, mLivingPikiRecordPanes[i]->getString());
 		cnvSpecialNumberHyphen(str);
@@ -97,7 +97,7 @@ zen::DrawTotalScore::DrawTotalScore(zen::TotalScoreRecord* record)
 	}
 	for (i = 0; i < 5; i++) {
 		sprintf(buf, "dp%02d", i + 1);
-		mDeadPikiRecordPanes[i] = (P2DTextBox*)screen->search(P2DPaneLibrary::makeTag(buf), true);
+		mDeadPikiRecordPanes[i] = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		char* str               = mDeadPikiRecordTexts[i];
 		strcpy(str, mDeadPikiRecordPanes[i]->getString());
 		cnvSpecialNumberHyphen(str);
@@ -125,7 +125,7 @@ zen::DrawTotalScore::DrawTotalScore(zen::TotalScoreRecord* record)
 	setNumberTag(screen, 'tp_2', &mTotalScoreRecord->mTotalPikis, 10);
 	setNumberTag(screen, 'tp_1', &mTotalScoreRecord->mTotalPikis, 1);
 
-	_7C          = (P2DPicture*)screen->search('newd', true);
+	_7C          = static_cast<P2DPicture*>(screen->search('newd', true));
 	mEffectMgr2D = new EffectMgr2D(0x10, 0x40, 0x40);
 	mBest.init(screen);
 	mBest.sleep();

--- a/src/plugPikiYamashita/drawGameInfo.cpp
+++ b/src/plugPikiYamashita/drawGameInfo.cpp
@@ -48,7 +48,7 @@ struct PikiIconCallBack : public P2DPaneCallBack {
 	PikiIconCallBack(P2DPane* pane)
 	    : P2DPaneCallBack(pane, PANETYPE_Picture)
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		mFrameTimer     = frameMax;
 		for (int i = 0; i < 19; i++) {
 			Texture* tex     = zen::loadTexExp(pikiTexNametable[i], true, true);
@@ -111,12 +111,12 @@ struct DateCallBack : public P2DPaneCallBack, public zen::NumberTex {
 		checkPaneType(slPane, PANETYPE_Picture);
 		checkPaneType(srPane, PANETYPE_Picture);
 
-		mCentreDigit       = (P2DPicture*)cPane;
-		mLeftDigit         = (P2DPicture*)lPane;
-		mRightDigit        = (P2DPicture*)rPane;
-		mCentreDigitShadow = (P2DPicture*)scPane;
-		mLeftDigitShadow   = (P2DPicture*)slPane;
-		mRightDigitShadow  = (P2DPicture*)srPane;
+		mCentreDigit       = static_cast<P2DPicture*>(cPane);
+		mLeftDigit         = static_cast<P2DPicture*>(lPane);
+		mRightDigit        = static_cast<P2DPicture*>(rPane);
+		mCentreDigitShadow = static_cast<P2DPicture*>(scPane);
+		mLeftDigitShadow   = static_cast<P2DPicture*>(slPane);
+		mRightDigitShadow  = static_cast<P2DPicture*>(srPane);
 
 		setTex();
 	}
@@ -174,7 +174,7 @@ struct LifePinchCallBack : public P2DPaneCallBack {
 	LifePinchCallBack(P2DPane* pane)
 	    : P2DPaneCallBack(pane, PANETYPE_Picture)
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		_04 = _08 = 0.0f;
 		_10       = false;
 		_0C       = 0;
@@ -184,7 +184,7 @@ struct LifePinchCallBack : public P2DPaneCallBack {
 
 	virtual bool invoke(P2DPane* pane) // _08
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		Navi* navi      = nullptr;
 		f32 healthRatio = 0.0f;
 		if (naviMgr) {
@@ -273,7 +273,7 @@ struct NaviTexCallBack : public P2DPaneCallBack {
 
 	virtual bool invoke(P2DPane* pane) // _08
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		if (naviMgr) {
 			Navi* navi = naviMgr->getNavi(0);
 			if (navi->mHealth == 0.0f) {
@@ -395,7 +395,7 @@ struct MoonIconCallBack : public P2DPaneCallBack, public SunMove {
 
 	virtual bool invoke(P2DPane* pane) // _08
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		if (gameflow.mWorldClock.mTimeOfDay >= 7.0f && gameflow.mWorldClock.mTimeOfDay <= 19.0f) {
 			pic->hide();
 		} else {
@@ -439,7 +439,7 @@ struct SunAnim {
 	// DLL inlines to do:
 	void anim(P2DPane* pane)
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		if (gameflow.mWorldClock.mTimeOfDay >= 7.0f && gameflow.mWorldClock.mTimeOfDay <= 19.0f) {
 			pic->show();
 			if (!gameflow.mIsUIOverlayActive) {
@@ -521,7 +521,7 @@ struct SunCapsuleCallBack : public P2DPaneCallBack {
 
 	virtual bool invoke(P2DPane* pane) // _08
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		_04 += 2047;
 		pic->setAlpha(zen::RoundOff(sinShort(_04) * 27.5f + 227.5f));
 		return true;
@@ -567,7 +567,7 @@ struct MapPikminWindowCallBack : public P2DPaneCallBack {
 
 	virtual bool invoke(P2DPane* pane) // _08
 	{
-		P2DPicture* pic = (P2DPicture*)pane;
+		P2DPicture* pic = static_cast<P2DPicture*>(pane);
 		_08 += gsys->getFrameTime();
 		if (_08 > 2.0f) {
 			_08 -= 2.0f;

--- a/src/plugPikiYamashita/drawGameOver.cpp
+++ b/src/plugPikiYamashita/drawGameOver.cpp
@@ -58,7 +58,7 @@ public:
 			PRINT("not picture pane.\n");
 			ERROR("not picture pane.\n");
 		} else {
-			mLetterPic = (P2DPicture*)pane;
+			mLetterPic = static_cast<P2DPicture*>(pane);
 			mTargetX   = mLetterPic->getPosH();
 			mTargetY   = mLetterPic->getPosV();
 			initParams();

--- a/src/plugPikiYamashita/drawHurryUp.cpp
+++ b/src/plugPikiYamashita/drawHurryUp.cpp
@@ -36,12 +36,12 @@ zen::DrawHurryUp::DrawHurryUp()
 	mRootScale         = 0.75f;
 	_10C               = 1;
 	mRootPane          = mScreen.search('root', true);
-	mMovingHurryUpPane = (P2DPicture*)mScreen.search('hurr', true);
-	mMovingSundownPane = (P2DPicture*)mScreen.search('sund', true);
-	mFixedHurryUpPane  = (P2DPicture*)mScreen.search('hur2', true);
-	mFixedSundownPane  = (P2DPicture*)mScreen.search('sun2', true);
-	mMsgHaloPane       = (P2DPicture*)mScreen.search('sunl', true);
-	mMsgFillPane       = (P2DPicture*)mScreen.search('sunw', true);
+	mMovingHurryUpPane = static_cast<P2DPicture*>(mScreen.search('hurr', true));
+	mMovingSundownPane = static_cast<P2DPicture*>(mScreen.search('sund', true));
+	mFixedHurryUpPane  = static_cast<P2DPicture*>(mScreen.search('hur2', true));
+	mFixedSundownPane  = static_cast<P2DPicture*>(mScreen.search('sun2', true));
+	mMsgHaloPane       = static_cast<P2DPicture*>(mScreen.search('sunl', true));
+	mMsgFillPane       = static_cast<P2DPicture*>(mScreen.search('sunw', true));
 
 	mHurryUpDefaultPos.set(mMovingHurryUpPane->getPosH(), mMovingHurryUpPane->getPosV(), 0.0f);
 	mSundownDefaultPos.set(mMovingSundownPane->getPosH(), mMovingSundownPane->getPosV(), 0.0f);

--- a/src/plugPikiYamashita/drawMenu.cpp
+++ b/src/plugPikiYamashita/drawMenu.cpp
@@ -52,7 +52,7 @@ void zen::DrawMenuText::init(bool useNewColors, immut Colour& charColor, immut C
 void zen::DrawMenuText::setPane(P2DPane* textPane, P2DPane* parentPane)
 {
 	if (textPane->getTypeID() == PANETYPE_TextBox) {
-		mTextPane  = (P2DTextBox*)textPane;
+		mTextPane  = static_cast<P2DTextBox*>(textPane);
 		mCharColor = mTextPane->getCharColor();
 		mGradColor = mTextPane->getGradColor();
 		mTextPane->setOffset(mTextPane->getWidth() >> 1, mTextPane->getHeight() >> 1);
@@ -62,7 +62,7 @@ void zen::DrawMenuText::setPane(P2DPane* textPane, P2DPane* parentPane)
 
 	if (parentPane) {
 		if (parentPane->getTypeID() == PANETYPE_TextBox) {
-			mParentPane = (P2DTextBox*)parentPane;
+			mParentPane = static_cast<P2DTextBox*>(parentPane);
 			mParentPane->setOffset(mParentPane->getWidth() >> 1, mParentPane->getHeight() >> 1);
 		} else {
 			ERROR("This pane is not Text Box.\n");
@@ -253,7 +253,7 @@ zen::DrawMenu::DrawMenu(immut char* bloFileName, bool useAlphaMgr, bool useTexAn
 	P2DPane* pane;
 	P2DPane* paneAlso = mScreen.search('se_c', true);
 	if (paneAlso->getTypeID() == PANETYPE_TextBox) {
-		P2DTextBox* tBox = (P2DTextBox*)paneAlso;
+		P2DTextBox* tBox = static_cast<P2DTextBox*>(paneAlso);
 		tBox->getFontColor(mCharColor, mGradColor);
 	} else {
 		ERROR("tag<se_c> pane is not text box.\n");
@@ -319,7 +319,7 @@ zen::DrawMenu::DrawMenu(immut char* bloFileName, bool useAlphaMgr, bool useTexAn
 		sprintf(buf, "z%02dl", i);
 		pane = mScreen.search(P2DPaneLibrary::makeTag(buf), true);
 		if (pane->getTypeID() == PANETYPE_Picture) {
-			mLeftCursorIcons[i] = (P2DPicture*)pane;
+			mLeftCursorIcons[i] = static_cast<P2DPicture*>(pane);
 			P2DPaneLibrary::changeParent(mLeftCursorIcons[i], mParentPane);
 			mLeftCursorIcons[i]->move(mMenuItems[mCurrentSelect].getIconLPosH() - 640, mMenuItems[mCurrentSelect].getIconLPosV());
 			mLeftCursorIcons[i]->show();
@@ -335,7 +335,7 @@ zen::DrawMenu::DrawMenu(immut char* bloFileName, bool useAlphaMgr, bool useTexAn
 		sprintf(buf, "z%02dr", i);
 		pane = mScreen.search(P2DPaneLibrary::makeTag(buf), true);
 		if (pane->getTypeID() == PANETYPE_Picture) {
-			mRightCursorIcons[i] = (P2DPicture*)pane;
+			mRightCursorIcons[i] = static_cast<P2DPicture*>(pane);
 			P2DPaneLibrary::changeParent(mRightCursorIcons[i], mParentPane);
 			mRightCursorIcons[i]->move(mMenuItems[mCurrentSelect].getIconRPosH() + 640, mMenuItems[mCurrentSelect].getIconRPosV());
 			mRightCursorIcons[i]->show();

--- a/src/plugPikiYamashita/drawMenuBase.cpp
+++ b/src/plugPikiYamashita/drawMenuBase.cpp
@@ -27,7 +27,7 @@ zen::DrawMenuBase::DrawMenuBase(immut char* bloFileName, bool useAlphaMgr, bool 
 
 	P2DPane* pane = mScreen.search('se_c', true);
 	if (pane->getTypeID() == PANETYPE_TextBox) {
-		P2DTextBox* tBox = (P2DTextBox*)pane;
+		P2DTextBox* tBox = static_cast<P2DTextBox*>(pane);
 		tBox->getFontColor(mCharColor, mGradColor);
 	} else {
 		ERROR("tag<se_c> pane is not text box.\n");

--- a/src/plugPikiYamashita/drawSaveFailure.cpp
+++ b/src/plugPikiYamashita/drawSaveFailure.cpp
@@ -27,7 +27,7 @@ zen::DrawSaveFailure::DrawSaveFailure()
 	P2DScreen* screen = mSaveFailScreen->getScreenPtr();
 	mSaveFailPane     = screen->search('saxx', true);
 	mSaveFailPane->setOffset(mSaveFailPane->getWidth() >> 1, mSaveFailPane->getHeight() >> 1);
-	mBackIcon = (P2DPicture*)screen->search('back', true);
+	mBackIcon = static_cast<P2DPicture*>(screen->search('back', true));
 	setMode(MODE_Unk0);
 }
 

--- a/src/plugPikiYamashita/drawSaveMes.cpp
+++ b/src/plugPikiYamashita/drawSaveMes.cpp
@@ -31,13 +31,13 @@ zen::DrawSaveMes::DrawSaveMes()
 	P2DScreen* screen = _08->getScreenPtr();
 	screen->setScale(0.0f);
 	screen->setOffset(screen->getWidth() >> 1, screen->getHeight() >> 1);
-	_18 = (P2DTextBox*)screen->search('savk', true);
-	_1C = (P2DTextBox*)screen->search('save', true);
-	_20 = (P2DTextBox*)screen->search('sakc', true);
-	_24 = (P2DTextBox*)screen->search('sa_c', true);
-	_28 = (P2DTextBox*)screen->search('saks', true);
-	_2C = (P2DTextBox*)screen->search('sa_s', true);
-	_30 = (P2DPicture*)screen->search('abtn', true);
+	_18 = static_cast<P2DTextBox*>(screen->search('savk', true));
+	_1C = static_cast<P2DTextBox*>(screen->search('save', true));
+	_20 = static_cast<P2DTextBox*>(screen->search('sakc', true));
+	_24 = static_cast<P2DTextBox*>(screen->search('sa_c', true));
+	_28 = static_cast<P2DTextBox*>(screen->search('saks', true));
+	_2C = static_cast<P2DTextBox*>(screen->search('sa_s', true));
+	_30 = static_cast<P2DPicture*>(screen->search('abtn', true));
 
 	_18->show();
 	_1C->show();
@@ -48,10 +48,10 @@ zen::DrawSaveMes::DrawSaveMes()
 
 	screen = _0C->getScreenPtr();
 	screen->setOffset(screen->getWidth() >> 1, screen->getHeight() >> 1);
-	mBackIcon = (P2DPicture*)screen->search('back', true);
+	mBackIcon = static_cast<P2DPicture*>(screen->search('back', true));
 	mBackIcon->show();
 	mBackIcon->setAlpha(0);
-	_14 = (P2DPicture*)screen->search('chui', true);
+	_14 = static_cast<P2DPicture*>(screen->search('chui', true));
 	_14->setOffset(_14->getWidth() >> 1, _14->getHeight() >> 1);
 	_04 = 0.0f;
 

--- a/src/plugPikiYamashita/drawUfoParts.cpp
+++ b/src/plugPikiYamashita/drawUfoParts.cpp
@@ -157,9 +157,9 @@ void zen::DrawUfoParts::dataSet()
 	P2DScreen* screen = mScreen->getScreenPtr();
 	for (i = 0; i < MAX_UFO_PARTS; i++) {
 		sprintf(buf, "ui%02d", i + 1);
-		P2DPicture* partIcon = (P2DPicture*)screen->search(P2DPaneLibrary::makeTag(buf), true);
+		P2DPicture* partIcon = static_cast<P2DPicture*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 		sprintf(buf, "un%02d", i + 1);
-		P2DTextBox* partLabel = (P2DTextBox*)screen->search(P2DPaneLibrary::makeTag(buf), true);
+		P2DTextBox* partLabel = static_cast<P2DTextBox*>(screen->search(P2DPaneLibrary::makeTag(buf), true));
 
 		if (playerState) {
 			if (!playerState->hasUfoParts(PelletMgr::getUfoIDFromIndex(i))) {

--- a/src/plugPikiYamashita/drawWMPause.cpp
+++ b/src/plugPikiYamashita/drawWMPause.cpp
@@ -26,7 +26,7 @@ zen::DrawWMPause::DrawWMPause()
 	mPauseMenu = new DrawMenu("screen/blo/pause_w.blo", false, false);
 	mPauseMenu->setCancelSelectMenuNo(0);
 	P2DScreen* pause = mPauseMenu->getScreenPtr();
-	mBackPane        = (P2DPicture*)pause->search('back', true);
+	mBackPane        = static_cast<P2DPicture*>(pause->search('back', true));
 	mBackPane->setAlpha(0);
 	mReturnFlag = RETURN_NULL;
 }

--- a/src/plugPikiYamashita/drawWorldMap.cpp
+++ b/src/plugPikiYamashita/drawWorldMap.cpp
@@ -142,9 +142,9 @@ public:
 		checkPaneType(leftPane, PANETYPE_Picture);
 		checkPaneType(rightPane, PANETYPE_Picture);
 
-		mCentrePane = (P2DPicture*)centrePane;
-		mLeftPane   = (P2DPicture*)leftPane;
-		mRightPane  = (P2DPicture*)rightPane;
+		mCentrePane = static_cast<P2DPicture*>(centrePane);
+		mLeftPane   = static_cast<P2DPicture*>(leftPane);
+		mRightPane  = static_cast<P2DPicture*>(rightPane);
 
 		setTex();
 	}
@@ -386,7 +386,7 @@ public:
 	{
 		P2DPane* icon = iconScreen->search(tag, true);
 		if (icon->getTypeID() == PANETYPE_Picture) {
-			mOnyonIcon = (P2DPicture*)icon;
+			mOnyonIcon = static_cast<P2DPicture*>(icon);
 			if (hideIcon) {
 				mOnyonIcon->hide();
 			}
@@ -509,7 +509,7 @@ public:
 	{
 		P2DPane* rocket = iconScreen->search('ri', true);
 		if (rocket->getTypeID() == PANETYPE_Picture) {
-			mRocketIcon = (P2DPicture*)rocket;
+			mRocketIcon = static_cast<P2DPicture*>(rocket);
 		}
 
 		mCursorOnyons[Blue].init(iconScreen, 'ci_b', false);
@@ -1066,7 +1066,7 @@ public:
 			sprintf(partStr, "pn%02d", i);
 			P2DPane* pane = dataScreen->search(P2DPaneLibrary::makeTag(partStr), true);
 			if (pane->getTypeID() == PANETYPE_Picture) {
-				mFadedStarIcons[i] = (P2DPicture*)pane;
+				mFadedStarIcons[i] = static_cast<P2DPicture*>(pane);
 				mFadedStarIcons[i]->show();
 				pane = P2DPaneLibrary::getParentPane(mFadedStarIcons[i]);
 				P2DPaneLibrary::changeParent(mFadedStarIcons[i], pane);
@@ -1078,7 +1078,7 @@ public:
 			sprintf(partStr, "pa%02d", i);
 			pane = dataScreen->search(P2DPaneLibrary::makeTag(partStr), true);
 			if (pane->getTypeID() == PANETYPE_Picture) {
-				mGlowingStarIcons[i] = (P2DPicture*)pane;
+				mGlowingStarIcons[i] = static_cast<P2DPicture*>(pane);
 				mGlowingStarIcons[i]->show();
 				pane = P2DPaneLibrary::getParentPane(mGlowingStarIcons[i]);
 				P2DPaneLibrary::changeParent(mGlowingStarIcons[i], pane);
@@ -1349,7 +1349,7 @@ public:
 	{
 		P2DPane* pane = wipeScreen->search(tag, true);
 		if (pane->getTypeID() == PANETYPE_Picture) {
-			mWipePane = (P2DPicture*)pane;
+			mWipePane = static_cast<P2DPicture*>(pane);
 			mDefaultPos.set(mWipePane->getPosH() + (mWipePane->getWidth() >> 1), mWipePane->getPosV() + (mWipePane->getHeight() >> 1),
 			                0.0f);
 			move(mWipePane->getPosH(), mWipePane->getPosV());
@@ -1580,17 +1580,17 @@ public:
 	{
 		P2DPane* pointPane1 = pointScreen->search(tag1, true);
 		if (pointPane1->getTypeID() == PANETYPE_Picture) {
-			mUnselectedPic = (P2DPicture*)pointPane1;
+			mUnselectedPic = static_cast<P2DPicture*>(pointPane1);
 			mUnselectedPic->setOffset(mUnselectedPic->getWidth() >> 1, mUnselectedPic->getHeight());
 		}
 		P2DPane* pointPane2 = pointScreen->search(tag2, true);
 		if (pointPane2->getTypeID() == PANETYPE_Picture) {
-			mSelectedPic = (P2DPicture*)pointPane2;
+			mSelectedPic = static_cast<P2DPicture*>(pointPane2);
 			mSelectedPic->setOffset(mSelectedPic->getWidth() >> 1, mSelectedPic->getHeight());
 		}
 		P2DPane* pointPane3 = pointScreen->search(tag3, true);
 		if (pointPane3->getTypeID() == PANETYPE_Picture) {
-			mOpenedPic = (P2DPicture*)pointPane3;
+			mOpenedPic = static_cast<P2DPicture*>(pointPane3);
 			mOpenedPic->setOffset(mSelectedPic->getWidth() >> 1, mSelectedPic->getHeight());
 			mOpenedPic->hide();
 		}
@@ -2029,23 +2029,23 @@ public:
 	{
 		P2DPane* pane1 = moniScreen->search('mi_1', true);
 		if (pane1->getTypeID() == PANETYPE_Picture) {
-			mMapImagePanes[0] = (P2DPicture*)pane1;
+			mMapImagePanes[0] = static_cast<P2DPicture*>(pane1);
 		}
 		P2DPane* pane2 = moniScreen->search('mi_2', true);
 		if (pane2->getTypeID() == PANETYPE_Picture) {
-			mMapImagePanes[1] = (P2DPicture*)pane2;
+			mMapImagePanes[1] = static_cast<P2DPicture*>(pane2);
 		}
 		P2DPane* pane3 = moniScreen->search('mi_3', true);
 		if (pane3->getTypeID() == PANETYPE_Picture) {
-			mMapImagePanes[2] = (P2DPicture*)pane3;
+			mMapImagePanes[2] = static_cast<P2DPicture*>(pane3);
 		}
 		P2DPane* pane4 = moniScreen->search('mi_4', true);
 		if (pane4->getTypeID() == PANETYPE_Picture) {
-			mMapImagePanes[3] = (P2DPicture*)pane4;
+			mMapImagePanes[3] = static_cast<P2DPicture*>(pane4);
 		}
 		P2DPane* pane5 = moniScreen->search('mi_5', true);
 		if (pane5->getTypeID() == PANETYPE_Picture) {
-			mMapImagePanes[4] = (P2DPicture*)pane5;
+			mMapImagePanes[4] = static_cast<P2DPicture*>(pane5);
 		}
 
 		init();

--- a/src/sysCommon/camera.cpp
+++ b/src/sysCommon/camera.cpp
@@ -249,11 +249,11 @@ void CullFrustum::createViewPlanes()
 void CullFrustum::additionalPlanes(CullFrustum* other)
 {
 	if (other) {
-		for (int i = 0; i < other->mTotalPlaneCount; ++i) {
-			mPlanePointers[i] = other->mPlanePointers[i];
+		for (int i1 = 0; i1 < other->mTotalPlaneCount; ++i1) {
+			mPlanePointers[i1] = other->mPlanePointers[i1];
 		}
-		for (int i = 0; i < mTotalPlaneCount; ++i) {
-			mPlanePointers[i + other->mTotalPlaneCount] = &mCullPlanes[i];
+		for (int i2 = 0; i2 < mTotalPlaneCount; ++i2) {
+			mPlanePointers[i2 + other->mTotalPlaneCount] = &mCullPlanes[i2];
 		}
 		mActivePlaneCount = mTotalPlaneCount + other->mTotalPlaneCount;
 	} else {

--- a/src/sysCommon/graphics.cpp
+++ b/src/sysCommon/graphics.cpp
@@ -568,16 +568,16 @@ void Font::setTexture(Texture* tex, int numRows, int numCols)
 	mCharHeight = mTexture->mHeight / numCols;
 
 	int charIndex = 0;
-	for (int i = 0; i < numCols; i++) {
-		for (int j = 0; j < numRows; j++) {
+	for (int col = 0; col < numCols; col++) {
+		for (int row = 0; row < numRows; row++) {
 			int leftEdge  = 0;
 			int rightEdge = 0;
 
 			// Find left boundary
-			for (int k = 0; k < mCharWidth; k++) {
+			for (int pixelX1 = 0; pixelX1 < mCharWidth; pixelX1++) {
 				int alphaCount = 0;
-				for (int m = 0; m < mCharHeight - 1; m++) {
-					if (!tex->getAlpha(k + (j * mCharWidth), m + (i * mCharHeight))) {
+				for (int pixelY1 = 0; pixelY1 < mCharHeight - 1; pixelY1++) {
+					if (!tex->getAlpha(pixelX1 + (row * mCharWidth), pixelY1 + (col * mCharHeight))) {
 						alphaCount++;
 					}
 				}
@@ -586,14 +586,14 @@ void Font::setTexture(Texture* tex, int numRows, int numCols)
 					break;
 				}
 
-				leftEdge = k;
+				leftEdge = pixelX1;
 			}
 
 			// Find right boundary
-			for (int k = mCharWidth - 1; k >= 0; k--) {
+			for (int pixelX2 = mCharWidth - 1; pixelX2 >= 0; pixelX2--) {
 				int alphaCount = 0;
-				for (int m = 0; m < mCharHeight - 1; m++) {
-					if (!tex->getAlpha(k + (j * mCharWidth), m + (i * mCharHeight))) {
+				for (int pixelY2 = 0; pixelY2 < mCharHeight - 1; pixelY2++) {
+					if (!tex->getAlpha(pixelX2 + (row * mCharWidth), pixelY2 + (col * mCharHeight))) {
 						alphaCount++;
 					}
 				}
@@ -602,22 +602,22 @@ void Font::setTexture(Texture* tex, int numRows, int numCols)
 					break;
 				}
 
-				rightEdge = mCharWidth - k;
+				rightEdge = mCharWidth - pixelX2;
 			}
 
 			// Find baseline
 			int baseline    = -1;
 			int baselinePos = mCharWidth;
-			for (int k = 0; k < mCharWidth; k++) {
-				int x    = j * mCharWidth;
-				int y    = (mCharHeight + (i * mCharHeight));
-				u8 alpha = tex->getAlpha(k + x, y - 1);
+			for (int pixelX3 = 0; pixelX3 < mCharWidth; pixelX3++) {
+				int x    = row * mCharWidth;
+				int y    = (mCharHeight + (col * mCharHeight));
+				u8 alpha = tex->getAlpha(pixelX3 + x, y - 1);
 				if (baseline < 0) {
 					if (!alpha) {
-						baseline = k;
+						baseline = pixelX3;
 					}
 				} else if (alpha) {
-					baselinePos = k;
+					baselinePos = pixelX3;
 					break;
 				}
 			}
@@ -626,9 +626,9 @@ void Font::setTexture(Texture* tex, int numRows, int numCols)
 			// so much indexing, this isn't even an inline function
 			mChars[charIndex].mCharSpacing         = baselinePos - baseline;
 			mChars[charIndex].mLeftOffset          = baseline - leftEdge;
-			mChars[charIndex].mTextureX            = leftEdge + j * mCharWidth;
+			mChars[charIndex].mTextureX            = leftEdge + row * mCharWidth;
 			mChars[charIndex].mWidth               = mCharWidth - leftEdge - rightEdge;
-			mChars[charIndex].mTextureY            = i * mCharHeight;
+			mChars[charIndex].mTextureY            = col * mCharHeight;
 			mChars[charIndex].mHeight              = mCharHeight - 1;
 			mChars[charIndex].mTextureCoords.mMinX = (s16)mChars[charIndex].mTextureX;
 			mChars[charIndex].mTextureCoords.mMinY = (s16)mChars[charIndex].mTextureY;

--- a/src/sysCommon/graphics.cpp
+++ b/src/sysCommon/graphics.cpp
@@ -577,7 +577,8 @@ void Font::setTexture(Texture* tex, int numRows, int numCols)
 			for (int pixelX1 = 0; pixelX1 < mCharWidth; pixelX1++) {
 				int alphaCount = 0;
 				for (int pixelY1 = 0; pixelY1 < mCharHeight - 1; pixelY1++) {
-					if (!tex->getAlpha(pixelX1 + (row * mCharWidth), pixelY1 + (col * mCharHeight))) {
+					u8 alpha = tex->getAlpha(row * mCharWidth + pixelX1, col * mCharHeight + pixelY1);
+					if (alpha == 0) {
 						alphaCount++;
 					}
 				}
@@ -593,7 +594,8 @@ void Font::setTexture(Texture* tex, int numRows, int numCols)
 			for (int pixelX2 = mCharWidth - 1; pixelX2 >= 0; pixelX2--) {
 				int alphaCount = 0;
 				for (int pixelY2 = 0; pixelY2 < mCharHeight - 1; pixelY2++) {
-					if (!tex->getAlpha(pixelX2 + (row * mCharWidth), pixelY2 + (col * mCharHeight))) {
+					u8 alpha = tex->getAlpha(row * mCharWidth + pixelX2, col * mCharHeight + pixelY2);
+					if (alpha == 0) {
 						alphaCount++;
 					}
 				}
@@ -609,14 +611,12 @@ void Font::setTexture(Texture* tex, int numRows, int numCols)
 			int baseline    = -1;
 			int baselinePos = mCharWidth;
 			for (int pixelX3 = 0; pixelX3 < mCharWidth; pixelX3++) {
-				int x    = row * mCharWidth;
-				int y    = (mCharHeight + (col * mCharHeight));
-				u8 alpha = tex->getAlpha(pixelX3 + x, y - 1);
+				u8 alpha = tex->getAlpha(row * mCharWidth + pixelX3, col * mCharHeight + (mCharHeight - 1));
 				if (baseline < 0) {
-					if (!alpha) {
+					if (alpha == 0) {
 						baseline = pixelX3;
 					}
-				} else if (alpha) {
+				} else if (alpha != 0) {
 					baselinePos = pixelX3;
 					break;
 				}
@@ -626,7 +626,7 @@ void Font::setTexture(Texture* tex, int numRows, int numCols)
 			// so much indexing, this isn't even an inline function
 			mChars[charIndex].mCharSpacing         = baselinePos - baseline;
 			mChars[charIndex].mLeftOffset          = baseline - leftEdge;
-			mChars[charIndex].mTextureX            = leftEdge + row * mCharWidth;
+			mChars[charIndex].mTextureX            = row * mCharWidth + leftEdge;
 			mChars[charIndex].mWidth               = mCharWidth - leftEdge - rightEdge;
 			mChars[charIndex].mTextureY            = col * mCharHeight;
 			mChars[charIndex].mHeight              = mCharHeight - 1;

--- a/src/sysCommon/shapeBase.cpp
+++ b/src/sysCommon/shapeBase.cpp
@@ -2787,7 +2787,7 @@ void BaseShape::initialise()
 				!!(&mMaterialList[matIdx].mTextureInfo);
 				mMaterialList[matIdx].mTextureInfo.mTextureData[texDataIdx].mTexture;
 #if 0 // This is what the DLL actually does instead of all this noise.
-				Texture* unused = mMaterialList[matIdx].mTextureInfo.mTextureData[j].mTexture;
+				Texture* unused = mMaterialList[matIdx].mTextureInfo.mTextureData[texDataIdx].mTexture;
 #endif
 			}
 		} else if (mMaterialList[matIdx].mTextureIndex != -1) {

--- a/src/sysCommon/shpRoutes.cpp
+++ b/src/sysCommon/shpRoutes.cpp
@@ -101,7 +101,8 @@ void RouteGroup::refresh(Graphics& gfx, EditNode* node)
 	int alpha     = mColour.a;
 	gfx.setCBlending(BLEND_Alpha);
 
-	FOREACH_NODE(RoutePoint, mPointListRoot.mChild, point)
+	RoutePoint* point;
+	FOREACH_NODE_REUSE(RoutePoint, mPointListRoot.mChild, point)
 	{
 		FOREACH_NODE(RouteLink, point->mLink.mChild, link)
 		{
@@ -152,7 +153,7 @@ void RouteGroup::refresh(Graphics& gfx, EditNode* node)
 
 	gfx.setColour(Colour(mColour.r, mColour.g, mColour.b, alpha), true);
 
-	FOREACH_NODE(RoutePoint, mPointListRoot.mChild, point)
+	FOREACH_NODE_REUSE(RoutePoint, mPointListRoot.mChild, point)
 	{
 		gfx.useTexture(nullptr, GX_TEXMAP0);
 		gfx.setColour(Colour(255, 255, 0, 64), true);
@@ -254,7 +255,8 @@ void RouteGroup::saveini(immut char* name, RandomAccessStream& s)
 	s.print("%s\tcolour\t%d %d %d %d\n", name, mColour.r, mColour.g, mColour.b, mColour.a);
 
 	int idx = 0;
-	FOREACH_NODE(RoutePoint, mPointListRoot.mChild, point)
+	RoutePoint* point;
+	FOREACH_NODE_REUSE(RoutePoint, mPointListRoot.mChild, point)
 	{
 		point->mIndex = idx++;
 		s.print("\n%s\tpoint {\n", name);
@@ -265,7 +267,7 @@ void RouteGroup::saveini(immut char* name, RandomAccessStream& s)
 		s.print("%s\t\t}\n", name);
 	}
 	s.print("\n");
-	FOREACH_NODE(RoutePoint, mPointListRoot.mChild, point)
+	FOREACH_NODE_REUSE(RoutePoint, mPointListRoot.mChild, point)
 	{
 		FOREACH_NODE(RouteLink, point->mLink.mChild, link)
 		{

--- a/src/sysCommon/timers.cpp
+++ b/src/sysCommon/timers.cpp
@@ -144,7 +144,7 @@ void Timers::draw(Graphics& gfx, Font* font)
 		}
 	}
 
-	// Making these three named constants `const` breaks the stack for matching.  Lovely `const` memes!
+	// Making these three named constants `const` breaks the stack for matching.  Lovely const memes!
 	immut f32 chartMarginSize = TERNARY_BUGFIX(256.0f, 192.0f);
 	immut int chartTimeScale  = 4; // How many multiples of `MILLISEC_PER_FRAME` to fit on the chart
 	immut int chartBarHeight  = 12;

--- a/src/sysDolphin/dgxGraphics.cpp
+++ b/src/sysDolphin/dgxGraphics.cpp
@@ -416,10 +416,10 @@ u32 DGXGraphics::compileMaterial(Material* mat)
 		GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
 	}
 
-	GXSetTevKColor(GX_KCOLOR0, *((GXColor*)&mat->mTevInfo->mKonstColors[0]));
-	GXSetTevKColor(GX_KCOLOR1, *((GXColor*)&mat->mTevInfo->mKonstColors[1]));
-	GXSetTevKColor(GX_KCOLOR2, *((GXColor*)&mat->mTevInfo->mKonstColors[2]));
-	GXSetTevKColor(GX_KCOLOR3, *((GXColor*)&mat->mTevInfo->mKonstColors[3]));
+	GXSetTevKColor(GX_KCOLOR0, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[0]));
+	GXSetTevKColor(GX_KCOLOR1, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[1]));
+	GXSetTevKColor(GX_KCOLOR2, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[2]));
+	GXSetTevKColor(GX_KCOLOR3, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[3]));
 	for (int i = 0; i < mat->mTevInfo->mTevStageCount; i++) {
 		PVWTevStage& stage = mat->mTevInfo->mTevStages[i];
 		GXSetTevColorIn((GXTevStageID)i, (GXTevColorArg)stage.mTevColorCombiner.mInArgA, (GXTevColorArg)stage.mTevColorCombiner.mInArgB,
@@ -771,7 +771,7 @@ void DGXGraphics::setLight(Light* light, int idx)
 	}
 
 	lightColour.a *= mLightIntensity;
-	GXInitLightColor(gxLight, *(GXColor*)&lightColour);
+	GXInitLightColor(gxLight, reinterpret_cast<GXColor&>(lightColour));
 	GXLoadLightObjImm(gxLight, GXLightID(1 << idx));
 }
 
@@ -1036,10 +1036,10 @@ void DGXGraphics::setMaterial(Material* mat, bool p2)
 					GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
 				}
 
-				GXSetTevKColor(GX_KCOLOR0, *((GXColor*)&mat->mTevInfo->mKonstColors[0]));
-				GXSetTevKColor(GX_KCOLOR1, *((GXColor*)&mat->mTevInfo->mKonstColors[1]));
-				GXSetTevKColor(GX_KCOLOR2, *((GXColor*)&mat->mTevInfo->mKonstColors[2]));
-				GXSetTevKColor(GX_KCOLOR3, *((GXColor*)&mat->mTevInfo->mKonstColors[3]));
+				GXSetTevKColor(GX_KCOLOR0, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[0]));
+				GXSetTevKColor(GX_KCOLOR1, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[1]));
+				GXSetTevKColor(GX_KCOLOR2, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[2]));
+				GXSetTevKColor(GX_KCOLOR3, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[3]));
 				for (int i = 0; i < mat->mTevInfo->mTevStageCount; i++) {
 					PVWTevStage& stage = mat->mTevInfo->mTevStages[i];
 					GXSetTevColorIn((GXTevStageID)i, (GXTevColorArg)stage.mTevColorCombiner.mInArgA,
@@ -1084,7 +1084,7 @@ void DGXGraphics::setMaterial(Material* mat, bool p2)
 			Colour color;
 			color.set(mat->mColourInfo.mColour.r, mat->mColourInfo.mColour.g, mat->mColourInfo.mColour.b,
 			          mLightIntensity * mat->mColourInfo.mColour.a);
-			GXSetChanMatColor(GX_COLOR0A0, *(GXColor*)&color);
+			GXSetChanMatColor(GX_COLOR0A0, reinterpret_cast<GXColor&>(color));
 
 			if (mat->mTextureInfo.mUseScale) {
 				mCustomScale = &mat->mTextureInfo.mScale;
@@ -1123,7 +1123,7 @@ void DGXGraphics::setMaterial(Material* mat, bool p2)
 		Colour color;
 		color.set(mat->mColourInfo.mColour.r, mat->mColourInfo.mColour.g, mat->mColourInfo.mColour.b,
 		          mLightIntensity * mat->mColourInfo.mColour.a);
-		GXSetChanMatColor(GX_COLOR0A0, *(GXColor*)&color);
+		GXSetChanMatColor(GX_COLOR0A0, reinterpret_cast<GXColor&>(color));
 
 		if (mLightCam) {
 			return;
@@ -1414,10 +1414,10 @@ void DGXGraphics::setAuxColour(immut Colour& color)
 void DGXGraphics::setPrimEnv(immut Colour* col1, immut Colour* col2)
 {
 	if (col1) {
-		GXSetTevColor(GX_TEVREG0, *(GXColor*)col1);
+		GXSetTevColor(GX_TEVREG0, *reinterpret_cast<GXColor*>(col1));
 	}
 	if (col2) {
-		GXSetTevColor(GX_TEVREG1, *(GXColor*)col2);
+		GXSetTevColor(GX_TEVREG1, *reinterpret_cast<GXColor*>(col2));
 	}
 }
 
@@ -1434,7 +1434,7 @@ void DGXGraphics::setClearColour(immut Colour& color)
  */
 void DGXGraphics::clearBuffer(int, bool)
 {
-	GXSetCopyClear(*(GXColor*)&mBufferClearColour, 0xFFFFFF); // max clear_z value
+	GXSetCopyClear(reinterpret_cast<GXColor&>(mBufferClearColour), 0xFFFFFF); // max clear_z value
 }
 
 /**
@@ -1444,10 +1444,10 @@ void DGXGraphics::setFog(bool set)
 {
 	if (set) {
 #if defined(VERSION_PIKIDEMO) || defined(VERSION_GPIJ01)
-		GXSetFog(GX_FOG_LINEAR, mFogStart, mFogEnd, mCamera->mNear, mCamera->mFar, *(GXColor*)&mFogColour);
+		GXSetFog(GX_FOG_LINEAR, mFogStart, mFogEnd, mCamera->mNear, mCamera->mFar, reinterpret_cast<GXColor&>(mFogColour));
 #else
 		if (mCamera->mNear < mCamera->mFar) {
-			GXSetFog(GX_FOG_LINEAR, mFogStart, mFogEnd, mCamera->mNear, mCamera->mFar, *(GXColor*)&mFogColour);
+			GXSetFog(GX_FOG_LINEAR, mFogStart, mFogEnd, mCamera->mNear, mCamera->mFar, reinterpret_cast<GXColor&>(mFogColour));
 		} else {
 #if defined(VERSION_GPIP01)
 			OSReport("%s:%d Warning: cam->vNear >= cam->vFar\n", __FILE__, TERNARY_BUILD_MATCHING(1732, __LINE__));
@@ -2040,7 +2040,7 @@ void DGXGraphics::texturePrintf(Font* font, int x, int y, immut char* format, ..
 	GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_CLEAR);
 	useTexture(font->mTexture, GX_TEXMAP0);
 
-	GXSetChanMatColor(GX_COLOR0, *(GXColor*)&mPrimaryColour);
+	GXSetChanMatColor(GX_COLOR0, reinterpret_cast<GXColor&>(mPrimaryColour));
 
 	GXClearVtxDesc();
 	GXSetVtxDesc(GX_VA_POS, GX_DIRECT);

--- a/src/sysDolphin/dgxGraphics.cpp
+++ b/src/sysDolphin/dgxGraphics.cpp
@@ -1040,31 +1040,31 @@ void DGXGraphics::setMaterial(Material* mat, bool p2)
 				GXSetTevKColor(GX_KCOLOR1, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[1]));
 				GXSetTevKColor(GX_KCOLOR2, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[2]));
 				GXSetTevKColor(GX_KCOLOR3, reinterpret_cast<GXColor&>(mat->mTevInfo->mKonstColors[3]));
-				for (int i = 0; i < mat->mTevInfo->mTevStageCount; i++) {
-					PVWTevStage& stage = mat->mTevInfo->mTevStages[i];
-					GXSetTevColorIn((GXTevStageID)i, (GXTevColorArg)stage.mTevColorCombiner.mInArgA,
+				for (int tevStageIdx = 0; tevStageIdx < mat->mTevInfo->mTevStageCount; tevStageIdx++) {
+					PVWTevStage& stage = mat->mTevInfo->mTevStages[tevStageIdx];
+					GXSetTevColorIn((GXTevStageID)tevStageIdx, (GXTevColorArg)stage.mTevColorCombiner.mInArgA,
 					                (GXTevColorArg)stage.mTevColorCombiner.mInArgB, (GXTevColorArg)stage.mTevColorCombiner.mInArgC,
 					                (GXTevColorArg)stage.mTevColorCombiner.mInArgD);
-					GXSetTevColorOp((GXTevStageID)i, (GXTevOp)stage.mTevColorCombiner.mTevOp, (GXTevBias)stage.mTevColorCombiner.mBias,
-					                (GXTevScale)stage.mTevColorCombiner.mScale, (GXBool)stage.mTevColorCombiner.mDoClamp,
-					                (GXTevRegID)stage.mTevColorCombiner.mOutReg);
-					GXSetTevAlphaIn((GXTevStageID)i, (GXTevAlphaArg)stage.mTevAlphaCombiner.mInArgA,
+					GXSetTevColorOp((GXTevStageID)tevStageIdx, (GXTevOp)stage.mTevColorCombiner.mTevOp,
+					                (GXTevBias)stage.mTevColorCombiner.mBias, (GXTevScale)stage.mTevColorCombiner.mScale,
+					                (GXBool)stage.mTevColorCombiner.mDoClamp, (GXTevRegID)stage.mTevColorCombiner.mOutReg);
+					GXSetTevAlphaIn((GXTevStageID)tevStageIdx, (GXTevAlphaArg)stage.mTevAlphaCombiner.mInArgA,
 					                (GXTevAlphaArg)stage.mTevAlphaCombiner.mInArgB, (GXTevAlphaArg)stage.mTevAlphaCombiner.mInArgC,
 					                (GXTevAlphaArg)stage.mTevAlphaCombiner.mInArgD);
-					GXSetTevAlphaOp((GXTevStageID)i, (GXTevOp)stage.mTevAlphaCombiner.mTevOp, (GXTevBias)stage.mTevAlphaCombiner.mBias,
-					                (GXTevScale)stage.mTevAlphaCombiner.mScale, (GXBool)stage.mTevAlphaCombiner.mDoClamp,
-					                (GXTevRegID)stage.mTevAlphaCombiner.mOutReg);
+					GXSetTevAlphaOp((GXTevStageID)tevStageIdx, (GXTevOp)stage.mTevAlphaCombiner.mTevOp,
+					                (GXTevBias)stage.mTevAlphaCombiner.mBias, (GXTevScale)stage.mTevAlphaCombiner.mScale,
+					                (GXBool)stage.mTevAlphaCombiner.mDoClamp, (GXTevRegID)stage.mTevAlphaCombiner.mOutReg);
 				}
 
 				gsys->mLightingSets++;
 				setLighting((mat->mLightingInfo.mCtrlFlag & LightingControlFlags::EnableColor0) != 0, &mat->mLightingInfo);
 			}
 
-			for (int i = 0; i < mat->mTextureInfo.mTextureDataCount; i++) {
-				if (mat->mTextureInfo.mTextureData[i].mTexture != mActiveTexture[i]) {
-					mActiveTexture[i] = mat->mTextureInfo.mTextureData[i].mTexture;
-					mActiveTexture[i]->makeResident();
-					GXLoadTexObj(mActiveTexture[i]->mTexObj, GXTexMapID(i));
+			for (int texIdx = 0; texIdx < mat->mTextureInfo.mTextureDataCount; texIdx++) {
+				if (mat->mTextureInfo.mTextureData[texIdx].mTexture != mActiveTexture[texIdx]) {
+					mActiveTexture[texIdx] = mat->mTextureInfo.mTextureData[texIdx].mTexture;
+					mActiveTexture[texIdx]->makeResident();
+					GXLoadTexObj(mActiveTexture[texIdx]->mTexObj, GXTexMapID(texIdx));
 				}
 			}
 
@@ -1074,11 +1074,12 @@ void DGXGraphics::setMaterial(Material* mat, bool p2)
 
 			GXSetNumTevStages(mat->mTevInfo->mTevStageCount);
 
-			for (int i = 0; i < mat->mTevInfo->mTevStageCount; i++) {
-				PVWTevStage& stage = mat->mTevInfo->mTevStages[i];
-				GXSetTevOrder(GXTevStageID(i), GXTexCoordID(stage.mTexCoordID), GXTexMapID(stage.mTexMapID), GXChannelID(stage.mChannelID));
-				GXSetTevKColorSel(GXTevStageID(i), GXTevKColorSel(stage.mTevKColorSel));
-				GXSetTevKAlphaSel(GXTevStageID(i), GXTevKAlphaSel(stage.mTevKAlphaSel));
+			for (int tevStageIdx = 0; tevStageIdx < mat->mTevInfo->mTevStageCount; tevStageIdx++) {
+				PVWTevStage& stage = mat->mTevInfo->mTevStages[tevStageIdx];
+				GXSetTevOrder(GXTevStageID(tevStageIdx), GXTexCoordID(stage.mTexCoordID), GXTexMapID(stage.mTexMapID),
+				              GXChannelID(stage.mChannelID));
+				GXSetTevKColorSel(GXTevStageID(tevStageIdx), GXTevKColorSel(stage.mTevKColorSel));
+				GXSetTevKAlphaSel(GXTevStageID(tevStageIdx), GXTevKAlphaSel(stage.mTevKAlphaSel));
 			}
 
 			Colour color;
@@ -1339,27 +1340,27 @@ void DGXGraphics::drawSingleMatpoly(Shape* model, Joint::MatPoly* matPoly)
 	useMaterial(&mat);
 	setupVtxDesc(model, &mat, &mesh);
 
-	for (int i = 0; i < mesh.mMtxGroupCount; i++) {
-		MtxGroup& group = mesh.mMtxGroupList[i];
-		for (int j = 0; j < group.mDepLength; j++) {
-			if (group.mDepList[j] == -1) {
+	for (int mtxGroupIdx = 0; mtxGroupIdx < mesh.mMtxGroupCount; mtxGroupIdx++) {
+		MtxGroup& group = mesh.mMtxGroupList[mtxGroupIdx];
+		for (int depListIdx = 0; depListIdx < group.mDepLength; depListIdx++) {
+			if (group.mDepList[depListIdx] == -1) {
 				continue;
 			}
 
-			VtxMatrix& vtxMtx = model->mVtxMatrixList[group.mDepList[j]];
+			VtxMatrix& vtxMtx = model->mVtxMatrixList[group.mDepList[depListIdx]];
 			if (model->mCurrentAnimation->mData) {
 				if (vtxMtx.mHasPartialWeights) {
-					useMatrixQuick(model->getAnimMatrix(vtxMtx.mIndex), j);
+					useMatrixQuick(model->getAnimMatrix(vtxMtx.mIndex), depListIdx);
 				} else {
-					useMatrixQuick(model->getAnimMatrix(model->mJointCount + vtxMtx.mIndex), j);
+					useMatrixQuick(model->getAnimMatrix(model->mJointCount + vtxMtx.mIndex), depListIdx);
 				}
 			} else {
-				useMatrixQuick(model->mJointList[vtxMtx.mIndex].mAnimMatrix, j);
+				useMatrixQuick(model->mJointList[vtxMtx.mIndex].mAnimMatrix, depListIdx);
 			}
 		}
 
-		for (int j = 0; j < group.mDispLength; j++) {
-			DispList& list = group.mDispList[j];
+		for (int dispListIdx = 0; dispListIdx < group.mDispLength; dispListIdx++) {
+			DispList& list = group.mDispList[dispListIdx];
 			setCullFront((list.mFlags & 3) ^ mCullFlip);
 			gsys->mPolygonCount += list.mFaceCount;
 			gsys->mDispCount++;
@@ -2303,18 +2304,18 @@ void Shape::optimize()
 
 	mVertexCacheFlags
 	    = VertexCacheFlags::VertexList | VertexCacheFlags::NormalList | VertexCacheFlags::NBTList | VertexCacheFlags::ColorList;
-	for (int i = 0; i < mTotalActiveTexCoords; i++) {
-		mVertexCacheFlags |= (1 << (i + 5)); // Effectively `(VertexCacheFlags::TexCoord0 << i)`
+	for (int texCoordNum = 0; texCoordNum < mTotalActiveTexCoords; texCoordNum++) {
+		mVertexCacheFlags |= (1 << (texCoordNum + 5)); // Effectively `(VertexCacheFlags::TexCoord0 << texCoordNum)`
 	}
 
 	if (!mMeshCount) {
 		return;
 	}
 
-	for (int i = 0; i < mMeshCount; i++) {
-		for (int j = 0; j < mMeshList[i].mMtxGroupCount; j++) {
-			DispList* list = mMeshList[i].mMtxGroupList[j].mDispList;
-			for (int k = 0; k < mMeshList[i].mMtxGroupList[j].mDispLength; k++) {
+	for (int meshIdx = 0; meshIdx < mMeshCount; meshIdx++) {
+		for (int mtxGroupIdx = 0; mtxGroupIdx < mMeshList[meshIdx].mMtxGroupCount; mtxGroupIdx++) {
+			DispList* list = mMeshList[meshIdx].mMtxGroupList[mtxGroupIdx].mDispList;
+			for (int dispCount = 0; dispCount < mMeshList[meshIdx].mMtxGroupList[mtxGroupIdx].mDispLength; dispCount++) {
 				DCStoreRange(list->mData, list->mDataLength);
 				list++; // why.
 			}

--- a/src/sysDolphin/dgxGraphics.cpp
+++ b/src/sysDolphin/dgxGraphics.cpp
@@ -1450,9 +1450,9 @@ void DGXGraphics::setFog(bool set)
 			GXSetFog(GX_FOG_LINEAR, mFogStart, mFogEnd, mCamera->mNear, mCamera->mFar, *(GXColor*)&mFogColour);
 		} else {
 #if defined(VERSION_GPIP01)
-			OSReport("%s:%d Warning: cam->vNear >= cam->vFar\n", __FILE__, 1732);
+			OSReport("%s:%d Warning: cam->vNear >= cam->vFar\n", __FILE__, TERNARY_BUILD_MATCHING(1732, __LINE__));
 #else
-			OSReport("%s:%d Warning: cam->vNear >= cam->vFar\n", __FILE__, 1683);
+			OSReport("%s:%d Warning: cam->vNear >= cam->vFar\n", __FILE__, TERNARY_BUILD_MATCHING(1683, __LINE__));
 #endif
 		}
 #endif
@@ -2304,7 +2304,7 @@ void Shape::optimize()
 	mVertexCacheFlags
 	    = VertexCacheFlags::VertexList | VertexCacheFlags::NormalList | VertexCacheFlags::NBTList | VertexCacheFlags::ColorList;
 	for (int i = 0; i < mTotalActiveTexCoords; i++) {
-		mVertexCacheFlags |= (1 << (i + 5));
+		mVertexCacheFlags |= (1 << (i + 5)); // Effectively `(VertexCacheFlags::TexCoord0 << i)`
 	}
 
 	if (!mMeshCount) {

--- a/src/sysDolphin/system.cpp
+++ b/src/sysDolphin/system.cpp
@@ -129,18 +129,18 @@ RandomAccessStream* System::openFile(immut char* path, bool isRelativePath, bool
 
 	if (isRelativePath && (mDvdRoot.getChildCount() || mAramRoot.getChildCount())) {
 
-		FOREACH_NODE(DirEntry, mDvdRoot.mChild, node)
+		FOREACH_NODE(DirEntry, mDvdRoot.mChild, dvdDirEnt)
 		{
-			if (strcmp(node->mName, path) == 0) {
-				aramStream.init(path, node->mAddress, node->mPending);
+			if (strcmp(dvdDirEnt->mName, path) == 0) {
+				aramStream.init(path, dvdDirEnt->mAddress, dvdDirEnt->mPending);
 				return new BufferedInputStream(&aramStream, DVDStream::readBuffer, dvdStream.mSize);
 			}
 		}
 
-		FOREACH_NODE(DirEntry, mAramRoot.mChild, node)
+		FOREACH_NODE(DirEntry, mAramRoot.mChild, aramDirEnt)
 		{
-			if (!strcmp(node->mName, path)) {
-				aramStream.init(path, node->mAddress, node->mPending);
+			if (!strcmp(aramDirEnt->mName, path)) {
+				aramStream.init(path, aramDirEnt->mAddress, aramDirEnt->mPending);
 				return new BufferedInputStream(&aramStream, DVDStream::readBuffer, dvdStream.mSize);
 			}
 		}


### PR DESCRIPTION
I have tackled every\* for-loop that currently requires the `#define for if (0) else for` macro on the [dll-decomp](https://github.com/projectPiki/pikmin/tree/dll-decomp) branch due to MSVC 6.0's pre-standard loop variable scope rule.  Hopefully this means that said macro can be left behind when the DLL matching build system is merged into the main branch, as it inhibits matching under debug MSVC 6.0.

\* I skipped the for-loops in `ParseMapFile` from "system.cpp" because I'm not convinced that function exists within the DLL.  That whole translation unit is probably radically different.

Also included are new codebase-wide macros in "types.h": `PIKI_USE_JAUDIO` and `PIKI_USE_DGX`.  Their usage should be self explanatory.  See their commit.