### PR TITLE
Potential fix for stack pad

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,13 +1,49 @@
 {
     "configurations": [
         {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/include",
+                "${workspaceFolder}/include/stl"
+            ],
+            "cStandard": "c99",
+            "cppStandard": "c++98",
+            "intelliSenseMode": "linux-clang-x86",
+            "compilerPath": "",
+            "configurationProvider": "ms-vscode.makefile-tools",
+            "forcedInclude": [
+                ".vscode/warnings.h"
+            ]
+        },
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/include",
+                "${workspaceFolder}/include/stl"
+            ],
+            "cStandard": "c99",
+            "cppStandard": "c++98",
+            "intelliSenseMode": "windows-msvc-x86",
+            "compilerPath": "",
+            "configurationProvider": "ms-vscode.makefile-tools",
+            "forcedInclude": [
+                ".vscode/warnings.h"
+            ]
+        },
+        {
             "name": "Mac",
             "includePath": [
                 "${workspaceFolder}/include",
                 "${workspaceFolder}/include/stl"
             ],
             "cStandard": "c99",
-            "cppStandard": "c++98"
+            "cppStandard": "c++98",
+            "intelliSenseMode": "macos-clang-x86",
+            "compilerPath": "",
+            "configurationProvider": "ms-vscode.makefile-tools",
+            "forcedInclude": [
+                ".vscode/warnings.h"
+            ]
         }
     ],
     "version": 4

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,49 +1,13 @@
 {
     "configurations": [
         {
-            "name": "Linux",
-            "includePath": [
-                "${workspaceFolder}/include",
-                "${workspaceFolder}/include/stl"
-            ],
-            "cStandard": "c99",
-            "cppStandard": "c++98",
-            "intelliSenseMode": "linux-clang-x86",
-            "compilerPath": "",
-            "configurationProvider": "ms-vscode.makefile-tools",
-            "forcedInclude": [
-                ".vscode/warnings.h"
-            ]
-        },
-        {
-            "name": "Win32",
-            "includePath": [
-                "${workspaceFolder}/include",
-                "${workspaceFolder}/include/stl"
-            ],
-            "cStandard": "c99",
-            "cppStandard": "c++98",
-            "intelliSenseMode": "windows-msvc-x86",
-            "compilerPath": "",
-            "configurationProvider": "ms-vscode.makefile-tools",
-            "forcedInclude": [
-                ".vscode/warnings.h"
-            ]
-        },
-        {
             "name": "Mac",
             "includePath": [
                 "${workspaceFolder}/include",
                 "${workspaceFolder}/include/stl"
             ],
             "cStandard": "c99",
-            "cppStandard": "c++98",
-            "intelliSenseMode": "macos-clang-x86",
-            "compilerPath": "",
-            "configurationProvider": "ms-vscode.makefile-tools",
-            "forcedInclude": [
-                ".vscode/warnings.h"
-            ]
+            "cppStandard": "c++98"
         }
     ],
     "version": 4

--- a/configure.py
+++ b/configure.py
@@ -266,10 +266,17 @@ cflags_jaudio = [
     "-common on",
     "-func_align 32",
     "-lang c++",
-    "-DNDEBUG=1",
     "-w off",
     "-use_lmw_stmw on",
 ]
+
+if args.debug:
+    cflags_jaudio.extend(["-sym on", "-DDEBUG=1"])
+else:
+    cflags_jaudio.append("-DNDEBUG=1")
+
+if args.develop:
+    cflags_jaudio.append("-DDEVELOP=1")
 
 # Game code flags
 cflags_pikmin = [

--- a/include/jaudio/debug.h
+++ b/include/jaudio/debug.h
@@ -1,0 +1,16 @@
+#ifndef _JAUDIO_DEBUG_H
+#define _JAUDIO_DEBUG_H
+
+#include "Dolphin/OS/OSError.h"
+
+/*
+ * This is intentionally an object-like macro. In retail builds, removing only
+ * the callee leaves the parenthesized arguments as a comma expression.
+ */
+#if defined(DEBUG)
+#define JAUDIO_PRINT OSReport
+#else
+#define JAUDIO_PRINT
+#endif
+
+#endif

--- a/src/jaudio/aictrl.c
+++ b/src/jaudio/aictrl.c
@@ -3,6 +3,7 @@
 #include "Dolphin/os.h"
 #include "jaudio/audiocommon.h"
 #include "jaudio/audiostruct.h"
+#include "jaudio/debug.h"
 #include "jaudio/driverinterface.h"
 #include "jaudio/dspbuf.h"
 #include "jaudio/dspproc.h"
@@ -54,13 +55,11 @@ void GetAudioHeapRemain(void)
  */
 void* OSAlloc2(u32 size)
 {
-	u32* REF_size;
-
 	void* alloc;
 	BOOL enabled;
 
-	enabled  = OSDisableInterrupts();
-	REF_size = &size;
+	JAUDIO_PRINT("OSAlloc2: size=%d\n", size);
+	enabled = OSDisableInterrupts();
 	switch (audio_hp_exist) {
 	case FALSE:
 	{

--- a/src/jaudio/aramcall.c
+++ b/src/jaudio/aramcall.c
@@ -1,5 +1,6 @@
 #include "jaudio/aramcall.h"
 
+#include "jaudio/debug.h"
 #include "jaudio/dummyrom.h"
 #include "jaudio/dvdthread.h"
 #include "jaudio/heapctrl.h"
@@ -26,8 +27,7 @@ void Jac_RegisterARAMCallback(ARAMCallback callback)
  */
 u32 LoadAram(immut char* filepath, u32* status, u32 dst)
 {
-	immut char** REF_filepath = &filepath;
-	u32* REF_dst              = &dst;
+	JAUDIO_PRINT("LoadAram: path=%s dst=%x\n", filepath, dst);
 
 	if (DVDT_LoadtoARAM(0, filepath, dst, 0, 0, status, NULL) == -1) {
 		return 0;
@@ -40,11 +40,7 @@ u32 LoadAram(immut char* filepath, u32* status, u32 dst)
  */
 u32 LoadAramSingle(immut char* filepath, u32 src, u32 length, u32* status, u32 dst)
 {
-	STACK_PAD_VAR(1);
-	immut char** REF_filepath = &filepath;
-	u32* REF_src              = &src;
-	u32* REF_length           = &length;
-
+	JAUDIO_PRINT("LoadAramSingle: path=%s length=%x src=%x (%d bytes)\n", filepath, length, src, length);
 	if (DVDT_LoadtoARAM(0, filepath, dst, src, length, status, NULL) == -1) {
 		return 0;
 	}

--- a/src/jaudio/audiothread.c
+++ b/src/jaudio/audiothread.c
@@ -7,6 +7,7 @@
 #include "jaudio/aictrl.h"
 #include "jaudio/audiocommon.h"
 #include "jaudio/cpubuf.h"
+#include "jaudio/debug.h"
 #include "jaudio/dspboot.h"
 #include "jaudio/dspbuf.h"
 #include "jaudio/dspinterface.h"
@@ -85,14 +86,12 @@ static void DspSync2(void*)
 	u32 check;
 	u32 mesg;
 
-	u32* REF_check = &check;
-	STACK_PAD_VAR(1);
-
 	do {
 		check = DSPCheckMailFromDSP();
 	} while (check == 0);
 
 	mesg = DSPReadMailFromDSP();
+	JAUDIO_PRINT("DspSync2: ready=%x mail=%x\n", check, mesg >> 16);
 	if (mesg >> 0x10 == 0xf355) {
 		switch (mesg & 0xff00) {
 		case 0xff00:

--- a/src/jaudio/bankdrv.c
+++ b/src/jaudio/bankdrv.c
@@ -1,6 +1,7 @@
 #include "jaudio/bankdrv.h"
 
 #include "jaudio/bx.h"
+#include "jaudio/debug.h"
 #include "jaudio/ja_calc.h"
 #include "jaudio/random.h"
 #include "jaudio/rate.h"
@@ -77,16 +78,14 @@ int Bank_GetInstKeymap(Inst_* inst, u8 key)
  */
 int Bank_GetInstVmap(Inst_* inst, u8 key, u8 velocity)
 {
-	STACK_PAD_VAR(1);
-
 	if (!inst) {
 		return 0;
 	}
 
 	int instIndex = Bank_GetInstKeymap(inst, key);
 	if (instIndex != -1) {
-		u8* REF_p3       = &velocity;
 		InstKeymap_* keymap = inst->mKeyRegions[instIndex];
+		JAUDIO_PRINT("Bank_GetInstVmap: velocity=%d regions=%d\n", velocity, keymap->mVelocityCount);
 		for (u32 i = 0; i < keymap->mVelocityCount; i++) {
 			Vmap_* vmap = keymap->mVelocities[i];
 			if (velocity <= vmap->mBaseVelocity) {

--- a/src/jaudio/centcalc.c
+++ b/src/jaudio/centcalc.c
@@ -1,5 +1,6 @@
 #include "jaudio/centcalc.h"
 
+#include "jaudio/debug.h"
 #include "jaudio/tables.h"
 
 // Calculated via powf(2.0f, x / 12.0f)
@@ -18,8 +19,6 @@ static f32 KEY_TABLE[KEY_CURVE_RESOLUTION] = {
  */
 f32 Jam_PitchToCent(f32 basePitch, f32 scaleFactor)
 {
-	STACK_PAD_VAR(1);
-
 	f32 scaledPitch;
 	f32 fractionalPart;
 	s16 tableIndex;
@@ -39,5 +38,7 @@ f32 Jam_PitchToCent(f32 basePitch, f32 scaleFactor)
 		tableIndex += 1;
 	}
 
+	JAUDIO_PRINT("Jam_PitchToCent: base=%f curve=%f\n", C5BASE_PITCHTABLE[tableIndex + 60],
+	             (KEY_TABLE)[(u16)(fractionalPart * KEY_CURVE_RESOLUTION)]);
 	return C5BASE_PITCHTABLE[tableIndex + 60] * (KEY_TABLE)[(u16)(fractionalPart * KEY_CURVE_RESOLUTION)];
 }

--- a/src/jaudio/cmdqueue.c
+++ b/src/jaudio/cmdqueue.c
@@ -1,6 +1,7 @@
 #include "jaudio/cmdqueue.h"
 
 #include "jaudio/audiomesg.h"
+#include "jaudio/debug.h"
 #include "jaudio/jammain_2.h"
 #include "jaudio/playercall.h"
 #include "jaudio/verysimple.h"
@@ -74,11 +75,7 @@ void Jal_SendCmdQueue(CmdQueue* queue, u16 msg)
  */
 void Jal_SendCmdQueue_Noblock(CmdQueue* queue, u16 msg)
 {
-	CmdQueue** REF_queue;
-	u16* REF_msg;
-
-	REF_queue = &queue;
-	REF_msg   = &msg;
+	JAUDIO_PRINT("Jal_SendCmdQueue_Noblock: queue=%x msg=%x\n", queue, msg);
 	Jac_SendMessage(&queue->msgQueue, (OSMessage)msg);
 
 #if defined(VERSION_GPIJ01_01)

--- a/src/jaudio/connect.c
+++ b/src/jaudio/connect.c
@@ -1,6 +1,7 @@
 #include "jaudio/connect.h"
 #include "jaudio/aramcall.h"
 #include "jaudio/bx.h"
+#include "jaudio/debug.h"
 #include "jaudio/heapctrl.h"
 #include <stddef.h>
 
@@ -39,8 +40,6 @@ static BOOL UpdateWave_Extern(WaveArchiveBank_* bank, CtrlGroup_* group, Ctrl_* 
 		}
 		Ctrl_* cdf = group->scenes[a]->cdf;
 		u32 index  = 0;
-		u32* ptr   = &a;
-		u32* ptr2  = &index;
 		while (index < cdf->count) {
 			if ((cdf->waveIDs[index]->id & 0xffff) == b) {
 				break;
@@ -49,6 +48,7 @@ static BOOL UpdateWave_Extern(WaveArchiveBank_* bank, CtrlGroup_* group, Ctrl_* 
 		}
 
 		if (index != cdf->count) {
+			JAUDIO_PRINT("UpdateWave_Extern: scene=%d index=%d\n", a, index);
 			WaveID_** wave2 = &cdf->waveIDs[index];
 			if ((*wave2)->heap.startAddress) {
 				wave->data = (*wave2)->data;
@@ -94,14 +94,13 @@ void Jac_SceneClose(WaveArchiveBank_* bank, CtrlGroup_* group, u32 id, BOOL set)
  */
 BOOL Jac_SceneSet(WaveArchiveBank_* bank, CtrlGroup_* group, u32 id, BOOL set)
 {
-	WaveArchiveBank_** bankp = &bank;
-	u32* idp                 = &id;
 	WaveArchive_* arc;
 	int stat = 0;
 	SCNE_* scene;
 	Ctrl_* cdf;
 	u32 i;
 
+	JAUDIO_PRINT("Jac_SceneSet: id=%d\n", id);
 	arc = bank->waveGroups[id];
 	!arc;
 
@@ -120,6 +119,7 @@ BOOL Jac_SceneSet(WaveArchiveBank_* bank, CtrlGroup_* group, u32 id, BOOL set)
 		}
 	}
 
+	JAUDIO_PRINT("Jac_SceneSet: bank=%x\n", bank);
 	scene = group->scenes[id];
 	cdf   = scene->cdf;
 	if (cdf) {
@@ -194,7 +194,6 @@ WaveID_* __GetSoundHandle(CtrlGroup_* group, u32 id, u32 id2)
  */
 WaveID_* GetSoundHandle(CtrlGroup_* group, u32 flag)
 {
-	u32* flagptr  = &flag;
 	WaveID_* wave = __GetSoundHandle(group, flag, group->mCurrentSceneIndex);
 	if (wave == NULL) {
 		return NULL;
@@ -203,18 +202,19 @@ WaveID_* GetSoundHandle(CtrlGroup_* group, u32 flag)
 		return NULL;
 	}
 
+	JAUDIO_PRINT("GetSoundHandle: flag=%x\n", flag);
 	u32* ptr = wave->data->fileLoadStatus;
 	if (ptr == NULL) {
 		return NULL;
 	}
 
 	if (*ptr == 0) {
+		JAUDIO_PRINT("GetSoundHandle: unavailable flag=%x scene=%d data=%p status=%d\n", flag,
+		             group->mCurrentSceneIndex, wave->data, *ptr);
 		return NULL;
 	}
 
 	return wave;
-
-	STACK_PAD_VAR(4);
 }
 
 /**
@@ -256,14 +256,10 @@ u16 Jac_WsPhysicalToVirtual(u16 ws)
  */
 void Jac_WsConnectTableSet(u32 id, u32 val)
 {
-	u32* id2 = &id;
-	u32* bnk = &val;
-
 	if (id != 0xffff && id < 0x100 && WS_V2P_TABLE[id] == -1) {
-		WS_V2P_TABLE[id] = *bnk;
+		WS_V2P_TABLE[id] = val;
+		JAUDIO_PRINT("Jac_WsConnectTableSet: id=%d (0x%x) value=%d\n", id, id, val);
 	}
-
-	STACK_PAD_VAR(2);
 }
 
 /**
@@ -271,14 +267,10 @@ void Jac_WsConnectTableSet(u32 id, u32 val)
  */
 void Jac_BnkConnectTableSet(u32 id, u32 val)
 {
-	u32* id2 = &id;
-	u32* bnk = &val;
-
 	if (id != 0xffff && id < 0x100 && BNK_V2P_TABLE[id] == -1) {
-		BNK_V2P_TABLE[id] = *bnk;
+		BNK_V2P_TABLE[id] = val;
+		JAUDIO_PRINT("Jac_BnkConnectTableSet: id=%d (0x%x) value=%d\n", id, id, val);
 	}
-
-	STACK_PAD_VAR(2);
 }
 
 /**

--- a/src/jaudio/driverinterface.c
+++ b/src/jaudio/driverinterface.c
@@ -3,6 +3,7 @@
 #include "jaudio/aictrl.h"
 #include "jaudio/audiostruct.h"
 #include "jaudio/bankdrv.h"
+#include "jaudio/debug.h"
 #include "jaudio/dspdriver.h"
 #include "jaudio/dspinterface.h"
 #include "jaudio/ja_calc.h"
@@ -184,9 +185,8 @@ void List_AddChannel(jc_** jc, jc_* in)
  */
 int FixAllocChannel(jcs_* sys, u32 size)
 {
-	jcs_** REF_sys = &sys;
-	u32* REF_size  = &size;
-	int num        = 0;
+	JAUDIO_PRINT("FixAllocChannel: system=%x count=%d\n", sys, size);
+	int num = 0;
 	while (num < size) {
 		jc_* chan = List_GetChannel(&GLOBAL_CHANNEL.freeChannels);
 		if (chan == NULL) {
@@ -758,9 +758,9 @@ static int CommonCallbackLogicalChannel(dspch_* ch, u32 eventType)
 	u32 activeOscCount = 0;
 	jc_* jc            = ch->logicalChan;
 	u32 oscIndex;
-	dspch_** REF_ch = &ch;
-	jc_** REF_jc    = &jc;
 	STACK_PAD_VAR(10);
+
+	JAUDIO_PRINT("CommonCallbackLogicalChannel: channel=%x\n", jc);
 
 	// Handle null logical channel - cleanup and return
 	if (jc == NULL) {
@@ -808,6 +808,7 @@ static int CommonCallbackLogicalChannel(dspch_* ch, u32 eventType)
 	}
 
 	// Handle priority update event
+	JAUDIO_PRINT("CommonCallbackLogicalChannel: priority channel=%x\n", ch);
 	if (eventType == DSPCHCB_PriorityUpdate) {
 		u8 prio = jc->channelPriority >> 16;
 		if (jc->dspChannel && prio < jc->dspChannel->prio) {
@@ -839,8 +840,8 @@ static int CommonCallbackLogicalChannel(dspch_* ch, u32 eventType)
 
 		// Process all oscillators
 		for (oscIndex = 0; oscIndex < 4; oscIndex++) {
-			u32* REF_i = &oscIndex;
 			if (jc->mOscillators[oscIndex]) {
+				JAUDIO_PRINT("CommonCallbackLogicalChannel: oscillator=%d\n", oscIndex);
 				DoEffectOsc(jc, jc->mOscillators[oscIndex]->mode, Bank_OscToOfs(jc->mOscillators[oscIndex], &jc->mOscBuffers[oscIndex]));
 
 				// Check if oscillator finished

--- a/src/jaudio/dspdriver.c
+++ b/src/jaudio/dspdriver.c
@@ -2,6 +2,7 @@
 
 #include "Dolphin/PPCArch.h"
 #include "jaudio/audiothread.h"
+#include "jaudio/debug.h"
 #include "jaudio/driverinterface.h"
 #include "jaudio/dspinterface.h"
 #include "jaudio/rate.h"
@@ -51,13 +52,11 @@ dspch_* AllocDSPchannel(u32 channelMode, u32 ownerId)
 {
 
 	s32 i;
-	STACK_PAD_VAR(1);
-	u32* REF_ownerId = &ownerId;
-	s32* REF_i       = &i;
 	if (channelMode == 0) {
 
 		for (i = 0; i < DSPCH_LENGTH; ++i) {
 			if (DSPCH[i].allocState == DSPCHAN_Free) {
+				JAUDIO_PRINT("AllocDSPchannel: owner=%x index=%d channel=%p\n", ownerId, i, &DSPCH[i]);
 				DSPCH[i].allocState  = DSPCHAN_MonoAllocated;
 				DSPCH[i].logicalChan = (jc_*)ownerId;
 				DSPCH[i].prio        = 1;
@@ -133,10 +132,6 @@ dspch_* GetLowerDSPchannel()
 	u32 id      = 0;
 	u32 x       = 0;
 	u32 i       = 0;
-	u8* REF_max = &max;
-	u32* REF_id = &id;
-	u32* REF_x  = &x;
-	u32* REF_i  = &i;
 
 	STACK_PAD_VAR(2);
 
@@ -162,6 +157,7 @@ dspch_* GetLowerDSPchannel()
 		}
 	}
 
+	JAUDIO_PRINT("GetLowerDSPchannel: priority=%d id=%d age=%d index=%d\n", max, id, x, i);
 	return &DSPCH[id];
 }
 
@@ -175,10 +171,6 @@ dspch_* GetLowerActiveDSPchannel()
 	u32 c     = 0;
 	u32 i;
 	DSPchannel_* buf;
-
-	u8* REF_a      = &a;
-	u32* REF_index = &index;
-	u32* REF_c     = &c;
 
 	for (i = 0; i < DSPCH_LENGTH; ++i) {
 		if (DSPCH[i].allocState == DSPCHAN_Stopping || DSPCH[i].allocState == DSPCHAN_Free)
@@ -200,6 +192,7 @@ dspch_* GetLowerActiveDSPchannel()
 		a     = DSPCH[i].prio;
 	}
 
+	JAUDIO_PRINT("GetLowerActiveDSPchannel: priority=%d index=%d age=%d\n", a, index, c);
 	return &DSPCH[index];
 }
 
@@ -208,11 +201,9 @@ dspch_* GetLowerActiveDSPchannel()
  */
 BOOL ForceStopDSPchannel(dspch_* chan)
 {
-	dspch_** REF_chan;
-
 	DSPchannel_* buf;
 
-	REF_chan = &chan;
+	JAUDIO_PRINT("ForceStopDSPchannel: channel=%x\n", chan);
 	if (chan->allocState == DSPCHAN_Stopping)
 		return FALSE;
 	buf = GetDspHandle(chan->buffer_idx);
@@ -229,13 +220,11 @@ BOOL ForceStopDSPchannel(dspch_* chan)
  */
 BOOL BreakLowerDSPchannel(u8 priority)
 {
-	u8* REF_priority;
-
 	dspch_* chan;
 	DSPchannel_* buf;
 
-	chan        = GetLowerDSPchannel();
-	REF_priority = &priority;
+	chan = GetLowerDSPchannel();
+	JAUDIO_PRINT("BreakLowerDSPchannel: priority=%d\n", priority);
 	if (chan->prio > priority)
 		return FALSE;
 	if (chan->prio == priority) {
@@ -259,10 +248,10 @@ BOOL BreakLowerDSPchannel(u8 priority)
  */
 BOOL BreakLowerActiveDSPchannel(u8 id)
 {
-	u8* id_ptr   = &id;
 	dspch_* chan = GetLowerActiveDSPchannel();
 
 	if (chan->prio > id) {
+		JAUDIO_PRINT("BreakLowerActiveDSPchannel: requested=%d priority=%d\n", id, chan->prio);
 		return FALSE;
 	}
 
@@ -282,8 +271,6 @@ BOOL BreakLowerActiveDSPchannel(u8 id)
 	}
 
 	return TRUE;
-
-	STACK_PAD_VAR(2);
 }
 
 /**
@@ -316,8 +303,7 @@ void UpdateDSPchannelAll()
 
 	// Update all DSP channels
 	for (u32 i = 0; i < DSPCH_LENGTH; i++) {
-		dspch_* chan     = &DSPCH[i];
-		dspch_** chanptr = &chan;
+		dspch_* chan = &DSPCH[i];
 
 		// Skip free channels
 		if (chan->allocState == DSPCHAN_Free) {
@@ -342,6 +328,7 @@ void UpdateDSPchannelAll()
 		}
 
 		// Handle aging and release timing
+		JAUDIO_PRINT("UpdateDSPchannelAll: channel=%x\n", chan);
 		if (!buf->endRequested) {
 			buf->ageCounter++;
 			if (buf->ageCounter == chan->releaseTime && chan->logicalChanCb) {

--- a/src/jaudio/dspinterface.c
+++ b/src/jaudio/dspinterface.c
@@ -1,6 +1,7 @@
 #include "jaudio/dspinterface.h"
 
 #include "Dolphin/os.h"
+#include "jaudio/debug.h"
 #include "jaudio/driverinterface.h"
 #include "jaudio/dspdriver.h"
 #include "jaudio/dspproc.h"
@@ -84,15 +85,10 @@ void DSP_SetMixerInitDelayMax(u8 idx, u8 initDelayMax)
  */
 void DSP_SetMixerInitVolume(u8 idx, u8 mixer, s16 volume, u8 level)
 {
-	u8* REF_idx;
-	u8* REF_mixer;
-
 	DSPchannel_* buf;
 	DSPMixerChannel* mixChan;
 
-	REF_idx   = &idx;
-	REF_mixer = &mixer;
-
+	JAUDIO_PRINT("DSP_SetMixerInitVolume: channel=%d mixer=%d\n", idx, mixer);
 	buf     = &CH_BUF[idx];
 	mixChan = &buf->mixChannels[mixer];
 
@@ -431,7 +427,7 @@ void DSP_SetupBuffer()
  */
 void DSP_InitBuffer()
 {
-	STACK_PAD_VAR(1);
+	JAUDIO_PRINT("DSP_InitBuffer: channels=%p count=%d\n", CH_BUF, CH_BUF_LENGTH);
 	for (int i = 0; i < 4; ++i)
 		DFX_SetFxLine(i, NULL, NULL);
 	DSP_ClearBuffer();

--- a/src/jaudio/dspproc.c
+++ b/src/jaudio/dspproc.c
@@ -1,6 +1,7 @@
 #include "jaudio/dspproc.h"
 #include "Dolphin/dsp.h"
 #include "Dolphin/os.h"
+#include "jaudio/debug.h"
 #include "jaudio/dspinterface.h"
 #include <stddef.h>
 
@@ -282,7 +283,7 @@ void DsyncFrame(u32 subframes, u32 dspbufStart, u32 dspbufEnd)
 	commands[2] = dspbufEnd;
 
 #if defined(VERSION_GPIP01)
-	STACK_PAD_VAR(1);
+	JAUDIO_PRINT("DsyncFrame: commands=%p header=%x\n", commands, commands[0]);
 	DSPSendCommands2(commands, ARRAY_SIZE(commands), NULL);
 #else
 	DSPSendCommands(commands, ARRAY_SIZE(commands));

--- a/src/jaudio/dvdthread.c
+++ b/src/jaudio/dvdthread.c
@@ -2,6 +2,7 @@
 #include "Dolphin/ar.h"
 #include "Dolphin/os.h"
 #include "jaudio/aictrl.h"
+#include "jaudio/debug.h"
 #include "jaudio/sample.h"
 #include <stddef.h>
 #include <string.h>
@@ -76,8 +77,7 @@ static s32 DVDReadMutex(DVDFileInfo* fileInfo, void* addr, s32 len, s32 offs, im
  */
 void DVDT_SetRootPath(immut char* path)
 {
-	// don't ask.
-	immut char** REF_path = &path;
+	JAUDIO_PRINT("DVDT_SetRootPath: path=%s\n", path);
 	if (strlen(path) < 31) {
 		strcpy(audio_root_path, path);
 	}
@@ -529,7 +529,7 @@ void DVDT_DRAMtoARAM(u32, u32, u32, u32, u32*, void (*)(u32))
 s32 DVDT_CheckFile(immut char* file)
 {
 	char path[64];
-	immut char** REF_file = &file;
+	JAUDIO_PRINT("DVDT_CheckFile: file=%s\n", file);
 	static DVDFileInfo finfo;
 
 	DVDT_ExtendPath(path, file);
@@ -548,14 +548,13 @@ s32 DVDT_CheckFile(immut char* file)
  */
 s32 DVDT_LoadFile(immut char* file, u8* dst)
 {
-	vu32 status           = 0;
-	immut char** REF_file = &file;
-	STACK_PAD_VAR(2);
+	vu32 status = 0;
 	DVDT_LoadtoDRAM(0, file, (u32)dst, 0, 0, (u32*)&status, NULL);
 
 	while (status == 0) { }
 
 	if (status == -1) {
+		JAUDIO_PRINT("DVDT_LoadFile: failed path=%s (%p), status=%d\n", file, file, status);
 		return 0;
 	}
 
@@ -644,7 +643,7 @@ static u32 dvd_entrynum[32];
 s32 Jac_RegisterFastOpen(immut char* file)
 {
 	volatile int num;
-	immut char** REF_file = &file;
+	JAUDIO_PRINT("Jac_RegisterFastOpen: file=%s\n", file);
 	STACK_PAD_VAR(3);
 	if (strlen(file) > 63) {
 		return -1;

--- a/src/jaudio/file_seq.c
+++ b/src/jaudio/file_seq.c
@@ -1,5 +1,6 @@
 #include "jaudio/file_seq.h"
 
+#include "jaudio/debug.h"
 #include "jaudio/jammain_2.h"
 #include "jaudio/seqsetup.h"
 #include "jaudio/virload.h"
@@ -39,12 +40,8 @@ static u32 first = TRUE;
  */
 void Jaf_InitSeqArchive2(immut char* barcFilepath, u8* barcData, u8* archiveWork)
 {
-	STACK_PAD_VAR(2);
-
-	immut char** REF_barcFilepath;
 	size_t i;
 
-	REF_barcFilepath = &barcFilepath;
 	for (i = strlen(barcFilepath); i != 0; --i) {
 		if (barcFilepath[i - 1] == '/') {
 			break;
@@ -53,6 +50,7 @@ void Jaf_InitSeqArchive2(immut char* barcFilepath, u8* barcData, u8* archiveWork
 
 	JV_InitHeader_M(barcFilepath, barcData, archiveWork);
 	seq_archandle = JV_GetArchiveHandle(&barcFilepath[i]);
+	JAUDIO_PRINT("Jaf_InitSeqArchive2: file=%s handle=%x\n", barcFilepath, seq_archandle);
 
 	for (i = 0; i < SEQ_LOADBUFFER_SIZE; ++i) {
 		seq_loadbuffer[i] = NULL;
@@ -112,7 +110,6 @@ u8* Jaf_CheckSeq(u32 index)
  */
 u32 Jaf_ReadySeq(u32 rootTrackIndex, u32 seqIndex)
 {
-	STACK_PAD_VAR(1);
 	seqp_* rootTrack = &rootseq[rootTrackIndex];
 	if (seqIndex >= SEQ_LOADBUFFER_SIZE) {
 		return 0;
@@ -127,6 +124,7 @@ u32 Jaf_ReadySeq(u32 rootTrackIndex, u32 seqIndex)
 	}
 
 	rootseqhandle[rootTrackIndex] = Jaq_SetSeqData(rootTrack, seq_loadbuffer[seqIndex], seqSize, 0);
+	JAUDIO_PRINT("Jaf_ReadySeq: buffer=%x handle=%x\n", seq_loadbuffer[seqIndex], rootseqhandle[rootTrackIndex]);
 	return rootseqhandle[rootTrackIndex];
 }
 
@@ -154,12 +152,11 @@ BOOL Jaf_StartSeq(u32 rootTrackIndex, u32 seqIndex)
  */
 BOOL Jaf_StopSeq(u32 index)
 {
-	STACK_PAD_VAR(2);
-
 	if (rootseqhandle[index] == -1) {
 		return FALSE;
 	}
 	BOOL result = Jaq_StopSeq(rootseqhandle[index]);
+	JAUDIO_PRINT("Jaf_StopSeq: handle=%d (0x%x)\n", rootseqhandle[index], rootseqhandle[index]);
 	while (Jaq_HandleToSeq(rootseqhandle[index])) { }
 	rootseqhandle[index] = -1;
 	return result;
@@ -206,9 +203,7 @@ static void Jaf_LoadFinish(u32 asyncContext)
  */
 u32 __LoadSeqA(u32 callbackArg, u32 seqIndex, u8* seqBuffer, void (*finishCallback)(u32))
 {
-	u32* REF_callbackArg = &callbackArg;
-	u32* REF_seqIndex    = &seqIndex;
-	u8** REF_seqBuffer   = &seqBuffer;
+	JAUDIO_PRINT("__LoadSeqA: callback=%x sequence=%d buffer=%x\n", callbackArg, seqIndex, seqBuffer);
 
 	u32 slotIndex;
 	u32 seqSize;

--- a/src/jaudio/fxinterface.c
+++ b/src/jaudio/fxinterface.c
@@ -1,6 +1,7 @@
 #include "jaudio/fxinterface.h"
 
 #include "Dolphin/os.h"
+#include "jaudio/debug.h"
 #include "jaudio/sample.h"
 
 static u16 SEND_TABLE[] = {
@@ -12,9 +13,6 @@ static u16 SEND_TABLE[] = {
  */
 BOOL DFX_SetFxLine(u8 idx, s16* circularBufferBase, FxlineConfig* config)
 {
-	STACK_PAD_VAR(2);
-	s16** REF_circularBufferBase;
-
 	FXBuffer* buf;
 	BOOL restoreInterrupts;
 
@@ -30,8 +28,8 @@ BOOL DFX_SetFxLine(u8 idx, s16* circularBufferBase, FxlineConfig* config)
 		buf->circularBufferSize = config->circularBufferSize;
 		DSP_SetFilterTable(buf->filterCoeffs, config->filterCoeffs, 8);
 	}
-	REF_circularBufferBase = &circularBufferBase;
 	if (circularBufferBase && config) {
+		JAUDIO_PRINT("DFX_SetFxLine: buffer=%x size=%d\n", circularBufferBase, config->circularBufferSize);
 		int size = config->circularBufferSize * 0xa0; // TODO: What is 160 bytes large?
 
 		buf->circularBufferBase = circularBufferBase;

--- a/src/jaudio/heapctrl.c
+++ b/src/jaudio/heapctrl.c
@@ -1,5 +1,6 @@
 #include "jaudio/heapctrl.h"
 
+#include "jaudio/debug.h"
 #include "jaudio/dummyrom.h"
 
 #include "Dolphin/OS/OSCache.h"
@@ -17,11 +18,8 @@ static u32 global_id = 0;
  */
 static void ARAMFinish(u32 msg)
 {
-	STACK_PAD_VAR(1);
-	u32* REF_msg;
-
-	REF_msg             = &msg;
 	ARQRequest* request = (ARQRequest*)msg;
+	JAUDIO_PRINT("ARAMFinish: message=%x owner=%x\n", msg, request->owner);
 	OSSendMessage((OSMessageQueue*)request->owner, (OSMessage)1, OS_MESSAGE_BLOCK);
 }
 
@@ -344,8 +342,8 @@ BOOL Jac_AllocHeap(jaheap_* heap, jaheap_* parent, u32 size)
 BOOL Jac_DeleteHeap(jaheap_* heap)
 {
 	STACK_PAD_VAR(4);
-	jaheap_** pt = &heap;
 
+	JAUDIO_PRINT("Jac_DeleteHeap: heap=%x\n", heap);
 	if (heap->startAddress == 0) {
 		return FALSE;
 	}

--- a/src/jaudio/jammain_2.c
+++ b/src/jaudio/jammain_2.c
@@ -2,6 +2,7 @@
 
 #include "jaudio/bankdrv.h"
 #include "jaudio/centcalc.h"
+#include "jaudio/debug.h"
 #include "jaudio/driverinterface.h"
 #include "jaudio/fat.h"
 #include "jaudio/jamosc.h"
@@ -10,8 +11,6 @@
 #include "jaudio/random.h"
 #include "jaudio/rate.h"
 #include "jaudio/seqsetup.h"
-
-#include "Dolphin/OS/OSError.h"
 
 #include <stddef.h>
 
@@ -273,7 +272,7 @@ u16 Extend8to16(u8 value)
  */
 void Jam_WriteTimeParam(seqp_* track, u8 controlByte)
 {
-	STACK_PAD_VAR(1);
+	JAUDIO_PRINT("Jam_WriteTimeParam: pc=%x\n", track->programCounter);
 
 	s32 duration;
 	u8 paramIndex;
@@ -352,8 +351,6 @@ void Jam_WriteTimeParam(seqp_* track, u8 controlByte)
  */
 void Jam_WriteRegDirect(seqp_* track, u8 index, u16 value)
 {
-	STACK_PAD_VAR(1);
-
 	u16 regValue;
 
 	switch (index) {
@@ -385,6 +382,7 @@ void Jam_WriteRegDirect(seqp_* track, u8 index, u16 value)
 	}
 	}
 
+	JAUDIO_PRINT("Jam_WriteRegDirect: value=%x pc=%x\n", value & 0xff, track->programCounter);
 	track->regParam.reg[index]  = value;
 	track->regParam.param.value = regValue;
 }
@@ -433,7 +431,7 @@ static u32 LoadTbl(seqp_* track, u32 ofs, u32 idx, u32 valueType)
  */
 void Jam_WriteRegParam(seqp_* track, u8 controlByte)
 {
-	STACK_PAD_VAR(1);
+	JAUDIO_PRINT("Jam_WriteRegParam: pc=%x mode=%x\n", track->programCounter, controlByte & 0x0c);
 
 	s16 r30_newRegValue; // r30
 	u8 r29_regIdx;       // r29
@@ -996,7 +994,6 @@ void Jam_InitRegistTrack(void)
  */
 void Jam_RegistTrack(seqp_* track, u32 trackId)
 {
-	u32* REF_trackId;
 	size_t i;
 
 	for (i = 0; i < T_LISTS; ++i) {
@@ -1017,7 +1014,7 @@ void Jam_RegistTrack(seqp_* track, u32 trackId)
 		i = T_LISTS;
 		++T_LISTS;
 	}
-	REF_trackId         = &trackId;
+	JAUDIO_PRINT("Jam_RegistTrack: id=%x\n", trackId);
 	TRACK_LIST[i].id    = trackId;
 	TRACK_LIST[i].track = track;
 	track->isRegistered = 1;
@@ -1675,8 +1672,6 @@ void Jam_UpdateTempo(seqp_* track)
 {
 	size_t i;
 
-	size_t* REF_i;
-
 	if (!track->parent) {
 		track->tempoFactor = (float)track->timeBase * (float)track->tempo / (JAC_DAC_RATE * 60.0f / 80.0f);
 		if ((track->outerParams->flags & OuterParamFlag_Tempo) != 0) {
@@ -1687,8 +1682,8 @@ void Jam_UpdateTempo(seqp_* track)
 		track->timeBase    = track->parent->timeBase;
 	}
 	for (i = 0; i < 16; ++i) {
-		REF_i = &i;
 		if (track->children[i] && track->children[i]->trackState) {
+			JAUDIO_PRINT("Jam_UpdateTempo: child=%d\n", i);
 			Jam_UpdateTempo(track->children[i]);
 		}
 	}
@@ -1738,15 +1733,13 @@ void Jam_PauseTrack(seqp_* track, u8 recursive)
 	size_t i;
 	jc_* pjVar1;
 
-	size_t* REF_i;
-
 	track->isPaused = TRUE;
 	if (track->pauseStatus & 0x01) {
 		track->updateFlags |= OuterParamFlag_Volume;
 	}
 	if (track->pauseStatus & 0x04) {
 		for (i = 0; i < 8; ++i) {
-			REF_i = &i;
+			JAUDIO_PRINT("Jam_PauseTrack: voice=%d\n", i);
 			NoteOFF_R(track, i, 10);
 		}
 	}
@@ -1776,12 +1769,10 @@ void Jam_UnPauseTrack(seqp_* track, u8 recursive)
 	size_t i;
 	jc_* pjVar1;
 
-	size_t* REF_i;
-
 	track->isPaused = FALSE;
 	track->updateFlags |= OuterParamFlag_Volume;
 	for (i = 0; i < 8; ++i) {
-		REF_i  = &i;
+		JAUDIO_PRINT("Jam_UnPauseTrack: voice=%d\n", i);
 		pjVar1 = track->channels[i];
 		if (pjVar1 && track->activeSoundIds[i] == pjVar1->channelId) {
 			UpdatePause_1Shot(pjVar1, 0);
@@ -2381,8 +2372,6 @@ static u32 Cmd_PanPowSet()
  */
 static u32 Cmd_IIRSet()
 {
-	STACK_PAD_VAR(2);
-
 	size_t i;
 	MoveParam_* iir;
 
@@ -2394,6 +2383,7 @@ static u32 Cmd_IIRSet()
 		iir->duration     = 1.0f;
 	}
 
+	JAUDIO_PRINT("Cmd_IIRSet: seq=%x arg0=%x\n", SEQ_P, SEQ_ARG[0]);
 	return 0;
 }
 
@@ -2751,13 +2741,6 @@ u32 Cmd_Process(seqp_* track, u8 cmd, u16 argTypeMask)
 	u32 arg;
 	CmdFunction function;
 
-	STACK_PAD_VAR(1);
-	seqp_** REF_track;
-	u8* REF_cmd;
-
-	REF_track = &track;
-	REF_cmd   = &cmd;
-
 	argpair  = Arglist[cmd - 0xC0];
 	argTypes = argpair.argTypes | argTypeMask;
 	for (i = 0; i < argpair.argCount; ++i) {
@@ -2794,6 +2777,8 @@ u32 Cmd_Process(seqp_* track, u8 cmd, u16 argTypeMask)
 
 	function = CMDP_LIST[cmd - 0xC0];
 	if (!function) {
+		JAUDIO_PRINT("Error: NULL Command Pointer (cmd. %x ) \n", cmd);
+		JAUDIO_PRINT("SEQP %x  Access Offset %d\n", track, track->programCounter);
 		return 0;
 	}
 	return function();

--- a/src/jaudio/jamosc.c
+++ b/src/jaudio/jamosc.c
@@ -1,4 +1,5 @@
 #include "jaudio/jamosc.h"
+#include "jaudio/debug.h"
 #include "jaudio/jammain_2.h"
 #include <stddef.h>
 
@@ -19,9 +20,7 @@ Osc_ OSC_DEF    = { 0, 1.0f, NULL, REL_TABLE, 1.0f, 0.0f };
  */
 void Osc_Update_Param(seqp_* track, u8 id, f32 val)
 {
-	u8* REF_id   = &id;
-	f32* REF_val = &val;
-
+	JAUDIO_PRINT("Osc_Update_Param: id=%d value=%f\n", id, val);
 	switch (id) {
 	case 6:
 	{
@@ -120,7 +119,6 @@ void Osc_Init_Env(seqp_* track)
  */
 void Osc_Setup_SimpleEnv(seqp_* track, u8 id, u32 val)
 {
-	STACK_PAD_VAR(2);
 	switch (id) {
 	case 0:
 	{
@@ -134,6 +132,8 @@ void Osc_Setup_SimpleEnv(seqp_* track, u8 id, u32 val)
 		break;
 	}
 	}
+	JAUDIO_PRINT("Osc_Setup_SimpleEnv: attack=%x release=%x\n", track->oscillators[0].attackVecOffset,
+	             track->oscillators[0].releaseVecOffset);
 }
 
 /**

--- a/src/jaudio/memory.c
+++ b/src/jaudio/memory.c
@@ -1,4 +1,5 @@
 #include "jaudio/memory.h"
+#include "jaudio/debug.h"
 #include <stddef.h>
 
 /**
@@ -133,9 +134,8 @@ void Nas_HeapFree(ALHeap*)
 void* Nas_HeapAlloc(ALHeap* heap, s32 size)
 {
 	STACK_PAD_VAR(4);
-	s32* REF_size;
 
-	REF_size        = &size;
+	JAUDIO_PRINT("Nas_HeapAlloc: size=%d\n", size);
 	u32 roundedSize = ALIGN_NEXT(size, 32);
 	if (!heap->base) {
 		return NULL;
@@ -158,13 +158,11 @@ void* Nas_HeapAlloc(ALHeap* heap, s32 size)
  */
 void Nas_HeapInit(ALHeap* heap, u8* basePtr, s32 heapSize)
 {
-	STACK_PAD_VAR(2);
-	ALHeap** REF_heap;
-
 	int length;
 
-	REF_heap    = &heap;
 	heap->count = 0;
+	JAUDIO_PRINT("Nas_HeapInit: heap=%p (0x%x) aligned base=%p\n", heap, heap,
+	             (u8*)ALIGN_NEXT((u32)basePtr, 32));
 	if (!basePtr) {
 		heap->length  = 0;
 		heap->current = NULL;

--- a/src/jaudio/noteon.c
+++ b/src/jaudio/noteon.c
@@ -2,6 +2,7 @@
 
 #include "jaudio/audiostruct.h"
 #include "jaudio/connect.h"
+#include "jaudio/debug.h"
 #include "jaudio/driverinterface.h"
 #include "jaudio/jammain_2.h"
 #include "jaudio/oneshot.h"
@@ -120,10 +121,9 @@ s32 NoteON(seqp_* track, s32 channel, s32 flag1, s32 flag2, s32 playFlag)
  */
 s32 NoteOFF_R(seqp_* track, u8 channelIndex, u16 releaseFrames)
 {
-	u8* REF_channelIndex;
 	jc_* jc;
 
-	REF_channelIndex = &channelIndex;
+	JAUDIO_PRINT("NoteOFF_R: channel=%d\n", channelIndex);
 	if (jc = track->channels[channelIndex]) {
 		if (jc->channelId == track->activeSoundIds[channelIndex]) {
 			if (releaseFrames == 0) {
@@ -152,8 +152,7 @@ s32 NoteOFF(seqp_* track, u8 channelIndex)
  */
 s32 GateON(seqp_* track, s32 channelId, s32 key, s32 velocity, s32 playId)
 {
-	s32* REF_param_3 = &key;
-
+	JAUDIO_PRINT("GateON: key=%d\n", key);
 	if (track->channels[channelId]) {
 		Gate_1Shot(track->channels[channelId], key, velocity, playId);
 	} else {

--- a/src/jaudio/oneshot.c
+++ b/src/jaudio/oneshot.c
@@ -4,6 +4,7 @@
 #include "jaudio/bankread.h"
 #include "jaudio/bx.h"
 #include "jaudio/connect.h"
+#include "jaudio/debug.h"
 #include "jaudio/driverinterface.h"
 #include "jaudio/dspdriver.h"
 #include "jaudio/rate.h"
@@ -110,8 +111,8 @@ static void EffecterInit(jc_* jc, Inst_* inst)
 	for (u32 i = 0; i < 2; i++) {
 		if (inst->mSensors[i]) {
 			u8 trigger     = __GetTrigger(jc, inst->mSensors[i]->type);
-			f32 sense      = Bank_SenseToOfs(inst->mSensors[i], trigger);
-			f32* REF_sense = &sense;
+			f32 sense = Bank_SenseToOfs(inst->mSensors[i], trigger);
+			JAUDIO_PRINT("EffecterInit: sense=%f\n", sense);
 			__DoEffect(jc, inst->mSensors[i]->id, sense);
 		}
 
@@ -149,8 +150,8 @@ static void EffecterInit_Perc(jc_* jc, Pmap_* pmap, u16 id)
 	for (u32 i = 0; i < 2; i++) {
 		Pmap_* map = (Pmap_*)((int*)pmap + i + 2);
 		if (map->randomEffect) {
-			f32 r      = Bank_RandToOfs(map->randomEffect);
-			f32* REF_r = &r;
+			f32 r = Bank_RandToOfs(map->randomEffect);
+			JAUDIO_PRINT("EffecterInit_Perc: random=%f\n", r);
 			__DoEffect(jc, map->randomEffect->id, r);
 		}
 
@@ -255,7 +256,6 @@ static jc_* __Oneshot_GetLogicalChannel(jcs_* jcs, CtrlWave_* wave)
 
 	jc_* chan = List_GetChannel(&jcs->freeChannels);
 	jc_* chan2;
-	jc_** REF_chan2 = &chan2;
 	STACK_PAD_VAR(6);
 	if (chan == NULL) {
 
@@ -277,6 +277,7 @@ static jc_* __Oneshot_GetLogicalChannel(jcs_* jcs, CtrlWave_* wave)
 				}
 			}
 
+			JAUDIO_PRINT("__Oneshot_GetLogicalChannel: stolen=%x\n", chan2);
 			if (chan2) {
 				chan2->mOscBuffers[0].state = 6;
 				List_AddChannel(&jcs->waitingChannels, chan2);
@@ -432,6 +433,7 @@ static void __Oneshot_StopMonoPolyCheck(jc_* jc, u32 id)
 
 			int flag = id >> 0x18 & 0x20;
 			if (chan->soundId == id) {
+				JAUDIO_PRINT("__Oneshot_StopMonoPolyCheck: sound=%x\n", chan->soundId);
 				if (flag) {
 					if (chan->polyphonyCounter > jc->polyphonyCounter) {
 						chan->polyphonyCounter--;
@@ -452,8 +454,6 @@ static void __Oneshot_StopMonoPolyCheck(jc_* jc, u32 id)
 			chan = chan->nextChan;
 		}
 	}
-
-	STACK_PAD_VAR(2);
 }
 
 /**
@@ -461,6 +461,7 @@ static void __Oneshot_StopMonoPolyCheck(jc_* jc, u32 id)
  */
 void Init_1shot(jcs_* jcs, u32 id)
 {
+	JAUDIO_PRINT("Init_1shot: channels=%d\n", jcs->chanCount);
 	if (jcs->chanCount != 0) {
 		FixReleaseChannelAll(jcs);
 	}
@@ -471,8 +472,6 @@ void Init_1shot(jcs_* jcs, u32 id)
 	} else {
 		jcs->voiceStealingMode = 1;
 	}
-
-	STACK_PAD_VAR(2);
 }
 
 /**
@@ -512,8 +511,8 @@ void AllStop_1Shot(jcs_* jcs)
 
 	jc_* jc = jcs->activeChannels;
 	jc_* next;
-	jc_** REF_jc = &jc;
 	STACK_PAD_VAR(4);
+	JAUDIO_PRINT("AllStop_1Shot: channel=%x\n", jc);
 	while (jc) {
 		next = jc->nextChan;
 		Stop_1Shot(jc);
@@ -588,7 +587,7 @@ void SetKeyTarget_1Shot(jc_* jc, u8 key, u32 steps)
  */
 void Gate_1Shot(jc_* jc, u8 key, u8 velocity, s32 noteId)
 {
-	STACK_PAD_VAR(2);
+	JAUDIO_PRINT("Gate_1Shot: previous note=%d channel type=%d\n", jc->noteId, jc->logicalChanType);
 	if (jc->noteId == -1) {
 		jc->noteId         = noteId;
 		jc->lastNotePlayed = jc->noteId;
@@ -706,9 +705,9 @@ void FlushRelease_1Shot(jcs_* jcs)
  */
 static BOOL Jesus1Shot_Update(jc_* jc, JCSTATUS jstatus)
 {
-	u32 test    = FALSE;
-	jc_** jcptr = &jc;
-	s32 status  = jstatus;
+	u32 test = FALSE;
+	JAUDIO_PRINT("Jesus1Shot_Update: channel=%x\n", jc);
+	s32 status = jstatus;
 
 	if (status == 0) {
 		for (u32 i = 0; i < 2; i++) {
@@ -822,6 +821,7 @@ jc_* Play_1shot(jcs_* jcs, SOUNDID_ sound, u32 id)
 	BOOL test = FALSE;
 
 	inst = InstRead(sound.bytes[0], sound.bytes[1]);
+	JAUDIO_PRINT("Play_1shot: sound=%x bank=%d\n", sound.value, sound.bytes[0]);
 	if (inst == NULL) {
 		return NULL;
 	}
@@ -900,8 +900,6 @@ jc_* Play_1shot(jcs_* jcs, SOUNDID_ sound, u32 id)
 		__Oneshot_WavePause(newjc, 1);
 	}
 	return newjc;
-
-	STACK_PAD_VAR(2);
 }
 
 /**
@@ -919,8 +917,8 @@ jc_* Play_1shot_Perc(jcs_* jcs, SOUNDID_ sound, u32 id)
 	}
 
 	testPercMap* map   = (testPercMap*)Bank_GetPercVmap(perc, sound.bytes[2], sound.bytes[3]);
-	testPercMap** mapp = &map;
 	if (map == NULL) {
+		JAUDIO_PRINT("Play_1shot_Perc: map=%p\n", map);
 		return NULL;
 	}
 

--- a/src/jaudio/piki_bgm.c
+++ b/src/jaudio/piki_bgm.c
@@ -2,6 +2,7 @@
 
 #include "Dolphin/os.h"
 #include "jaudio/aictrl.h"
+#include "jaudio/debug.h"
 #include "jaudio/file_seq.h"
 #include "jaudio/interface.h"
 #include "jaudio/jammain_2.h"
@@ -168,11 +169,10 @@ void Jac_InitBgm(void)
 		for (i = 0; i < 5; i++) {
 			u32 seqSize;
 			u8* seqBuffer;
-			STACK_PAD_VAR(1);
 			seqSize   = Jaf_CheckSeqSize(preloadSeqIds[i]);
-			u32* REF_size = &seqSize;
+			JAUDIO_PRINT("Jac_InitBgm: sequence=%d size=%d\n", preloadSeqIds[i], seqSize);
 			seqBuffer = (u8*)OSAlloc2(seqSize);
-			u8** REF_seqbuf = &seqBuffer;
+			JAUDIO_PRINT("Jac_InitBgm: sequence buffer=%x\n", seqBuffer);
 			if ((u32)Jaf_LoadSeq(preloadSeqIds[i], seqBuffer)) {
 				int* startTrackId = &startTrackIds[i];
 				if (*startTrackId != -1) {
@@ -212,7 +212,7 @@ void Jac_StopBgm(u32 trackIndex)
  */
 void Jac_ReadyBgm(u32 bgmID)
 {
-	u32* REF_id = &bgmID;
+	JAUDIO_PRINT("Jac_ReadyBgm: id=%d\n", bgmID);
 
 	if (bgmID < 2) {
 		bgmID = 2;
@@ -235,7 +235,7 @@ void Jac_ReadyBgm(u32 bgmID)
 void Jac_PlayBgm(u32 trackIndex, u32 bgmID)
 {
 	STACK_PAD_VAR(4);
-	u32* REF_b = &bgmID;
+	JAUDIO_PRINT("Jac_PlayBgm: id=%d\n", bgmID);
 	u32 seqState;
 	seqp_* track;
 	Jac_SetProcessStatus(8);
@@ -337,7 +337,7 @@ BOOL Jac_ChangeBgmMode(u32 trackIndex, u8 modeFlags)
 void Jac_SetBgmModeFlag(u32 trackIndex, u8 flagMask, u8 enabled)
 {
 #if defined(VERSION_GPIP01)
-	STACK_PAD_VAR(2);
+	JAUDIO_PRINT("Jac_SetBgmModeFlag: call=%d\n", call_counter);
 	if (call_counter < 6000 && Jac_GetCurrentScene() == SCENE_Course && flagMask != 8 && flagMask != 4) {
 		return;
 	}
@@ -529,8 +529,7 @@ void Jac_GameVolume(u8 bgmLevel, u8 seLevel)
  */
 void Jac_EasyCrossFade(u8 crossfadeMode, u32 fadeFrames)
 {
-	u8* REF_type = &crossfadeMode;
-	u32* REF_val = &fadeFrames;
+	JAUDIO_PRINT("Jac_EasyCrossFade: mode=%d frames=%d\n", crossfadeMode, fadeFrames);
 
 	switch (crossfadeMode) {
 	case 0: // exit boss mode
@@ -567,9 +566,7 @@ void Jac_EasyCrossFade(u8 crossfadeMode, u32 fadeFrames)
  */
 void Jac_DemoFade(u8 fadeType, u32 fadeFrames, f32 volumeScale)
 {
-	u8* REF_type  = &fadeType;
-	u32* REF_val  = &fadeFrames;
-	f32* REF_mult = &volumeScale;
+	JAUDIO_PRINT("Jac_DemoFade: type=%d frames=%d volume=%f\n", fadeType, fadeFrames, volumeScale);
 
 	switch (fadeType) {
 	case 0:

--- a/src/jaudio/piki_player.c
+++ b/src/jaudio/piki_player.c
@@ -1,5 +1,6 @@
 #include "jaudio/piki_player.h"
 #include "jaudio/cmdqueue.h"
+#include "jaudio/debug.h"
 #include "jaudio/ja_calc.h"
 #include "jaudio/jammain_2.h"
 #include "jaudio/piki_bgm.h"
@@ -89,6 +90,7 @@ void Jac_Orima_Formation(s32 stickX, s32 stickY)
 	int stickMag = sqrtf2(stickX * stickX + stickY * stickY);
 	Jam_WritePortAppDirect(stick_seqp, 2, stickX);
 	Jam_WritePortAppDirect(stick_seqp, 3, stickMag);
+	JAUDIO_PRINT("Jac_Orima_Formation: active=%d\n", flag);
 
 	if (stickX == 0 && stickMag == 0) {
 		if (flag) {
@@ -104,8 +106,6 @@ void Jac_Orima_Formation(s32 stickX, s32 stickY)
 		}
 		gaya_timer = 0;
 	}
-
-	STACK_PAD_VAR(2);
 }
 
 static seqp_* orima_seqp;
@@ -167,7 +167,7 @@ void Jac_PlayOrimaSe(u32 id)
 				variantSoundId = randomVariationId + 0x800d;
 			}
 
-			STACK_PAD_VAR(1);
+			JAUDIO_PRINT("Jac_PlayOrimaSe: previous variation=%d\n", old1);
 
 			if (old3 == old2 && old2 == old1) {
 				if (old1 != randomVariationId) {
@@ -281,6 +281,7 @@ void Jac_UpdatePikiGaya()
 	static f32 volume = 0.0f;
 	static OuterParam_ outerparam;
 
+	JAUDIO_PRINT("Jac_UpdatePikiGaya: pikis=%d\n", pikis);
 	if (Jac_GetCurrentScene() != SCENE_Course) {
 		Jam_SetExtParamD(0, &outerparam, 1);
 		return;
@@ -320,6 +321,4 @@ void Jac_UpdatePikiGaya()
 	}
 
 	gaya_timer++;
-
-	STACK_PAD_VAR(2);
 }

--- a/src/jaudio/piki_scene.c
+++ b/src/jaudio/piki_scene.c
@@ -1,6 +1,7 @@
 #include "jaudio/piki_scene.h"
 
 #include "jaudio/aramcall.h"
+#include "jaudio/debug.h"
 #include "jaudio/dvdthread.h"
 #include "jaudio/interface.h"
 #include "jaudio/jammain_2.h"
@@ -89,10 +90,9 @@ void Jac_Delete_CurrentBgmWave()
  */
 static void __Loaded(u32 a)
 {
-	STACK_PAD_VAR(1);
-	u32* REF_a = &a;
-	u32 hi     = a & 0xffff0000;
-	a          = a & 0x0000ffff;
+	JAUDIO_PRINT("__Loaded: value=%x kind=%x\n", a, a >> 16);
+	u32 hi = a & 0xffff0000;
+	a      = a & 0x0000ffff;
 
 	switch (hi) {
 	case 0x20000:
@@ -141,9 +141,7 @@ BOOL Jac_TellChgMode()
  */
 void Jac_SceneSetup(u32 sceneID, u32 stage)
 {
-	STACK_PAD_VAR(4);
-	u32* REF_sceneID = &sceneID;
-	u32* REF_stage   = &stage;
+	JAUDIO_PRINT("Jac_SceneSetup: scene=%d stage=%d\n", sceneID, stage);
 	static int first = 1;
 	BOOL closeScene, same;
 	int bgm;
@@ -217,6 +215,7 @@ void Jac_SceneSetup(u32 sceneID, u32 stage)
 		}
 	}
 
+	JAUDIO_PRINT("Jac_SceneSetup: scene=%d stage=%d current bgm=%d\n", sceneID, stage, current_bgm);
 	if (current_bgm != bgm2) {
 		closeScene = TRUE;
 		Jac_StopBgm(0);
@@ -340,16 +339,13 @@ void Jac_SceneExit(u32 nextSceneID, u32 stage)
 	int fade;
 	int newBgm;
 
-	int* REF_fade;
-	STACK_PAD_VAR(1);
-
 	if (current_scene == nextSceneID) {
 		return;
 	}
 
 	Jac_SetProcessStatus(2);
-	fade     = tbl_scene_to_fadetime[current_scene];
-	REF_fade = &fade;
+	fade = tbl_scene_to_fadetime[current_scene];
+	JAUDIO_PRINT("Jac_SceneExit: scene=%d fade=%d\n", current_scene, fade);
 	Jac_FadeOutBgm(0, fade);
 	Jac_FadeOutBgm(1, fade);
 
@@ -457,8 +453,7 @@ void Jac_StopDemoSound(u32 id)
 void Jac_PrepareDemoSound(u32 id)
 {
 	char buffer[64];
-	STACK_PAD_VAR(3);
-	u32* REF_id = &id;
+	JAUDIO_PRINT("Jac_PrepareDemoSound: id=%d\n", id);
 
 	if (StreamSyncCheckBusy(0, id) == 1) {
 		stop_ready = 0;
@@ -467,6 +462,7 @@ void Jac_PrepareDemoSound(u32 id)
 		} while (stop_ready == 0);
 	}
 	DVDT_ExtendPath(buffer, filelist[id]);
+	JAUDIO_PRINT("Jac_PrepareDemoSound: id=%d current=%d file=%s\n", id, current_prepare, filelist[id]);
 	StreamAudio_Start(0, id, buffer, TRUE, FALSE, NULL);
 	Jac_UpdateStreamLevel();
 	current_prepare = id;

--- a/src/jaudio/pikidemo.c
+++ b/src/jaudio/pikidemo.c
@@ -2,6 +2,7 @@
 #include "GlobalGameOptions.h"
 #include "MoviePlayer.h"
 #include "jaudio/cmdqueue.h"
+#include "jaudio/debug.h"
 #include "jaudio/dvdthread.h"
 #include "jaudio/interface.h"
 #include "jaudio/jammain_2.h"
@@ -276,8 +277,7 @@ BOOL Jac_DemoCheckEvent(u8 evt)
 static void DoSequence(u32 cinID, u32 frameId)
 {
 	u32 flag;
-	u16* REF_flag;
-	u32* REF_frameId = &frameId;
+	u16* eventData;
 	u32* data   = (u32*)DEMO_STATUS[cinID].mTimedEvents;
 	STACK_PAD_VAR(2);
 	if (data == NULL) {
@@ -286,13 +286,14 @@ static void DoSequence(u32 cinID, u32 frameId)
 	}
 
 	while (1) {
-		flag     = data[demo_seq_active];
-		REF_flag = (u16*)&flag;
-		if (REF_flag[0] > frameId) {
+		flag      = data[demo_seq_active];
+		eventData = (u16*)&flag;
+		if (eventData[0] > frameId) {
 			break;
 		}
 
-		if (REF_flag[1] == 0xfff9) {
+		JAUDIO_PRINT("DoSequence: frame=%d\n", frameId);
+		if (eventData[1] == 0xfff9) {
 			switch (cinID) {
 			case DEMOID_CollectFirstPartPractice:
 			{
@@ -305,7 +306,7 @@ static void DoSequence(u32 cinID, u32 frameId)
 				break;
 			}
 			}
-		} else if (REF_flag[1] == 0xfffa) {
+		} else if (eventData[1] == 0xfffa) {
 			if (DEMO_STATUS[cinID].mAudioConfig & 0x80) {
 				Jac_StartDemoSound(DEMO_STATUS[cinID].mAudioConfig & 0xf);
 			} else {
@@ -314,25 +315,25 @@ static void DoSequence(u32 cinID, u32 frameId)
 				current_seq_bgm = DEMO_STATUS[cinID].mAudioConfig & 0xf;
 			}
 		} else {
-			if (REF_flag[1] == 0xffff) {
+			if (eventData[1] == 0xffff) {
 				Jac_FinishDemo();
 				return;
 			}
-			if (REF_flag[1] == 0xfffe) {
+			if (eventData[1] == 0xfffe) {
 				demo_seq_active = -1;
 				return;
 			}
-			if (REF_flag[1] == 0xfffd) {
+			if (eventData[1] == 0xfffd) {
 				demo_seq_active = -1;
 				return;
 			}
-			if (REF_flag[1] == 0xfffc) {
+			if (eventData[1] == 0xfffc) {
 				Jac_BgmAnimEndStop();
 
-			} else if (REF_flag[1] == 0xfffb) {
+			} else if (eventData[1] == 0xfffb) {
 				Jac_BgmAnimEndRecover();
 			} else {
-				Jac_DemoSound(REF_flag[1]);
+				Jac_DemoSound(eventData[1]);
 			}
 		}
 
@@ -561,7 +562,7 @@ void Jac_StartDemo(u32 cinID)
 	{
 		event_pause_counter = 0;
 		seqp_* track        = Jam_GetTrackHandle(0x20000);
-		seqp_** tp          = &track;
+		JAUDIO_PRINT("Jac_StartDemo: pause track=%p\n", track);
 		Jam_PauseTrack(track, 1);
 		break;
 	}
@@ -660,11 +661,8 @@ void Jac_StartDemo(u32 cinID)
  */
 void Jac_DemoSound(int id)
 {
-	STACK_PAD_VAR(1);
-	int* REF_id;
-
 	if (current_demo_no != DEMOID_FINISHED) {
-		REF_id = &id;
+		JAUDIO_PRINT("Jac_DemoSound: id=%d demo=%d\n", id, current_demo_no);
 #if defined(VERSION_G98P01_PIKIDEMO) || defined(VERSION_DPIJ01_PIKIDEMO)
 		Jal_SendCmdQueue(&demo_q, id);
 #else
@@ -784,7 +782,7 @@ void Jac_DemoBGMForceStop()
  */
 void __Jac_FinishDemo()
 {
-	STACK_PAD_VAR(2);
+	JAUDIO_PRINT("__Jac_FinishDemo: sequence=%d\n", current_seq_bgm);
 	if (current_demo_no == DEMOID_FINISHED) {
 		return;
 	}
@@ -845,9 +843,8 @@ void __Jac_FinishDemo()
  */
 void Jac_FinishDemo(void)
 {
-	int cinID     = current_demo_no;
-	int* REF_demo = &cinID;
-	STACK_PAD_VAR(1);
+	int cinID = current_demo_no;
+	JAUDIO_PRINT("Jac_FinishDemo: id=%d sequence=%d\n", cinID, demo_seq_active);
 	Jac_SetProcessStatus(6);
 	__Jac_FinishDemo();
 
@@ -1036,9 +1033,8 @@ void __Prepare_BGM(u32 cinID)
  */
 void Jac_PrepareDemo(u32 cinID)
 {
-	STACK_PAD_VAR(1);
-	u32* REF_id = &cinID;
 	if (cinID >= DEMOID_CHECK_BGM_CAT) {
+		JAUDIO_PRINT("Jac_PrepareDemo: id=%d current=%d\n", cinID, current_demo_no);
 		switch (cinID) {
 		case DEMOID_Unk80:
 		case DEMOID_GenericDayEnd:
@@ -1085,8 +1081,7 @@ void Jac_PrepareDemo(u32 cinID)
  */
 void Jac_StartPartsFindDemo(u32 jingleType, BOOL hasAudio)
 {
-	STACK_PAD_VAR(2);
-	u32* REF_p1;
+	JAUDIO_PRINT("Jac_StartPartsFindDemo: jingle=%d pause=%d\n", jingleType, event_pause_counter);
 
 	// we're already playing a part-related screen/cutscene!
 	if (parts_find_demo_state == 1) {
@@ -1104,7 +1099,7 @@ void Jac_StartPartsFindDemo(u32 jingleType, BOOL hasAudio)
 	if (hasAudio) {
 		Jac_DemoFade(1, 15, 0.1f);
 
-		REF_p1 = &jingleType;
+		JAUDIO_PRINT("Jac_StartPartsFindDemo: jingle=%d\n", jingleType);
 		if (jingleType == 0) {
 			// captain accessing the ship jingle
 			Jac_PlaySystemSe(JACSYS_Unk36);
@@ -1178,9 +1173,7 @@ void Jac_FinishTextDemo(void)
  */
 void Jac_SetDemoPartsID(int id)
 {
-	int* REF_id;
-
-	REF_id        = &id;
+	JAUDIO_PRINT("Jac_SetDemoPartsID: id=%d\n", id);
 	demo_parts_id = id;
 }
 
@@ -1189,9 +1182,7 @@ void Jac_SetDemoPartsID(int id)
  */
 void Jac_SetDemoOnyons(int num)
 {
-	int* REF_num;
-
-	REF_num        = &num;
+	JAUDIO_PRINT("Jac_SetDemoOnyons: count=%d\n", num);
 	demo_onyon_num = num;
 }
 
@@ -1200,8 +1191,6 @@ void Jac_SetDemoOnyons(int num)
  */
 void Jac_SetDemoPartsCount(int count)
 {
-	int* REF_count;
-
-	REF_count      = &count;
+	JAUDIO_PRINT("Jac_SetDemoPartsCount: count=%d\n", count);
 	demo_parts_num = count;
 }

--- a/src/jaudio/pikiinter.c
+++ b/src/jaudio/pikiinter.c
@@ -2,6 +2,7 @@
 
 #include "jaudio/cmdqueue.h"
 #include "jaudio/cmdstack.h"
+#include "jaudio/debug.h"
 #include "jaudio/filter3d.h"
 #include "jaudio/interface.h"
 #include "jaudio/jammain_2.h"
@@ -309,7 +310,7 @@ int Jac_CreateEvent(u32 eventType, struct SVector_* eventPos)
 	u32 i;
 	u32 idx;
 	SEvent_* event;
-	u32* REF_p1 = &eventType;
+	JAUDIO_PRINT("Jac_CreateEvent: type=%d\n", eventType);
 	if (!eventType) {
 		return -1;
 	}

--- a/src/jaudio/seqsetup.c
+++ b/src/jaudio/seqsetup.c
@@ -1,5 +1,6 @@
 #include "jaudio/seqsetup.h"
 
+#include "jaudio/debug.h"
 #include "jaudio/driverinterface.h"
 #include "jaudio/fat.h"
 #include "jaudio/jammain_2.h"
@@ -66,10 +67,8 @@ void Jaq_GetRemainFreeTracks(void)
  */
 static BOOL BackTrack(seqp_* track)
 {
-	seqp_** REF_track;
-
-	REF_track         = &track;
 	track->trackState = 0;
+	JAUDIO_PRINT("BackTrack: track=%x\n", track);
 	if (track->isAllocated == 1) {
 		if (SEQ_REMAIN == FREE_SEQP_QUEUE_SIZE) {
 			return FALSE;
@@ -479,8 +478,6 @@ s32 Jaq_OpenTrack(seqp_* track, u32 flags, u32 source)
 	u8 childIndex;
 	u8 trackFlags;
 
-	u8* REF_index;
-
 	childIndex = (flags & 0b00001111);
 	trackFlags = (flags & 0b11000000) >> 6;
 	if ((flags & 0b00100000)) {
@@ -491,7 +488,7 @@ s32 Jaq_OpenTrack(seqp_* track, u32 flags, u32 source)
 		childIndex = Jam_ReadRegDirect(track, childIndex);
 	}
 
-	REF_index = &childIndex;
+	JAUDIO_PRINT("Jaq_OpenTrack: child=%d\n", childIndex);
 	if (childIndex >= 16) {
 		return -1;
 	}

--- a/src/jaudio/syncstream.c
+++ b/src/jaudio/syncstream.c
@@ -2,6 +2,7 @@
 #include "Dolphin/dvd.h"
 #include "jaudio/aictrl.h"
 #include "jaudio/audiostruct.h"
+#include "jaudio/debug.h"
 #include "jaudio/dspdriver.h"
 #include "jaudio/dspinterface.h"
 #include "jaudio/dummyprobe.h"
@@ -621,7 +622,6 @@ static s32 StreamAudio_Callback(void* data)
 				for (channelIdx = 0; channelIdx < 2; channelIdx++) {
 					u16 pitch = (4096.0f * ctrl->header.sampleRate * ctrl->pitchRatio) / JAC_DAC_RATE;
 #if defined(VERSION_GPIP01)
-					u16* REF_pitch = &pitch;
 					STACK_PAD_VAR(5);
 #endif
 					Play_DirectPCM(ctrl->dspch[channelIdx], ctrl->loopBufs[channelIdx], ctrl->loopSize, ctrl->totalSamples);
@@ -645,6 +645,9 @@ static s32 StreamAudio_Callback(void* data)
 						break;
 					}
 					}
+#endif
+#if defined(VERSION_GPIP01)
+					JAUDIO_PRINT("StreamAudio_Callback: pitch=%d\n", pitch);
 #endif
 					DSP_SetPitch(ctrl->dspch[channelIdx]->buffer_idx, pitch);
 					DSP_FlushChannel(ctrl->dspch[channelIdx]->buffer_idx);
@@ -1189,7 +1192,7 @@ BOOL StreamSetDVDPause(u32 ctrlID, BOOL isPaused)
 	BOOL tmp = ctrl->isPaused;
 
 #if defined(VERSION_GPIP01)
-	BOOL* REF_isPaused = &isPaused;
+	JAUDIO_PRINT("StreamSetDVDPause: paused=%d\n", isPaused);
 #endif
 
 	ctrl->isPaused = isPaused;

--- a/src/jaudio/verysimple.c
+++ b/src/jaudio/verysimple.c
@@ -7,6 +7,7 @@
 #include "jaudio/cmdqueue.h"
 #include "jaudio/cmdstack.h"
 #include "jaudio/connect.h"
+#include "jaudio/debug.h"
 #include "jaudio/driverinterface.h"
 #include "jaudio/dvdthread.h"
 #include "jaudio/fat.h"
@@ -345,10 +346,7 @@ static u16 TrackReceive(seqp_* track, u16 message)
  */
 static void AuxBusInit()
 {
-	u32* REF_alloc2Size;
 	u32 alloc2Size;
-
-	STACK_PAD_VAR(2);
 
 	u32 i;
 	s16* circularBufferBase;
@@ -363,7 +361,7 @@ static void AuxBusInit()
 	for (i = 0; i < 4; ++i) {
 		if (i < 3) {
 			alloc2Size         = fx_config[i].circularBufferSize * 0xa0; // TODO: What is 160 bytes large?
-			REF_alloc2Size     = &alloc2Size;
+			JAUDIO_PRINT("AuxBusInit: size=%d config=%p\n", alloc2Size, &fx_config[i]);
 			circularBufferBase = (s16*)OSAlloc2(alloc2Size);
 		} else {
 			circularBufferBase = NULL;

--- a/src/jaudio/virload.c
+++ b/src/jaudio/virload.c
@@ -1,6 +1,7 @@
 #include "jaudio/virload.h"
 
 #include "jaudio/aictrl.h"
+#include "jaudio/debug.h"
 #include "jaudio/dvdthread.h"
 
 #include <stddef.h>
@@ -31,8 +32,6 @@ void JV_InitHeader(immut char* fileName)
  */
 BOOL JV_InitHeader_M(immut char* fileName, u8* barcData, u8* archiveWork)
 {
-	STACK_PAD_VAR(1);
-	immut char** REF_fileName = &fileName;
 	if (!barcData) {
 		// if no barc data, read from disk
 		u32 fileSize = DVDT_CheckFile(fileName);
@@ -51,6 +50,7 @@ BOOL JV_InitHeader_M(immut char* fileName, u8* barcData, u8* archiveWork)
 		}
 	}
 
+	JAUDIO_PRINT("JV_InitHeader_M: file=%s header=%x\n", fileName, *(u32*)barcData);
 	u32 dirSeparatorIndex = strlen(fileName) - 1;
 
 	for (dirSeparatorIndex; dirSeparatorIndex > 0; dirSeparatorIndex--) {
@@ -185,16 +185,14 @@ u32 JV_LoadFile(u32 handle, u8* dst, u32 offset, u32 length)
 	char path[128];
 	volatile u32 loadStatus;
 
-	u32* REF_handle = &handle;
-	u8** REF_dst    = &dst;
-	u32* REF_length = &length;
+	JAUDIO_PRINT("JV_LoadFile: handle=%x dst=%x length=%x\n", handle, dst, length);
 
 	u32 archiveIndex = handle >> 16;
 	loadStatus      = 0;
 
 	sourceOffset = JV_GetRealHandle(handle)->offset;
 	sourceOffset += offset;
-	u32* REF_src = &sourceOffset;
+	JAUDIO_PRINT("JV_LoadFile: source=%x\n", sourceOffset);
 
 	strcpy(path, JV_DIR_NAME[archiveIndex]);
 	strcat(path, "/");
@@ -219,15 +217,13 @@ u32 JV_LoadFile_Async2(u32 handle, u8* dst, u32 offset, u32 length, void (*callb
 	u32 archiveIndex;
 	u32 sourceOffset;
 	char path[128];
-	u32* REF_handle = &handle;
-	u8** REF_dst    = &dst;
-	u32* REF_length = &length;
+	JAUDIO_PRINT("JV_LoadFile_Async2: handle=%x dst=%x length=%x\n", handle, dst, length);
 	STACK_PAD_VAR(3);
 
 	archiveIndex = handle >> 16;
 	sourceOffset = JV_GetRealHandle(handle)->offset;
 	sourceOffset += offset;
-	u32* REF_src = &sourceOffset;
+	JAUDIO_PRINT("JV_LoadFile_Async2: source=%x\n", sourceOffset);
 
 	strcpy(path, JV_DIR_NAME[archiveIndex]);
 	strcat(path, "/");

--- a/src/jaudio/waveread.c
+++ b/src/jaudio/waveread.c
@@ -2,6 +2,7 @@
 
 #include "jaudio/bx.h"
 #include "jaudio/connect.h"
+#include "jaudio/debug.h"
 #include "jaudio/heapctrl.h"
 #include <stddef.h>
 
@@ -39,7 +40,6 @@ CtrlGroup_* Wave_Test(u8* data)
 	WaveArchiveBank_* arcBank;
 	CtrlGroup_* group;
 	WaveArchive_* arc;
-	WaveArchive_** REF_arc;
 	SCNE_* scene;
 	Ctrl_* cdf;
 	Ctrl_* cex;
@@ -61,8 +61,8 @@ CtrlGroup_* Wave_Test(u8* data)
 
 	for (i = 0; i < arcBank->count; i++) {
 		PTconvert((void**)&arcBank->waveGroups[i], base_addr);
-		arc     = arcBank->waveGroups[i];
-		REF_arc = &arc;
+		arc = arcBank->waveGroups[i];
+		JAUDIO_PRINT("Wave_Test: archive=%x\n", arc);
 		Jac_InitHeap(&arc->heap);
 		arc->heap.startAddress = 0;
 
@@ -151,9 +151,6 @@ CtrlGroup_* WaveidToWavegroup(u32 waveId, u32 fallbackIndex)
 {
 	u16 virtID = waveId >> 16;
 	u16 index;
-	u16* REF_virtID = &virtID;
-
-	STACK_PAD_VAR(1);
 
 	if (virtID == 0xFFFF) {
 		index = fallbackIndex;
@@ -161,6 +158,9 @@ CtrlGroup_* WaveidToWavegroup(u32 waveId, u32 fallbackIndex)
 		index = Jac_WsVirtualToPhysical(virtID);
 	}
 
+	if (index < WAVEGROUP_SIZE) {
+		JAUDIO_PRINT("WaveidToWavegroup: virtual=%x group=%p\n", virtID, wavegroup[index]);
+	}
 	return index >= WAVEGROUP_SIZE ? NULL : wavegroup[index];
 }
 
@@ -169,20 +169,15 @@ CtrlGroup_* WaveidToWavegroup(u32 waveId, u32 fallbackIndex)
  */
 static BOOL __WaveScene_Set(u32 waveIndex, u32 ctrlIndex, BOOL doSet)
 {
-	STACK_PAD_VAR(2);
-	u32* REF_param_1;
-	u32* REF_param_2;
-
 	CtrlGroup_* group;
 
-	REF_param_1 = &waveIndex;
 	if (waveIndex >= WAVEGROUP_SIZE) {
 		return FALSE;
 	}
 	if (!(group = wavegroup[waveIndex])) {
 		return FALSE;
 	}
-	REF_param_2 = &ctrlIndex;
+	JAUDIO_PRINT("__WaveScene_Set: wave=%d control=%d count=%d archive=%x\n", waveIndex, ctrlIndex, group->count, wavearc[waveIndex]);
 	if (ctrlIndex >= group->count) {
 		return FALSE;
 	}
@@ -210,18 +205,13 @@ BOOL WaveScene_Load(u32 waveIndex, u32 ctrlIndex)
  */
 static void __WaveScene_Close(u32 waveIndex, u32 ctrlIndex, BOOL eraseOnly)
 {
-	STACK_PAD_VAR(2);
-	u32* REF_param_1;
-	u32* REF_param_2;
-
 	CtrlGroup_* group;
 
-	REF_param_1 = &waveIndex;
 	if (waveIndex >= WAVEGROUP_SIZE) {
 		return;
 	}
 	if (group = wavegroup[waveIndex]) {
-		REF_param_2 = &ctrlIndex;
+		JAUDIO_PRINT("__WaveScene_Close: wave=%d control=%d archive=%x count=%d\n", waveIndex, ctrlIndex, wavearc[waveIndex], group->count);
 		if (ctrlIndex < group->count) {
 			Jac_SceneClose(wavearc[waveIndex], group, ctrlIndex, eraseOnly);
 		}


### PR DESCRIPTION
Going off what HeartPiece said on Discord:
> I've got a hunch that the stack stuff was something to do with how they called print or error statements via a macro

I'm undecided on this, but it does seem plausible to me
Writing a random `("blah", arg1, arg2);` changes codegen which would look weird on it's own, but if we assumed JAudio used to be a debug print defined like
```c
#if defined(DEBUG)
#define JAUDIO_PRINT OSReport
#else
#define JAUDIO_PRINT
#endif
```

Then...
```c
// This:
JAUDIO_PRINT("Some print %s", arg1);

// Would become when debug is not on:
("Some print %s", arg1);
```

I've just taken the function name and tagged on reasonable vars that could have been printed for debug (also to achieve the correct stack) not sure if it's possible to recover what the actual print strings would have been.
I wasn't able to apply this to everywhere there was stack padding, so there's possibly something else at play as well

> used a combination of Sol and Fable to help with this
